### PR TITLE
us the ami ids from the ECS docs, not the aws marketplace

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -107,7 +107,7 @@
   "Parameters": {
     "Ami": {
       "Type": "String",
-      "Description": "Amazon Machine Image",
+      "Description": "Amazon Machine Image: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html",
       "Default": ""
     },
     "ClientId": {

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -11,12 +11,12 @@
   },
   "Mappings": {
     "RegionConfig": {
-      "us-east-1": { "Ami": "ami-e2b1f988" },
-      "us-west-1": { "Ami": "ami-06d1b966" },
-      "us-west-2": { "Ami": "ami-37ccd056" },
-      "eu-west-1": { "Ami": "ami-f402a287" },
-      "ap-northeast-1": { "Ami": "ami-9c4a61f2" },
-      "ap-southeast-2": { "Ami": "ami-e1d31082" }
+      "us-east-1": { "Ami": "ami-6ff4bd05" },
+      "us-west-1": { "Ami": "ami-46cda526" },
+      "us-west-2": { "Ami": "ami-313d2150" },
+      "eu-west-1": { "Ami": "ami-8073d3f3" },
+      "ap-northeast-1": { "Ami": "ami-6ca38b02" },
+      "ap-southeast-2": { "Ami": "ami-00e7bf63" }
     }
   },
   "Outputs": {


### PR DESCRIPTION
use:
http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html

not:
![screen shot 2015-12-15 at 6 37 08 pm](https://cloud.githubusercontent.com/assets/173457/11853080/ca69c6de-a3f0-11e5-9ff3-196ba274dfc0.png)
