### PR TITLE
log into Grid without a valid rack; switch to a valid rack

### DIFF
--- a/api/controllers/auth.go
+++ b/api/controllers/auth.go
@@ -1,0 +1,12 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/convox/rack/api/httperr"
+)
+
+func Auth(w http.ResponseWriter, r *http.Request) *httperr.Error {
+	w.Write([]byte("OK\n"))
+	return nil
+}

--- a/api/controllers/routes.go
+++ b/api/controllers/routes.go
@@ -36,6 +36,7 @@ func NewRouter() (router *mux.Router) {
 	router.HandleFunc("/apps/{app}/ssl", api("ssl.list", SSLList)).Methods("GET")
 	router.HandleFunc("/apps/{app}/ssl", api("ssl.create", SSLCreate)).Methods("POST")
 	router.HandleFunc("/apps/{app}/ssl/{process}/{port}", api("ssl.delete", SSLDelete)).Methods("DELETE")
+	router.HandleFunc("/auth", api("auth", Auth)).Methods("GET")
 	router.HandleFunc("/instances", api("instances.get", InstancesList)).Methods("GET")
 	router.HandleFunc("/instances/{id}", api("instance.delete", InstanceTerminate)).Methods("DELETE")
 	router.HandleFunc("/instances/keyroll", api("instances.keyroll", InstancesKeyroll)).Methods("POST")

--- a/api/manifest.yml
+++ b/api/manifest.yml
@@ -441,6 +441,18 @@ paths:
           description: not found
           schema:
             $ref: '#/definitions/error'
+  /auth:
+    get:
+      description: authenticate password
+      responses:
+        200:
+          description: valid password
+          schema:
+            type: string
+        401:
+          description: invalid password
+          schema:
+            type: string
   /instances:
     get:
       description: List instances.

--- a/client/auth.go
+++ b/client/auth.go
@@ -20,7 +20,7 @@ func (c *Client) Auth() error {
 		return err
 	}
 
-	if resp.Status != "200" {
+	if resp.StatusCode != 200 {
 		return fmt.Errorf("invalid login")
 	}
 

--- a/client/auth.go
+++ b/client/auth.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (c *Client) Auth() error {
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/auth", c.Host), nil)
+
+	if err != nil {
+		return err
+	}
+
+	req.SetBasicAuth("convox", string(c.Password))
+
+	resp, err := c.client().Do(req)
+
+	if err != nil {
+		return err
+	}
+
+	resp.Body.Close()
+	return nil
+}

--- a/client/auth.go
+++ b/client/auth.go
@@ -20,6 +20,10 @@ func (c *Client) Auth() error {
 		return err
 	}
 
+	if resp.Status != "200" {
+		return fmt.Errorf("ERROR: invalid login\n")
+	}
+
 	resp.Body.Close()
 	return nil
 }

--- a/client/auth.go
+++ b/client/auth.go
@@ -21,7 +21,7 @@ func (c *Client) Auth() error {
 	}
 
 	if resp.Status != "200" {
-		return fmt.Errorf("ERROR: invalid login\n")
+		return fmt.Errorf("invalid login")
 	}
 
 	resp.Body.Close()

--- a/client/switch.go
+++ b/client/switch.go
@@ -1,10 +1,52 @@
 package client
 
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
 func (c *Client) Switch(rackName string) (success map[string]string, err error) {
-	params := map[string]string{
-		"rack-name": rackName,
+	form := url.Values{}
+	form.Set("rack-name", rackName)
+	body := strings.NewReader(form.Encode())
+	url := fmt.Sprintf("https://%s/switch", c.Host)
+
+	req, err := http.NewRequest("POST", url, body)
+
+	if err != nil {
+		return nil, err
 	}
 
-	err = c.Post("/switch", params, &success)
-	return
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("convox", string(c.Password))
+
+	resp, err := c.client().Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if err := responseError(resp); err != nil {
+		return nil, err
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(data, &success)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return success, nil
 }

--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -371,7 +371,12 @@ func testLogin(host, password, version string) (err error) {
 	_, err = cl.GetApps()
 
 	if err != nil {
-		return
+		err = cl.Auth()
+
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
 	}
 
 	return nil

--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -374,7 +374,6 @@ func testLogin(host, password, version string) (err error) {
 		err = cl.Auth()
 
 		if err != nil {
-			fmt.Println(err.Error())
 			return
 		}
 	}

--- a/cmd/convox/login_test.go
+++ b/cmd/convox/login_test.go
@@ -14,6 +14,7 @@ func TestInvalidLogin(t *testing.T) {
 
 	ts := testServer(t,
 		test.Http{Method: "GET", Path: "/apps", Code: 401, Response: "unauthorized"},
+		test.Http{Method: "GET", Path: "/auth", Code: 404, Response: "not found"},
 	)
 
 	defer ts.Close()


### PR DESCRIPTION
* Add `/auth` func to client and call it if proxying to Rack `/apps` fails.
* Change `/switch` to not call `/system` (aka versionCheck). This works around Rack errors so users in a bad state to switch to a known good Rack.

This change enables users who can't log into Grid via the CLI because their current Rack is bad or nonexistent to get back to a good state. Once this is released they can:

1. `convox update`
2. `convox login grid.convox.com`
3. `convox switch [good rack]`

Depends on https://github.com/convox/grid/pull/107