### PR TITLE
use a region specific bucket for papertrail lambda code

### DIFF
--- a/api/models/templates/service/papertrail.tmpl
+++ b/api/models/templates/service/papertrail.tmpl
@@ -80,7 +80,7 @@
           "Handler": "index.handler",
           "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
           "Code": {
-            "S3Bucket": "convox",
+            "S3Bucket": { "Fn::Join": [ "-", [ "convox", { "Ref": "AWS::Region" } ] ] },
             "S3Key": "lambda/papertrail.zip"
           },
           "Runtime": "nodejs",


### PR DESCRIPTION
In conjunction with https://github.com/convox/papertrail/commit/48395b7899a7a2027b478679c49e68a23389d006