### PR TITLE
better deploy messaging

### DIFF
--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -175,7 +175,7 @@ func executeBuildDir(c *cli.Context, dir string, app string) (string, error) {
 		return "", err
 	}
 
-	fmt.Print("Uploading... ")
+	fmt.Print("Creating tarball... ")
 
 	tar, err := createTarball(dir)
 
@@ -187,11 +187,15 @@ func executeBuildDir(c *cli.Context, dir string, app string) (string, error) {
 
 	cache := !c.Bool("no-cache")
 
+	fmt.Print("Uploading... ")
+
 	build, err := rackClient(c).CreateBuildSource(app, tar, cache)
 
 	if err != nil {
 		return "", err
 	}
+
+	fmt.Println("OK")
 
 	return finishBuild(c, app, build)
 }


### PR DESCRIPTION
when `convox deploy` is creating the tarball, it now says "Creating tarball... OK".  then when it uploads the tarball it says "Uploading... OK".

should reduce confusion from folks on slow connections.
