### PR TITLE
allow rack switching with grid API

### DIFF
--- a/api/controllers/routes.go
+++ b/api/controllers/routes.go
@@ -39,6 +39,7 @@ func NewRouter() (router *mux.Router) {
 	router.HandleFunc("/services/{service}", api("service.delete", ServiceDelete)).Methods("DELETE")
 	router.HandleFunc("/system", api("system.show", SystemShow)).Methods("GET")
 	router.HandleFunc("/system", api("system.update", SystemUpdate)).Methods("PUT")
+	router.HandleFunc("/switch", api("switch", Switch)).Methods("POST")
 
 	// websockets
 	router.Handle("/apps/{app}/logs", ws("app.logs", AppLogs)).Methods("GET")

--- a/api/controllers/switch.go
+++ b/api/controllers/switch.go
@@ -1,0 +1,10 @@
+package controllers
+
+import "net/http"
+
+func Switch(w http.ResponseWriter, r *http.Request) error {
+	response := map[string]string{
+		"source": "rack",
+	}
+	return RenderJson(w, response)
+}

--- a/client/switch.go
+++ b/client/switch.go
@@ -1,0 +1,10 @@
+package client
+
+func (c *Client) Switch(rackName string) (success map[string]string, err error) {
+	params := map[string]string{
+		"rack-name": rackName,
+	}
+
+	err = c.Post("/switch", params, &success)
+	return
+}

--- a/cmd/convox/main.go
+++ b/cmd/convox/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/convox/rack/client"
 	"github.com/codegangsta/cli"
+	"github.com/convox/rack/client"
 	"github.com/convox/rack/cmd/convox/stdcli"
 )
 

--- a/cmd/convox/switch.go
+++ b/cmd/convox/switch.go
@@ -27,7 +27,7 @@ func cmdSwitch(c *cli.Context) {
 	res, err := rackClient(c).Switch(rackName)
 
 	if err != nil {
-		stdcli.Error(err)
+		cmdLogin(c)
 		return
 	}
 

--- a/cmd/convox/switch.go
+++ b/cmd/convox/switch.go
@@ -11,7 +11,7 @@ func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "switch",
 		Description: "switch to another Convox rack",
-		Usage:       "[hostname]",
+		Usage:       "[rack name]",
 		Action:      cmdSwitch,
 	})
 }
@@ -22,14 +22,19 @@ func cmdSwitch(c *cli.Context) {
 		return
 	}
 
-	host := c.Args()[0]
+	rackName := c.Args()[0]
 
-	err := switchHost(host)
+	res, err := rackClient(c).Switch(rackName)
 
 	if err != nil {
 		stdcli.Error(err)
 		return
 	}
 
-	fmt.Printf("Switched to %s\n", host)
+	switch {
+	case res["source"] == "rack":
+		cmdLogin(c)
+	case res["source"] == "grid":
+		fmt.Println(res["message"])
+	}
 }


### PR DESCRIPTION
Changes behavior of `convox login` and `convox switch` to fit the usage we expect and to work with grid-like authentication proxies.

If you `convox login` then it will try auth on your system first and if that succeeds you're good. So you can exit a grid with `convox login <host>`.  

`convox swtich <hostname>` against a rack defaults to `convox login <hostname>`
`convox switch <rack name>` against a grid tries to switch you to a rack of the given name that you have access to in a grid. it suggests names if one does not match.

After login, the CLI does not know if it is talking to a Rack or the RackProxy

```
$ cx login grid.convox.com
Logged in successfully.

$ cx apps
APP      STATUS
compose  running
testy    running

$ cx switch prod
Switched to prod

$ cx apps
APP      STATUS
compose  running
testy    running

$ cx switch demo
Switched to demo

$ cx apps
APP       STATUS
grid      running
invite    running
payments  running
release   running
release2  running
sinatra   running
web2lead  running

$ cx switch foo
Rack not found.
Try one of: prod, demo, dev
```