### PR TITLE
fetch app name from .convox/app file if it exists

### DIFF
--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -82,6 +83,7 @@ func Debug() bool {
 }
 
 // If user specifies the app's name from command line, then use it;
+// if not, try to read the app name from .convox/app
 // otherwise use the current working directory's name
 func DirApp(c *cli.Context, wd string) (string, string, error) {
 	abs, err := filepath.Abs(wd)
@@ -93,10 +95,30 @@ func DirApp(c *cli.Context, wd string) (string, string, error) {
 	app := c.String("app")
 
 	if app == "" {
+		app, err = ReadSetting("app")
+
+		if err != nil {
+			app = ""
+		}
+	}
+
+	if app == "" {
 		app = path.Base(abs)
 	}
 
 	return abs, app, nil
+}
+
+func ReadSetting(setting string) (string, error) {
+	value, err := ioutil.ReadFile(fmt.Sprintf(".convox/%s", setting))
+
+	if err != nil {
+		return "", err
+	}
+
+	output := strings.TrimSpace(string(value))
+
+	return output, nil
 }
 
 func RegisterCommand(cmd cli.Command) {

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -141,6 +141,12 @@ func VersionPrinter(printer func(*cli.Context)) {
 	cli.VersionPrinter = printer
 }
 
+func WriteSetting(setting, value string) error {
+	err := ioutil.WriteFile(fmt.Sprintf(".convox/%s", setting), []byte(value), 0777)
+
+	return err
+}
+
 func Error(err error) {
 	fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 	Exiter(1)


### PR DESCRIPTION
With this change you can now set a `.convox/app` config file in your project containing the app name of the deployment. This way, you no longer have to include the `--app` option and your deployment name can differ from the current directory name.

App name detection now goes in this order, with the first found being used:
- `--app`
- `.convox/app`
- current directory

Fixes #57