### PR TITLE
move notify event to client

### DIFF
--- a/api/models/notify.go
+++ b/api/models/notify.go
@@ -8,16 +8,10 @@ import (
 	"github.com/convox/rack/api/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws"
 	"github.com/convox/rack/api/Godeps/_workspace/src/github.com/aws/aws-sdk-go/service/sns"
 	"github.com/convox/rack/api/Godeps/_workspace/src/github.com/ddollar/logger"
+	"github.com/convox/rack/client"
 )
 
 var PauseNotifications = false
-
-type NotifyEvent struct {
-	Action    string            `json:"action"`
-	Status    string            `json:"status"`
-	Data      map[string]string `json:"data"`
-	Timestamp time.Time         `json:"timestamp"`
-}
 
 // uniform error handling
 func NotifyError(action string, err error, data map[string]string) error {
@@ -37,7 +31,7 @@ func Notify(name, status string, data map[string]string) error {
 	log := logger.New("ns=kernel")
 	data["rack"] = os.Getenv("RACK")
 
-	event := &NotifyEvent{
+	event := &client.NotifyEvent{
 		Action:    name,
 		Status:    status,
 		Data:      data,

--- a/client/notify_event.go
+++ b/client/notify_event.go
@@ -1,0 +1,12 @@
+package client
+
+import "time"
+
+//a NotifyEvent is the payload of any webhook services
+//it is serialized to json
+type NotifyEvent struct {
+	Action    string            `json:"action"`
+	Status    string            `json:"status"`
+	Data      map[string]string `json:"data"`
+	Timestamp time.Time         `json:"timestamp"`
+}


### PR DESCRIPTION
so we can consume anywhere we're already importing the client. 