### PR TITLE
Add vpc-cidr parameter to convox install for custom vpc sizes

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -179,6 +179,21 @@
       "Description": "Registry port",
       "Default": ""
     },
+    "Subnet0CIDR": {
+      "Default": "10.0.1.0/24",
+      "Description": "Subnet 0 CIDR Block",
+      "Type": "String"
+    },
+    "Subnet1CIDR": {
+      "Default": "10.0.2.0/24",
+      "Description": "Subnet 0 CIDR Block",
+      "Type": "String"
+    },
+    "Subnet2CIDR": {
+      "Default": "10.0.3.0/24",
+      "Description": "Subnet 0 CIDR Block",
+      "Type": "String"
+    },
     "Version": {
       "Default": "latest",
       "Description": "Convox release version",
@@ -188,6 +203,11 @@
       "Type": "Number",
       "Description": "Default disk size in GB",
       "Default": "30"
+    },
+    "VPCCIDR": {
+      "Default": "10.0.0.0/16",
+      "Description": "VPC CIDR Block",
+      "Type": "String"
     },
     "Tenancy": {
       "Type": "String",
@@ -344,7 +364,7 @@
     "Vpc": {
       "Type": "AWS::EC2::VPC",
       "Properties": {
-        "CidrBlock": "10.0.0.0/16",
+        "CidrBlock": { "Ref": "VPCCIDR" },
         "InstanceTenancy": "default",
         "Tags": [
           { "Key": "Name", "Value": { "Ref": "AWS::StackName" } }
@@ -369,7 +389,7 @@
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "AvailabilityZone": { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone0" ] },
-        "CidrBlock": "10.0.1.0/24",
+        "CidrBlock": { "Ref": "Subnet0CIDR" },
         "VpcId": { "Ref": "Vpc" }
       }
     },
@@ -378,7 +398,7 @@
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "AvailabilityZone": { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone1" ] },
-        "CidrBlock": "10.0.2.0/24",
+        "CidrBlock": { "Ref": "Subnet1CIDR" },
         "VpcId": { "Ref": "Vpc" }
       }
     },
@@ -387,7 +407,7 @@
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "AvailabilityZone": { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone2" ] },
-        "CidrBlock": "10.0.3.0/24",
+        "CidrBlock": { "Ref": "Subnet2CIDR" },
         "VpcId": { "Ref": "Vpc" }
       }
     },

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -124,6 +124,26 @@ func init() {
 				Value:  "latest",
 				Usage:  "release version in the format of '20150810161818', or 'latest' by default",
 			},
+			cli.StringFlag{
+				Name:  "vpc-cidr",
+				Value: "10.0.0.0/16",
+				Usage: "The VPC CIDR block",
+			},
+			cli.StringFlag{
+				Name:  "subnet0-cidr",
+				Value: "10.0.1.0/24",
+				Usage: "Subnet 0 CIDR block",
+			},
+			cli.StringFlag{
+				Name:  "subnet1-cidr",
+				Value: "10.0.2.0/24",
+				Usage: "Subnet 1 CIDR block",
+			},
+			cli.StringFlag{
+				Name:  "subnet2-cidr",
+				Value: "10.0.3.0/24",
+				Usage: "Subnet 2 CIDR block",
+			},
 		},
 	})
 
@@ -224,6 +244,14 @@ func cmdInstall(c *cli.Context) {
 
 	stackName := c.String("stack-name")
 
+	vpcCIDR := c.String("vpc-cidr")
+
+	subnet0CIDR := c.String("subnet0-cidr")
+
+	subnet1CIDR := c.String("subnet1-cidr")
+
+	subnet2CIDR := c.String("subnet2-cidr")
+
 	versions, err := version.All()
 
 	if err != nil {
@@ -269,6 +297,10 @@ func cmdInstall(c *cli.Context) {
 			&cloudformation.Parameter{ParameterKey: aws.String("Password"), ParameterValue: aws.String(password)},
 			&cloudformation.Parameter{ParameterKey: aws.String("Tenancy"), ParameterValue: aws.String(tenancy)},
 			&cloudformation.Parameter{ParameterKey: aws.String("Version"), ParameterValue: aws.String(versionName)},
+			&cloudformation.Parameter{ParameterKey: aws.String("Subnet0CIDR"), ParameterValue: aws.String(subnet0CIDR)},
+			&cloudformation.Parameter{ParameterKey: aws.String("Subnet1CIDR"), ParameterValue: aws.String(subnet1CIDR)},
+			&cloudformation.Parameter{ParameterKey: aws.String("Subnet2CIDR"), ParameterValue: aws.String(subnet2CIDR)},
+			&cloudformation.Parameter{ParameterKey: aws.String("VPCCIDR"), ParameterValue: aws.String(vpcCIDR)},
 		},
 		StackName:   aws.String(stackName),
 		TemplateURL: aws.String(formationUrl),


### PR DESCRIPTION
This PR adds the ability to specify the size of the VPC you want to allocate for a convox rack. The subnets are calculated dynamically by splitting the chosen vpc into the 4 largest subnets that will fit.