### PR TITLE
Apps info args

### DIFF
--- a/cmd/convox/apps.go
+++ b/cmd/convox/apps.go
@@ -18,19 +18,19 @@ func init() {
 			{
 				Name:        "create",
 				Description: "create a new application",
-				Usage:       "[name]",
+				Usage:       "<name>",
 				Action:      cmdAppCreate,
 			},
 			{
 				Name:        "delete",
 				Description: "delete an application",
-				Usage:       "[name]",
+				Usage:       "<name>",
 				Action:      cmdAppDelete,
 			},
 			{
 				Name:        "info",
 				Description: "see info about an app",
-				Usage:       "",
+				Usage:       "[name]",
 				Action:      cmdAppInfo,
 				Flags:       []cli.Flag{appFlag},
 			},

--- a/cmd/convox/apps.go
+++ b/cmd/convox/apps.go
@@ -105,7 +105,14 @@ func cmdAppDelete(c *cli.Context) {
 }
 
 func cmdAppInfo(c *cli.Context) {
-	_, app, err := stdcli.DirApp(c, ".")
+	var app string
+	var err error
+
+	if len(c.Args()) > 0 {
+		app = c.Args()[0]
+	} else {
+		_, app, err = stdcli.DirApp(c, ".")
+	}
 
 	a, err := rackClient(c).GetApp(app)
 


### PR DESCRIPTION
Allow the passing of an app name as a positional arg to `convox apps info`. This is brings it into parity with the format of `convox apps create` and `convox apps delete` which should be less confusing.

```
$ convox apps info rails2
Name       rails2
Status     running
Release    RGBYRCRKWAP
Processes  db web
Hostname   rails2-1579255890.us-east-1.elb.amazonaws.com
Ports      web:5000
```

Backwards compatibility with the `--app <appname>` option as well as the directory name is maintained, but the positional argument, if present, gets priority.

```
$ convox apps info --app rails2
Name       rails2
Status     running
Release    RGBYRCRKWAP
Processes  db web
Hostname   rails2-1579255890.us-east-1.elb.amazonaws.com
Ports      web:5000

$ mkdir rails2
$ convox apps info
Name       rails2
Status     running
Release    RGBYRCRKWAP
Processes  db web
Hostname   rails2-1579255890.us-east-1.elb.amazonaws.com
Ports      web:5000

$ convox apps info rails2 --app grid
Name       rails2
Status     running
Release    RGBYRCRKWAP
Processes  db web
Hostname   rails2-1579255890.us-east-1.elb.amazonaws.com
Ports      web:5000
```

Fixes #57 
