### PR TITLE
Specify docker-compose.yml file

### DIFF
--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -50,7 +50,7 @@ func main() {
 		die(err)
 	}
 
-	m, err := manifest.Read(dir)
+	m, err := manifest.Read(dir, "docker-compose.yml")
 
 	if err != nil {
 		die(err)

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -29,6 +29,7 @@ func main() {
 	push := flag.String("push", "", "push build to this prefix when done")
 	auth := flag.String("auth", "", "auth token for push")
 	noCache := flag.Bool("no-cache", false, "skip the docker cache")
+	config := flag.String("config", "docker-compose.yml", "docker compose filename")
 
 	flag.Parse()
 
@@ -50,7 +51,7 @@ func main() {
 		die(err)
 	}
 
-	m, err := manifest.Read(dir, "docker-compose.yml")
+	m, err := manifest.Read(dir, *config)
 
 	if err != nil {
 		die(err)

--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -118,7 +118,7 @@ func BuildCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	}
 
 	if repo := r.FormValue("repo"); repo != "" {
-		go build.ExecuteRemote(repo, cache, ch)
+		go build.ExecuteRemote(repo, cache, config, ch)
 
 		err = <-ch
 

--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -65,6 +65,7 @@ func BuildGet(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 
 func BuildCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	build := models.NewBuild(mux.Vars(r)["app"])
+	config := r.FormValue("config")
 
 	if build.IsRunning() {
 		return httperr.Errorf(403, "another build is currently running. Please try again later.")
@@ -105,7 +106,7 @@ func BuildCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 			return httperr.Server(err)
 		}
 
-		go build.ExecuteLocal(source, cache, ch)
+		go build.ExecuteLocal(source, cache, config, ch)
 
 		err = <-ch
 

--- a/api/manifest.yml
+++ b/api/manifest.yml
@@ -111,6 +111,11 @@ paths:
         type: boolean
         in: formData
         required: false
+      - name: config
+        description: docker compose yaml file
+        type: string
+        in: formData
+        required: false
       - name: repo
         description: repository
         type: string

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -78,11 +78,11 @@ func Init(dir string) (changed []string, err error) {
 	return changed, nil
 }
 
-func Read(dir string) (*Manifest, error) {
-	data, err := ioutil.ReadFile(filepath.Join(dir, "docker-compose.yml"))
+func Read(dir, filename string) (*Manifest, error) {
+	data, err := ioutil.ReadFile(filepath.Join(dir, filename))
 
 	if err != nil {
-		return nil, fmt.Errorf("file not found: docker-compose.yml")
+		return nil, fmt.Errorf("file not found: %s", filename)
 	}
 
 	var m Manifest

--- a/api/manifest/manifest_test.go
+++ b/api/manifest/manifest_test.go
@@ -18,6 +18,8 @@ type Cases []struct {
 	got, want interface{}
 }
 
+const defaultManifestFile = "docker-compose.yml"
+
 func TestBuild(t *testing.T) {
 	t.Skip("skipping until i can figure out regex")
 	return
@@ -26,7 +28,7 @@ func TestBuild(t *testing.T) {
 	defer os.RemoveAll(destDir)
 
 	_, _ = Init(destDir)
-	m, _ := Read(destDir)
+	m, _ := Read(destDir, defaultManifestFile)
 
 	stdout, stderr := testBuild(m, "compose")
 
@@ -47,7 +49,7 @@ func TestPortsWanted(t *testing.T) {
 	defer os.RemoveAll(destDir)
 
 	_, _ = Init(destDir)
-	m, _ := Read(destDir)
+	m, _ := Read(destDir, defaultManifestFile)
 	ps, _ := m.PortsWanted()
 
 	cases := Cases{
@@ -91,7 +93,7 @@ func TestRun(t *testing.T) {
 	defer os.RemoveAll(destDir)
 
 	_, _ = Init(destDir)
-	m, _ := Read(destDir)
+	m, _ := Read(destDir, defaultManifestFile)
 
 	stdout, stderr := testRun(m, "compose")
 
@@ -108,7 +110,7 @@ func TestGenerateDockerCompose(t *testing.T) {
 	defer os.RemoveAll(destDir)
 
 	_, _ = Init(destDir)
-	m, _ := Read(destDir)
+	m, _ := Read(destDir, defaultManifestFile)
 
 	cases := Cases{
 		{readFile(t, destDir, "docker-compose.yml"), `web:
@@ -133,7 +135,7 @@ func TestGenerateDockerfile(t *testing.T) {
 	defer os.RemoveAll(destDir)
 
 	_, _ = Init(destDir)
-	m, _ := Read(destDir)
+	m, _ := Read(destDir, defaultManifestFile)
 
 	cases := Cases{
 		{readFile(t, destDir, "docker-compose.yml"), `main:
@@ -152,7 +154,7 @@ func TestGenerateProcfile(t *testing.T) {
 	defer os.RemoveAll(destDir)
 
 	_, _ = Init(destDir)
-	m, _ := Read(destDir)
+	m, _ := Read(destDir, defaultManifestFile)
 
 	cases := Cases{
 		{readFile(t, destDir, "docker-compose.yml"), `web:

--- a/api/models/build.go
+++ b/api/models/build.go
@@ -200,7 +200,7 @@ func (b *Build) ExecuteLocal(r io.Reader, cache bool, config string, ch chan err
 	}
 }
 
-func (b *Build) ExecuteRemote(repo string, cache bool, ch chan error) {
+func (b *Build) ExecuteRemote(repo string, cache bool, config string, ch chan error) {
 	b.Status = "building"
 	b.Save()
 
@@ -210,6 +210,10 @@ func (b *Build) ExecuteRemote(repo string, cache bool, ch chan error) {
 
 	if pw := os.Getenv("PASSWORD"); pw != "" {
 		args = append(args, "-auth", pw)
+	}
+
+	if config != "" {
+		args = append(args, "-config", config)
 	}
 
 	if !cache {

--- a/api/models/build.go
+++ b/api/models/build.go
@@ -165,7 +165,7 @@ func (b *Build) Cleanup() error {
 	return nil
 }
 
-func (b *Build) ExecuteLocal(r io.Reader, cache bool, ch chan error) {
+func (b *Build) ExecuteLocal(r io.Reader, cache bool, config string, ch chan error) {
 	b.Status = "building"
 	b.Save()
 
@@ -175,6 +175,10 @@ func (b *Build) ExecuteLocal(r io.Reader, cache bool, ch chan error) {
 
 	if pw := os.Getenv("PASSWORD"); pw != "" {
 		args = append(args, "-auth", pw)
+	}
+
+	if config != "" {
+		args = append(args, "-config", config)
 	}
 
 	if !cache {

--- a/client/builds.go
+++ b/client/builds.go
@@ -32,7 +32,7 @@ func (c *Client) GetBuilds(app string) (Builds, error) {
 	return builds, nil
 }
 
-func (c *Client) CreateBuildSource(app string, source []byte, cache bool) (*Build, error) {
+func (c *Client) CreateBuildSource(app string, source []byte, cache bool, config string) (*Build, error) {
 	var build Build
 
 	files := map[string][]byte{
@@ -40,7 +40,8 @@ func (c *Client) CreateBuildSource(app string, source []byte, cache bool) (*Buil
 	}
 
 	params := map[string]string{
-		"cache": fmt.Sprintf("%t", cache),
+		"cache":  fmt.Sprintf("%t", cache),
+		"config": config,
 	}
 
 	err := c.PostMultipart(fmt.Sprintf("/apps/%s/builds", app), files, params, &build)
@@ -52,11 +53,12 @@ func (c *Client) CreateBuildSource(app string, source []byte, cache bool) (*Buil
 	return &build, nil
 }
 
-func (c *Client) CreateBuildUrl(app string, url string, cache bool) (*Build, error) {
+func (c *Client) CreateBuildUrl(app string, url string, cache bool, config string) (*Build, error) {
 	var build Build
 
 	params := map[string]string{
-		"repo": url,
+		"repo":   url,
+		"config": config,
 	}
 
 	err := c.Post(fmt.Sprintf("/apps/%s/builds", app), params, &build)

--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -28,7 +28,7 @@ func init() {
 				Usage: "Do not use Docker cache during build.",
 			},
 			cli.StringFlag{
-				Name:  "file",
+				Name:  "file, f",
 				Value: "docker-compose.yml",
 				Usage: "a file to use in place of docker-compose.yml",
 			},
@@ -49,7 +49,7 @@ func init() {
 				Flags: []cli.Flag{
 					appFlag,
 					cli.StringFlag{
-						Name:  "file",
+						Name:  "file, f",
 						Value: "docker-compose.yml",
 						Usage: "a file to use in place of docker-compose.yml",
 					},

--- a/cmd/convox/builds_test.go
+++ b/cmd/convox/builds_test.go
@@ -27,7 +27,7 @@ func TestBuildsPreventAgainstCreating(t *testing.T) {
 func TestBuildsCreateReturnsNoBuild(t *testing.T) {
 	ts := testServer(t,
 		test.Http{Method: "GET", Path: "/apps/foo", Code: 200, Response: client.App{Name: "foo", Status: "running"}},
-		test.Http{Method: "POST", Path: "/apps/foo/builds", Body: "repo=https%3A%2F%2Fexample.org", Code: 200, Response: client.Build{}},
+		test.Http{Method: "POST", Path: "/apps/foo/builds", Body: "config=docker-compose.yml&repo=https%3A%2F%2Fexample.org", Code: 200, Response: client.Build{}},
 	)
 
 	defer ts.Close()

--- a/cmd/convox/deploy.go
+++ b/cmd/convox/deploy.go
@@ -20,7 +20,7 @@ func init() {
 				Usage: "Do not use Docker cache during build.",
 			},
 			cli.StringFlag{
-				Name:  "file",
+				Name:  "file, f",
 				Value: "docker-compose.yml",
 				Usage: "a file to use in place of docker-compose.yml",
 			},

--- a/cmd/convox/deploy.go
+++ b/cmd/convox/deploy.go
@@ -19,6 +19,11 @@ func init() {
 				Name:  "no-cache",
 				Usage: "Do not use Docker cache during build.",
 			},
+			cli.StringFlag{
+				Name:  "file",
+				Value: "docker-compose.yml",
+				Usage: "a file to use in place of docker-compose.yml",
+			},
 		},
 	})
 }
@@ -57,7 +62,7 @@ func cmdDeploy(c *cli.Context) {
 	}
 
 	// build
-	release, err := executeBuild(c, dir, app)
+	release, err := executeBuild(c, dir, app, c.String("file"))
 
 	if err != nil {
 		stdcli.Error(err)

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -26,6 +26,7 @@ func init() {
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "file",
+				Value: "docker-compose.yml",
 				Usage: "a file to use in place of docker-compose.yml",
 			},
 		},
@@ -53,10 +54,6 @@ func cmdStart(c *cli.Context) {
 	}
 
 	file := c.String("file")
-
-	if file == "" {
-		file = "docker-compose.yml"
-	}
 
 	m, err := manifest.Read(dir, file)
 

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -25,7 +25,7 @@ func init() {
 		Action:      cmdStart,
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  "file",
+				Name:  "file, f",
 				Value: "docker-compose.yml",
 				Usage: "a file to use in place of docker-compose.yml",
 			},

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -23,6 +23,12 @@ func init() {
 		Description: "start an app for local development",
 		Usage:       "[directory]",
 		Action:      cmdStart,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "file",
+				Usage: "a file to use in place of docker-compose.yml",
+			},
+		},
 	})
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "init",
@@ -46,7 +52,13 @@ func cmdStart(c *cli.Context) {
 		return
 	}
 
-	m, err := manifest.Read(dir)
+	file := c.String("file")
+
+	if file == "" {
+		file = "docker-compose.yml"
+	}
+
+	m, err := manifest.Read(dir, file)
 
 	if err != nil {
 		changes, err := manifest.Init(dir)
@@ -58,7 +70,7 @@ func cmdStart(c *cli.Context) {
 
 		fmt.Printf("Generated: %s\n", strings.Join(changes, ", "))
 
-		m, err = manifest.Read(dir)
+		m, err = manifest.Read(dir, file)
 
 		if err != nil {
 			stdcli.Error(err)


### PR DESCRIPTION
This contains changes to the client and server which allow you to pass a `--file <filename>` option to `convox start`, `convox build`, and `convox deploy` if you want to use a file other than `docker-compose.yml`.  The option is never required and in all cases defaults to `docker-compose.yml`.

Fixes https://github.com/convox/kernel/issues/97