### PR TITLE
use -a for app and standardize

### DIFF
--- a/cmd/convox/env.go
+++ b/cmd/convox/env.go
@@ -13,7 +13,7 @@ import (
 )
 
 var appFlag = cli.StringFlag{
-	Name:  "app",
+	Name:  "app, a",
 	Usage: "App name. Inferred from current directory if not specified.",
 }
 

--- a/cmd/convox/exec.go
+++ b/cmd/convox/exec.go
@@ -16,12 +16,7 @@ func init() {
 		Description: "exec a command in a process in your Convox rack",
 		Usage:       "[pid] [command]",
 		Action:      cmdExec,
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "app",
-				Usage: "App name. Inferred from current directory if not specified.",
-			},
-		},
+		Flags:       []cli.Flag{appFlag},
 	})
 }
 

--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -28,7 +28,7 @@ func init() {
 		Action:      cmdLogin,
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  "password",
+				Name:  "password, p",
 				Usage: "Password to use for authentication. If not specified, prompt for password.",
 			},
 		},

--- a/cmd/convox/logs.go
+++ b/cmd/convox/logs.go
@@ -13,12 +13,7 @@ func init() {
 		Description: "stream the logs for an application",
 		Usage:       "",
 		Action:      cmdLogsStream,
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "app",
-				Usage: "App name. Inferred from current directory if not specified.",
-			},
-		},
+		Flags:       []cli.Flag{appFlag},
 	})
 }
 

--- a/cmd/convox/releases.go
+++ b/cmd/convox/releases.go
@@ -29,36 +29,21 @@ func init() {
 		Description: "list an app's releases",
 		Usage:       "",
 		Action:      cmdReleases,
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "app",
-				Usage: "App name. Inferred from current directory if not specified.",
-			},
-		},
+		Flags:       []cli.Flag{appFlag},
 		Subcommands: []cli.Command{
 			{
 				Name:        "info",
 				Description: "see info about a release",
 				Usage:       "<release id>",
 				Action:      cmdReleaseInfo,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "app",
-						Usage: "app name. Inferred from current directory if not specified.",
-					},
-				},
+				Flags:       []cli.Flag{appFlag},
 			},
 			{
 				Name:        "promote",
 				Description: "promote a release",
 				Usage:       "<release id>",
 				Action:      cmdReleasePromote,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "app",
-						Usage: "app name. Inferred from current directory if not specified.",
-					},
-				},
+				Flags:       []cli.Flag{appFlag},
 			},
 		},
 	})

--- a/cmd/convox/run.go
+++ b/cmd/convox/run.go
@@ -19,11 +19,7 @@ func init() {
 		Description: "run a one-off command in your Convox rack",
 		Usage:       "[process] [command]",
 		Action:      cmdRun,
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "app",
-				Usage: "App name. Inferred from current directory if not specified.",
-			},
+		Flags: []cli.Flag{appFlag,
 			cli.BoolFlag{
 				Name:  "detach",
 				Usage: "run in the background",

--- a/cmd/convox/scale.go
+++ b/cmd/convox/scale.go
@@ -13,11 +13,7 @@ func init() {
 		Description: "scale an app's processes",
 		Usage:       "PROCESS [--count 2] [--memory 512]",
 		Action:      cmdScale,
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "app",
-				Usage: "App name. Inferred from current directory if not specified.",
-			},
+		Flags: []cli.Flag{appFlag,
 			cli.StringFlag{
 				Name:  "count",
 				Value: "",


### PR DESCRIPTION
```

$ cx apps info -a grid
Name       grid
Status     running
Release    RTUHBOURORW
Processes  web
Endpoints  grid-1749418666.us-east-1.elb.amazonaws.com:80 (web)
           grid-1749418666.us-east-1.elb.amazonaws.com:443 (web)

```