### PR TITLE
better rolling of asgs

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -554,7 +554,7 @@
         "AutoScalingRollingUpdate": {
           "MaxBatchSize": 1,
           "MinInstancesInService": 1,
-          "PauseTime" : "PT5M",
+          "PauseTime" : "PT15M",
           "WaitOnResourceSignals": "true"
         }
       }

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -510,7 +510,7 @@
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
             "curl -s http://convox.s3.amazonaws.com/agent/0.3/convox.conf > /etc/init/convox.conf",
             { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
-            { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "-s", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
+            { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "-s", "true", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
             "start convox"
           ] ] }
         }

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -494,6 +494,7 @@
             "#!/bin/bash",
             "fallocate -l 5G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile",
             "yum -y update",
+            "yum -y install aws-cfn-bootstrap",
             { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },
             "echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config",
             { "Fn::If": [ "BlankCertificate",
@@ -508,8 +509,8 @@
             "mkdir -p /etc/convox",
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
             "curl -s http://convox.s3.amazonaws.com/agent/0.3/convox.conf > /etc/init/convox.conf",
-            { "Fn::Join": [ " ", [ "cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
-            { "Fn::Join": [ " ", [ "cfn-signal", "-s", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
+            { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
+            { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "-s", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
             "start convox"
           ] ] }
         }

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -508,6 +508,8 @@
             "mkdir -p /etc/convox",
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
             "curl -s http://convox.s3.amazonaws.com/agent/0.3/convox.conf > /etc/init/convox.conf",
+            { "Fn::Join": [ " ", [ "cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
+            { "Fn::Join": [ " ", [ "cfn-signal", "-s", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
             "start convox"
           ] ] }
         }
@@ -551,7 +553,9 @@
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
           "MaxBatchSize": 1,
-          "MinInstancesInService": 1
+          "MinInstancesInService": 1,
+          "PauseTime" : "PT5M",
+          "WaitOnResourceSignals": "true"
         }
       }
     },

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -510,7 +510,7 @@
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
             "curl -s http://convox.s3.amazonaws.com/agent/0.3/convox.conf > /etc/init/convox.conf",
             { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
-            { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "-s", "true", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
+            { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
             "start convox"
           ] ] }
         }


### PR DESCRIPTION
simple first pass

- wait for resource signals, 15m timeout
- send signals after `cfn-init` completes

note: does not wait for ecs-agent or convox start to finish.