### PR TITLE
Documentation fix for #109

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -51,7 +51,7 @@ We recommend that you create a new set of credentials exclusively for this
 install process and then delete them once the installer has completed.
 
 To generate a new set of AWS credentials go to:
-https://docs.convox.com/docs/creating-an-iam-user
+https://docs.convox.com/creating-an-iam-user
 `
 
 var FormationUrl = "http://convox.s3.amazonaws.com/release/%s/formation.json"


### PR DESCRIPTION
Redirection from https://docs.convox.com adds /docs/ to path, so removed the additional docs from the path so the URL wouldn't 404.