### PR TITLE
don't specify CPU parameter

### DIFF
--- a/api/cmd/formation/handler/ecs.go
+++ b/api/cmd/formation/handler/ecs.go
@@ -264,14 +264,12 @@ func ECSTaskDefinitionCreate(req Request) (string, map[string]string, error) {
 	for i, itask := range tasks {
 		task := itask.(map[string]interface{})
 
-		cpu, _ := strconv.Atoi(task["CPU"].(string))
 		memory, _ := strconv.Atoi(task["Memory"].(string))
 
 		r.ContainerDefinitions[i] = &ecs.ContainerDefinition{
 			Name:      aws.String(task["Name"].(string)),
 			Essential: aws.Bool(true),
 			Image:     aws.String(task["Image"].(string)),
-			Cpu:       aws.Int64(int64(cpu)),
 			Memory:    aws.Int64(int64(memory)),
 		}
 

--- a/api/models/fixtures/web_external_internal.json
+++ b/api/models/fixtures/web_external_internal.json
@@ -499,9 +499,6 @@
             "Fn::If": [
               "BlankWebService",
               {
-                "CPU": {
-                  "Ref": "WebMemory"
-                },
                 "Command": {
                   "Ref": "WebCommand"
                 },

--- a/api/models/fixtures/web_postgis.json
+++ b/api/models/fixtures/web_postgis.json
@@ -486,9 +486,6 @@
             "Fn::If": [
               "BlankPostgresService",
               {
-                "CPU": {
-                  "Ref": "PostgresMemory"
-                },
                 "Command": {
                   "Ref": "PostgresCommand"
                 },
@@ -684,9 +681,6 @@
             "Fn::If": [
               "BlankWebService",
               {
-                "CPU": {
-                  "Ref": "WebMemory"
-                },
                 "Command": {
                   "Ref": "WebCommand"
                 },

--- a/api/models/fixtures/web_postgis_internal.json
+++ b/api/models/fixtures/web_postgis_internal.json
@@ -345,9 +345,6 @@
             "Fn::If": [
               "BlankPostgresService",
               {
-                "CPU": {
-                  "Ref": "PostgresMemory"
-                },
                 "Command": {
                   "Ref": "PostgresCommand"
                 },
@@ -518,9 +515,6 @@
             "Fn::If": [
               "BlankWebService",
               {
-                "CPU": {
-                  "Ref": "WebMemory"
-                },
                 "Command": {
                   "Ref": "WebCommand"
                 },

--- a/api/models/fixtures/worker.json
+++ b/api/models/fixtures/worker.json
@@ -339,9 +339,6 @@
             "Fn::If": [
               "BlankPostgresService",
               {
-                "CPU": {
-                  "Ref": "PostgresMemory"
-                },
                 "Command": {
                   "Ref": "PostgresCommand"
                 },
@@ -512,9 +509,6 @@
             "Fn::If": [
               "BlankWorkerService",
               {
-                "CPU": {
-                  "Ref": "WorkerMemory"
-                },
                 "Command": {
                   "Ref": "WorkerCommand"
                 },

--- a/api/models/helpers.go
+++ b/api/models/helpers.go
@@ -401,7 +401,6 @@ func templateHelpers() template.FuncMap {
 				"Name": "%s",
 				"Image": { "Ref": "%sImage" },
 				"Command": { "Ref": "%sCommand" },
-				"CPU": { "Ref": "%sMemory" },
 				"Memory": { "Ref": "%sMemory" },
 				"Environment": {
 					"KINESIS": { "Ref": "Kinesis" },
@@ -411,7 +410,7 @@ func templateHelpers() template.FuncMap {
 				"Volumes": [ %s ],
 				"Services": [ %s ],
 				"PortMappings": [ %s ]
-			}, { "Ref" : "AWS::NoValue" } ] }`, UpperName(ps), ps, UpperName(ps), UpperName(ps), UpperName(ps), UpperName(ps), strings.Join(envs, ","), strings.Join(links, ","), strings.Join(volumes, ","), strings.Join(services, ","), strings.Join(mappings, ","))
+			}, { "Ref" : "AWS::NoValue" } ] }`, UpperName(ps), ps, UpperName(ps), UpperName(ps), UpperName(ps), strings.Join(envs, ","), strings.Join(links, ","), strings.Join(volumes, ","), strings.Join(services, ","), strings.Join(mappings, ","))
 
 			return template.HTML(l)
 		},


### PR DESCRIPTION
CPU parameter is optional. Rather than tying directly to Memory which can cause ECS not to schedule the process for lack of available CPU units we simply don't specify it.