### PR TITLE
Restore env var check on convox start

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -247,6 +247,19 @@ func (m *Manifest) Build(app, dir string, cache bool) []error {
 	return []error{}
 }
 
+func (me *ManifestEntry) ResolvedEnvironment() []string {
+	r := []string{}
+
+	for _, env := range me.EnvironmentArray() {
+		if strings.Index(env, "=") == -1 {
+			env = fmt.Sprintf("%s=%s", env, os.Getenv(env))
+		}
+		r = append(r, env)
+	}
+
+	return r
+}
+
 func (me *ManifestEntry) EnvironmentArray() []string {
 	var arr []string
 	switch t := me.Environment.(type) {
@@ -256,11 +269,7 @@ func (me *ManifestEntry) EnvironmentArray() []string {
 		}
 	case []interface{}:
 		for _, s := range t {
-			env := s.(string)
-			if strings.Index(env, "=") == -1 {
-				env = fmt.Sprintf("%s=%s", env, os.Getenv(env))
-			}
-			arr = append(arr, env)
+			arr = append(arr, s.(string))
 		}
 	default:
 		// Unknown type. No action.
@@ -495,7 +504,7 @@ func (me ManifestEntry) runAsync(prefix, app, process string, ch chan error) {
 
 	args := []string{"run", "-i", "--name", name}
 
-	for _, env := range me.EnvironmentArray() {
+	for _, env := range me.ResolvedEnvironment() {
 		args = append(args, "-e", env)
 	}
 

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -365,13 +365,6 @@ func (m *Manifest) Raw() ([]byte, error) {
 
 func (m *Manifest) Run(app string) []error {
 	ch := make(chan error)
-
-	missing := m.MissingEnvironment()
-
-	if len(missing) > 0 {
-		return []error{fmt.Errorf("env expected: %s", strings.Join(missing, ", "))}
-	}
-
 	sigch := make(chan os.Signal, 1)
 	signal.Notify(sigch, os.Interrupt, os.Kill)
 


### PR DESCRIPTION
example shell session covering all the cases.

```
~/convox/demo (master*)$ cat docker-compose.yml
web:
  build: .
  command: bin/web
  environment:
    - DEVELOPMENT=true
    - MESSAGE
  ports:
    - 80:3000
  volumes:
    - .:/go/src/github.com/convox/demo

~/convox/demo (master*)$ rm .env
~/convox/demo (master*)$ cx start
ERROR: env expected: MESSAGE

~/convox/demo (master*)$ echo "MESSAGE=foo" > .env
~/convox/demo (master*)$ cx start
RUNNING: docker build -t aythzffsrz /Users/csquared/convox/demo
...
~/convox/demo (master*)$ rm .env
~/convox/demo (master*)$ cx start
ERROR: env expected: MESSAGE
~/convox/demo (master*)$ # set it explicitly to empty
~/convox/demo (master*)$ sed -i '' 's/MESSAGE/MESSAGE=/' docker-compose.yml
~/convox/demo (master*)$ cx start
RUNNING: docker build -t fxontgmaxq /Users/csquared/convox/demo
...
~/convox/demo (master*)$ sed -i '' 's/MESSAGE=/MESSAGE/' docker-compose.yml
~/convox/demo (master*)$ cx start
ERROR: env expected: MESSAGE

~/convox/demo (master*)$ echo "MESSAGE=" > .env
~/convox/demo (master*)$ cx start
RUNNING: docker build -t tuyxglylrl /Users/csquared/convox/demo
...
```