### PR TITLE
use random ports for defaults

### DIFF
--- a/api/models/manifest.go
+++ b/api/models/manifest.go
@@ -2,11 +2,15 @@ package models
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 
 	"gopkg.in/yaml.v2"
 )
+
+// set to false when testing for deterministic ports
+var ManifestRandomPorts = true
 
 type Manifest []ManifestEntry
 
@@ -44,8 +48,12 @@ func LoadManifest(data string) (Manifest, error) {
 		entry.randoms = make(map[string]int)
 
 		for _, port := range entry.Ports {
-			entry.randoms[port] = currentPort
-			currentPort += 1
+			if ManifestRandomPorts {
+				entry.randoms[port] = rand.Intn(62000) + 3000
+			} else {
+				entry.randoms[port] = currentPort
+				currentPort += 1
+			}
 		}
 
 		manifest = append(manifest, ManifestEntry(entry))

--- a/api/models/manifest_test.go
+++ b/api/models/manifest_test.go
@@ -68,8 +68,19 @@ func TestManifestInvalid(t *testing.T) {
 }
 
 func TestManifestFixtures(t *testing.T) {
+	ManifestRandomPorts = false
 	assertFixture(t, "web_external_internal")
 	assertFixture(t, "web_postgis")
 	assertFixture(t, "web_postgis_internal")
 	assertFixture(t, "worker")
+	ManifestRandomPorts = true
+}
+
+func TestManifestRandomPorts(t *testing.T) {
+	manifest, err := LoadManifest("web:\n  ports:\n  - 80:3000\n  - 3001")
+
+	require.Nil(t, err)
+
+	// kinda hacky but just making sure we're not in sequence here
+	assert.NotEqual(t, 1, (manifest[0].randoms["3001"] - manifest[0].randoms["80:3000"]))
 }


### PR DESCRIPTION
Use random port assignment for the default externally mapped ports to avoid conflicts between apps