### PR TITLE
Fix api test failures

### DIFF
--- a/api/controllers/api_test.go
+++ b/api/controllers/api_test.go
@@ -6,9 +6,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/convox/rack/api/controllers"
+	"github.com/stretchr/testify/assert"
 )
+
+// Note: these tests don't use the api helpers to ensure a naked
+//       client can connect
 
 func TestNoPassword(t *testing.T) {
 	aws := stubAws(DescribeConvoxStackCycle("convox-test"))

--- a/api/controllers/apps.go
+++ b/api/controllers/apps.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/convox/rack/api/models"
 	"github.com/gorilla/mux"
 	"golang.org/x/net/websocket"
-	"github.com/convox/rack/api/models"
 )
 
 func AppList(rw http.ResponseWriter, r *http.Request) error {

--- a/api/controllers/apps_helpers_test.go
+++ b/api/controllers/apps_helpers_test.go
@@ -3,12 +3,13 @@ package controllers_test
 import (
 	"net/http/httptest"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/convox/rack/api/awsutil"
 )
 
 func init() {
-	aws.DefaultConfig.Region = "test"
+	region := "test"
+	defaults.DefaultConfig.Region = &region
 }
 
 /*
@@ -22,7 +23,7 @@ Example:
 func stubAws(cycles ...awsutil.Cycle) (s *httptest.Server) {
 	handler := awsutil.NewHandler(cycles)
 	s = httptest.NewServer(handler)
-	aws.DefaultConfig.Endpoint = s.URL
+	defaults.DefaultConfig.Endpoint = &s.URL
 	return s
 }
 

--- a/api/controllers/apps_test.go
+++ b/api/controllers/apps_test.go
@@ -2,21 +2,17 @@ package controllers_test
 
 import (
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/convox/rack/api/controllers"
 )
 
 func TestAppList(t *testing.T) {
 	aws := stubAws(DescribeStackCycleWithoutQuery("bar"))
 	defer aws.Close()
 
-	body := assert.HTTPBody(controllers.HandlerFunc, "GET", "http://convox/apps", nil)
+	body := HTTPBody("GET", "http://convox/apps", nil)
 
 	var resp []map[string]string
 	err := json.Unmarshal([]byte(body), &resp)
@@ -31,7 +27,7 @@ func TestAppShow(t *testing.T) {
 	aws := stubAws(DescribeAppStackCycle("bar"))
 	defer aws.Close()
 
-	body := assert.HTTPBody(controllers.HandlerFunc, "GET", "http://convox/apps/bar", nil)
+	body := HTTPBody("GET", "http://convox/apps/bar", nil)
 
 	var resp map[string]string
 	err := json.Unmarshal([]byte(body), &resp)
@@ -46,11 +42,7 @@ func TestAppShowWithAppNotFound(t *testing.T) {
 	aws := stubAws(DescribeStackNotFound("bar"))
 	defer aws.Close()
 
-	req, _ := http.NewRequest("GET", "http://convox/apps/bar", nil)
-	w := httptest.NewRecorder()
-	controllers.HandlerFunc(w, req)
-
-	assert.Equal(t, 404, w.Code)
+	AssertStatus(t, 404, "GET", "http://convox/apps/bar", nil)
 }
 
 func TestAppCreate(t *testing.T) {
@@ -61,15 +53,11 @@ func TestAppCreate(t *testing.T) {
 	defer aws.Close()
 
 	val := url.Values{"name": []string{"application"}}
-	postBody := strings.NewReader(val.Encode())
-	req, _ := http.NewRequest("POST", "http://convox/apps", postBody)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	w := httptest.NewRecorder()
-	controllers.HandlerFunc(w, req)
+	body := HTTPBody("POST", "http://convox/apps", val)
 
-	if assert.Equal(t, 200, w.Code) {
+	if assert.NotEqual(t, "", body) {
 		var resp map[string]string
-		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		err := json.Unmarshal([]byte(body), &resp)
 
 		if assert.Nil(t, err) {
 			assert.Equal(t, "application", resp["name"])
@@ -86,13 +74,7 @@ func TestAppCreateWithAlreadyExists(t *testing.T) {
 	defer aws.Close()
 
 	val := url.Values{"name": []string{"application"}}
-	postBody := strings.NewReader(val.Encode())
-	req, _ := http.NewRequest("POST", "http://convox/apps", postBody)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	w := httptest.NewRecorder()
-	controllers.HandlerFunc(w, req)
-
-	assert.Equal(t, 403, w.Code)
+	AssertStatus(t, 403, "POST", "http://convox/apps", val)
 }
 
 // TODO: test bucket cleanup. this is handled via goroutines.
@@ -106,7 +88,7 @@ func TestAppDelete(t *testing.T) {
 	)
 	defer aws.Close()
 
-	body := assert.HTTPBody(controllers.HandlerFunc, "DELETE", "http://convox/apps/bar", nil)
+	body := HTTPBody("DELETE", "http://convox/apps/bar", nil)
 
 	var resp map[string]bool
 	err := json.Unmarshal([]byte(body), &resp)
@@ -120,11 +102,7 @@ func TestAppDeleteWithAppNotFound(t *testing.T) {
 	aws := stubAws(DescribeStackNotFound("bar"))
 	defer aws.Close()
 
-	req, _ := http.NewRequest("DELETE", "http://convox/apps/bar", nil)
-	w := httptest.NewRecorder()
-	controllers.HandlerFunc(w, req)
-
-	assert.Equal(t, 404, w.Code)
+	AssertStatus(t, 404, "DELETE", "http://convox/apps/bar", nil)
 }
 
 func TestAppLogs(t *testing.T) {

--- a/api/controllers/helpers_test.go
+++ b/api/controllers/helpers_test.go
@@ -1,0 +1,52 @@
+package controllers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/convox/rack/api/controllers"
+	"github.com/stretchr/testify/assert"
+)
+
+func AssertStatus(t *testing.T, status int, method, url string, values url.Values) string {
+	w := httptest.NewRecorder()
+	req, err := buildRequest(method, url, values)
+
+	if err != nil {
+		t.Error(err)
+		return ""
+	}
+
+	controllers.HandlerFunc(w, req)
+	assert.Equal(t, status, w.Code)
+	return w.Body.String()
+}
+
+func HTTPBody(method, url string, values url.Values) string {
+	w := httptest.NewRecorder()
+	req, err := buildRequest(method, url, values)
+
+	if err != nil {
+		return ""
+	}
+
+	controllers.HandlerFunc(w, req)
+	return w.Body.String()
+}
+
+func buildRequest(method, url string, values url.Values) (req *http.Request, err error) {
+
+	if method == "POST" {
+		postBody := strings.NewReader(values.Encode())
+		req, err = http.NewRequest("POST", url, postBody)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	} else {
+		req, err = http.NewRequest(method, url+"?"+values.Encode(), nil)
+	}
+	req.Header.Set("Version", "dev")
+
+	return
+}


### PR DESCRIPTION
add helpers that will let us set Headers b.c the `assert` helpers don't do that. we were going to need these helpers in the tests eventually