### PR TITLE
Fix link to cmd/crypt submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Convox agent for ECS instances
 
 Convox CLI
 
-### [cmd/crypt](https://github.com/crypt/rack/tree/master/cmd/crypt)
+### [cmd/crypt](https://github.com/convox/rack/tree/master/cmd/crypt)
 
 Encrypt/decrypt sensitive information
 


### PR DESCRIPTION
Basic edit to make sure that the link to cmd/crypt is pointing at the right place.