### PR TITLE
Appname regex

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -87,7 +87,7 @@ func (a *App) Create() error {
 	helpers.SendMixpanelEvent("kernel-app-create-start", "")
 
 	if !regexValidAppName.MatchString(a.Name) {
-		return fmt.Errorf("app name can contain only alphanumeric characters and dashes and must between 4 and 30 characters")
+		return fmt.Errorf("app name can contain only alphanumeric characters and dashes and must be between 4 and 30 characters")
 	}
 
 	formation, err := a.Formation()

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -81,13 +81,13 @@ func GetApp(name string) (*App, error) {
 	return app, nil
 }
 
-var regexValidAppName = regexp.MustCompile(`\A[a-z0-9_]{4,30}\z`)
+var regexValidAppName = regexp.MustCompile(`\A[a-zA-Z][-a-zA-Z0-9]{4,30}\z`)
 
 func (a *App) Create() error {
 	helpers.SendMixpanelEvent("kernel-app-create-start", "")
 
 	if !regexValidAppName.MatchString(a.Name) {
-		return fmt.Errorf("app name must be [a-z0-9_] and between 4 and 30 characters")
+		return fmt.Errorf("app name can contain only alphanumeric characters and dashes and must between 4 and 30 characters")
 	}
 
 	formation, err := a.Formation()


### PR DESCRIPTION
Update appname regex to match the one provided by AWS. Dashes are allowed, not underscores. Also updates the error message to explain in English. The regex is somewhat cryptic, but the rules are simple enough to explain in words.