### PR TITLE
make the list of container ports unique

### DIFF
--- a/api/models/manifest.go
+++ b/api/models/manifest.go
@@ -254,12 +254,17 @@ func (me ManifestEntry) InternalPorts() []string {
 }
 
 func (me ManifestEntry) ContainerPorts() []string {
+	extmap := map[string]bool{}
 	ext := []string{}
 
 	for _, port := range me.Ports {
 		if parts := strings.Split(port, ":"); len(parts) == 2 {
-			ext = append(ext, parts[1])
+			extmap[parts[1]] = true
 		}
+	}
+
+	for k, _ := range extmap {
+		ext = append(ext, k)
 	}
 
 	return ext


### PR DESCRIPTION
This prevents the doubling up of ContainerPorts when two external ports map to the same internal port. This prevents the ECS service from being deleted on every deploy because this list of container ports incoming (with dupes) mismatches the existing container ports (uniqued)