### PR TITLE
Service Options (was RDS options)

### DIFF
--- a/api/controllers/services.go
+++ b/api/controllers/services.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/convox/rack/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/convox/rack/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/convox/rack/Godeps/_workspace/src/golang.org/x/net/websocket"
 	"github.com/convox/rack/api/httperr"
@@ -37,33 +38,38 @@ func ServiceShow(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 }
 
 func ServiceCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
-	name := GetForm(r, "name")
-	t := GetForm(r, "type")
-	url := GetForm(r, "url")
+	err := r.ParseForm()
+	if err != nil {
+		return httperr.Server(err)
+	}
+
+	// get the last set value for all form values
+	// ie:  foo=1&foo=2  sets foo to "2"
+	options := make(map[string]string)
+	for key, values := range r.Form {
+		val := values[len(values)-1]
+		options[key] = val
+	}
+	name := options["name"]
+	delete(options, "name")
+	kind := options["type"]
+	delete(options, "type")
 
 	service := &models.Service{
-		Name: name,
-		Type: t,
-		URL:  url,
+		Name:    name,
+		Type:    kind,
+		Options: options,
 	}
 
-	var err error
-
-	switch t {
-	case "papertrail":
-		err = service.CreatePapertrail()
-	case "webhook":
-		err = service.CreateWebhook()
-	default:
-		err = service.CreateDatastore()
-	}
+	err = service.Create()
 
 	if err != nil && strings.HasSuffix(err.Error(), "not found") {
-		return httperr.Errorf(403, "invalid service type: %s", t)
+		return httperr.Errorf(403, "invalid service type: %s", kind)
 	}
 
 	if err != nil && awsError(err) == "ValidationError" {
-		return httperr.Errorf(403, "invalid service name: %s", name)
+		e := err.(awserr.Error)
+		return httperr.Errorf(403, e.Message())
 	}
 
 	if err != nil {

--- a/api/models/service-datastore.go
+++ b/api/models/service-datastore.go
@@ -7,36 +7,17 @@ import (
 	"github.com/convox/rack/Godeps/_workspace/src/github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
-func (s *Service) CreateDatastore() error {
+func (s *Service) CreateDatastore() (*cloudformation.CreateStackInput, error) {
 	formation, err := s.Formation()
 
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	params := map[string]string{
 		"Password": generateId("", 30),
 		"Subnets":  os.Getenv("SUBNETS"),
 		"Vpc":      os.Getenv("VPC"),
-	}
-
-	for key, value := range s.Options {
-		var val string
-		switch value {
-		case "":
-			val = "No"
-		case "true":
-			val = "Yes"
-		default:
-			val = value
-		}
-		params[AwsCamelize(key)] = val
-	}
-
-	tags := map[string]string{
-		"System":  os.Getenv("RACK"),
-		"Type":    "service",
-		"Service": s.Type,
 	}
 
 	req := &cloudformation.CreateStackInput{
@@ -49,11 +30,5 @@ func (s *Service) CreateDatastore() error {
 		req.Parameters = append(req.Parameters, &cloudformation.Parameter{ParameterKey: aws.String(key), ParameterValue: aws.String(value)})
 	}
 
-	for key, value := range tags {
-		req.Tags = append(req.Tags, &cloudformation.Tag{Key: aws.String(key), Value: aws.String(value)})
-	}
-
-	_, err = CloudFormation().CreateStack(req)
-
-	return err
+	return req, err
 }

--- a/api/models/service-datastore.go
+++ b/api/models/service-datastore.go
@@ -14,20 +14,14 @@ func (s *Service) CreateDatastore() (*cloudformation.CreateStackInput, error) {
 		return nil, err
 	}
 
-	params := map[string]string{
-		"Password": generateId("", 30),
-		"Subnets":  os.Getenv("SUBNETS"),
-		"Vpc":      os.Getenv("VPC"),
-	}
+	s.Parameters["Password"] = generateId("", 30)
+	s.Parameters["Subnets"] = os.Getenv("SUBNETS")
+	s.Parameters["Vpc"] = os.Getenv("VPC")
 
 	req := &cloudformation.CreateStackInput{
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
 		StackName:    aws.String(s.Name),
 		TemplateBody: aws.String(formation),
-	}
-
-	for key, value := range params {
-		req.Parameters = append(req.Parameters, &cloudformation.Parameter{ParameterKey: aws.String(key), ParameterValue: aws.String(value)})
 	}
 
 	return req, err

--- a/api/models/service-papertrail.go
+++ b/api/models/service-papertrail.go
@@ -10,10 +10,6 @@ import (
 )
 
 func (s *Service) CreatePapertrail() (*cloudformation.CreateStackInput, error) {
-	if s.Options["url"] == "" {
-		return nil, fmt.Errorf("Syslog URL is required")
-	}
-
 	input := struct {
 		ARNs []string
 	}{

--- a/api/models/service-papertrail.go
+++ b/api/models/service-papertrail.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *Service) CreatePapertrail() error {
-	if s.URL == "" {
+	if s.Options["url"] == "" {
 		return fmt.Errorf("Papertrail URL is required")
 	}
 
@@ -27,7 +27,7 @@ func (s *Service) CreatePapertrail() error {
 	}
 
 	params := map[string]string{
-		"Url": s.URL,
+		"Url": s.Options["url"],
 	}
 
 	tags := map[string]string{

--- a/api/models/service-webhook.go
+++ b/api/models/service-webhook.go
@@ -27,7 +27,8 @@ func (s *Service) CreateWebhook() (*cloudformation.CreateStackInput, error) {
 		}
 
 		encEndpoint := url.QueryEscape(s.Parameters["Url"])
-		//NOTE always assumes https instead of u.Scheme
+		//NOTE: using http SNS notifier because https
+		//      doesn't work with rack's self-signed cert
 		proxyEndpoint := "http://" + NotificationHost + "/sns?endpoint=" + encEndpoint
 		s.Parameters["Url"] = proxyEndpoint
 	}

--- a/api/models/service-webhook.go
+++ b/api/models/service-webhook.go
@@ -1,0 +1,72 @@
+package models
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/convox/rack/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws"
+	"github.com/convox/rack/Godeps/_workspace/src/github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+var NotificationTopic = os.Getenv("NOTIFICATION_TOPIC")
+var NotificationHost = os.Getenv("NOTIFICATION_HOST")
+
+func (s *Service) CreateWebhook() error {
+	if s.Options["url"] == "" {
+		return fmt.Errorf("Webhook URL is required")
+	}
+
+	//ensure valid URL
+	_, err := url.Parse(s.Options["url"])
+	if err != nil {
+		return err
+	}
+
+	var input interface{}
+	formation, err := buildTemplate("service/webhook", "service", input)
+
+	if err != nil {
+		return err
+	}
+
+	encEndpoint := url.QueryEscape(s.Options["url"])
+	//NOTE always assumes https instead of u.Scheme
+	proxyEndpoint := "http://" + NotificationHost + "/sns?endpoint=" + encEndpoint
+
+	params := map[string]string{
+		"Url":               proxyEndpoint,
+		"NotificationTopic": NotificationTopic,
+		"CustomTopic":       CustomTopic,
+	}
+
+	tags := map[string]string{
+		"System":  "convox",
+		"Type":    "service",
+		"Service": "webhook",
+	}
+
+	req := &cloudformation.CreateStackInput{
+		//TODO: do i need this?
+		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
+		StackName:    aws.String(s.Name),
+		TemplateBody: aws.String(formation),
+	}
+
+	for key, value := range params {
+		req.Parameters = append(req.Parameters, &cloudformation.Parameter{ParameterKey: aws.String(key), ParameterValue: aws.String(value)})
+	}
+
+	for key, value := range tags {
+		req.Tags = append(req.Tags, &cloudformation.Tag{Key: aws.String(key), Value: aws.String(value)})
+	}
+
+	_, err = CloudFormation().CreateStack(req)
+
+	NotifySuccess("service:create", map[string]string{
+		"name": s.Name,
+		"type": s.Type,
+	})
+
+	return err
+}

--- a/api/models/service.go
+++ b/api/models/service.go
@@ -204,6 +204,7 @@ func serviceFromStack(stack *cloudformation.Stack) *Service {
 		Parameters: parameters,
 		Tags:       tags,
 		Exports:    exports,
+		URL:        exports["URL"],
 	}
 }
 

--- a/api/models/service.go
+++ b/api/models/service.go
@@ -27,7 +27,11 @@ func ListServices() (Services, error) {
 	for _, stack := range res.Stacks {
 		tags := stackTags(stack)
 
-		if tags["System"] == os.Getenv("RACK") && tags["Type"] == "service" {
+		//NOTE: services used to not have a tag so the empty "Rack"
+		//      is for untagged services
+		if tags["System"] == "convox" &&
+			tags["Type"] == "service" &&
+			(tags["Rack"] == os.Getenv("RACK") || tags["Rack"] == "") {
 			services = append(services, *serviceFromStack(stack))
 		}
 	}
@@ -93,9 +97,10 @@ func (s *Service) Create() error {
 
 	// tag the service
 	tags := map[string]string{
-		"System":  os.Getenv("RACK"),
-		"Type":    "service",
+		"Rack":    os.Getenv("RACK"),
+		"System":  "convox",
 		"Service": s.Type,
+		"Type":    "service",
 	}
 
 	for key, value := range tags {

--- a/api/models/service.go
+++ b/api/models/service.go
@@ -204,7 +204,8 @@ func serviceFromStack(stack *cloudformation.Stack) *Service {
 		Parameters: parameters,
 		Tags:       tags,
 		Exports:    exports,
-		URL:        exports["URL"],
+		// NOTE: this field is deprecated, use Exports instead
+		URL: exports["URL"],
 	}
 }
 

--- a/api/models/services_test.go
+++ b/api/models/services_test.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/convox/rack/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+)
+
+func TestCFParams(t *testing.T) {
+	params := CFParams(map[string]string{
+		"foo":                 "bar",
+		"multi-az":            "true",
+		"encrypted-storage":   "",
+		"test-test-test-test": "TEST",
+	})
+
+	assert.Equal(t, "bar", params["Foo"])
+	assert.Equal(t, "Yes", params["MultiAZ"])
+	assert.Equal(t, "No", params["EncryptedStorage"])
+	assert.Equal(t, "TEST", params["TestTestTestTest"])
+}

--- a/client/services.go
+++ b/client/services.go
@@ -9,7 +9,6 @@ type Service struct {
 	Type         string            `json:"type"`
 	Exports      map[string]string `json:"exports"`
 
-	Options    map[string]string `json:"-"`
 	Outputs    map[string]string `json:"-"`
 	Parameters map[string]string `json:"-"`
 	Tags       map[string]string `json:"-"`

--- a/client/services.go
+++ b/client/services.go
@@ -8,6 +8,9 @@ type Service struct {
 	StatusReason string            `json:"status-reason"`
 	Type         string            `json:"type"`
 	Exports      map[string]string `json:"exports"`
+	// DEPRECATED: should inject any data in Exports
+	// we only set this on the outgoing response for old clients
+	URL string `json:"url"`
 
 	Outputs    map[string]string `json:"-"`
 	Parameters map[string]string `json:"-"`

--- a/client/services.go
+++ b/client/services.go
@@ -3,11 +3,16 @@ package client
 import "fmt"
 
 type Service struct {
-	Name   string `json:"name"`
-	Status string `json:"status"`
-	Type   string `json:"type"`
-	URL    string `json:"url"`
-	Size   string `json:"size"`
+	Name         string            `json:"name"`
+	Status       string            `json:"status"`
+	StatusReason string            `json:"status-reason"`
+	Type         string            `json:"type"`
+	Exports      map[string]string `json:"exports"`
+
+	Options    map[string]string `json:"-"`
+	Outputs    map[string]string `json:"-"`
+	Parameters map[string]string `json:"-"`
+	Tags       map[string]string `json:"-"`
 }
 
 type Services []Service
@@ -24,17 +29,8 @@ func (c *Client) GetServices() (Services, error) {
 	return services, nil
 }
 
-func (c *Client) CreateService(kind, name string, options map[string]string) (*Service, error) {
-
+func (c *Client) CreateService(kind string, options map[string]string) (*Service, error) {
 	params := Params(options)
-	//NOTE: might move this to ParseOpts
-	for key, value := range params {
-		if value == "" {
-			params[key] = "true"
-		}
-	}
-
-	params["name"] = name
 	params["type"] = kind
 	var service Service
 

--- a/client/services.go
+++ b/client/services.go
@@ -7,6 +7,7 @@ type Service struct {
 	Status string `json:"status"`
 	Type   string `json:"type"`
 	URL    string `json:"url"`
+	Size   string `json:"size"`
 }
 
 type Services []Service
@@ -23,13 +24,18 @@ func (c *Client) GetServices() (Services, error) {
 	return services, nil
 }
 
-func (c *Client) CreateService(typ, name, url string) (*Service, error) {
-	params := Params{
-		"name": name,
-		"type": typ,
-		"url":  url,
+func (c *Client) CreateService(kind, name string, options map[string]string) (*Service, error) {
+
+	params := Params(options)
+	//NOTE: might move this to ParseOpts
+	for key, value := range params {
+		if value == "" {
+			params[key] = "true"
+		}
 	}
 
+	params["name"] = name
+	params["type"] = kind
 	var service Service
 
 	err := c.Post("/services", params, &service)

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -19,7 +19,7 @@ func init() {
 			{
 				Name:            "create",
 				Description:     "create a new service",
-				Usage:           "<type> [--name=value] [--Key=Value]",
+				Usage:           "<type> [--name=value] [--key-name=value]",
 				Action:          cmdServiceCreate,
 				SkipFlagParsing: true,
 			},
@@ -71,13 +71,19 @@ func cmdServices(c *cli.Context) {
 }
 
 func cmdServiceCreate(c *cli.Context) {
+	// ensure type included
 	if !(len(c.Args()) > 0) {
 		stdcli.Usage(c, "create")
 		return
 	}
 
-	t := c.Args()[0]
+	// ensure everything after type is a flag
+	if len(c.Args()) > 1 && !strings.HasPrefix(c.Args()[1], "--") {
+		stdcli.Usage(c, "create")
+		return
+	}
 
+	t := c.Args()[0]
 	options := stdcli.ParseOpts(c.Args()[1:])
 	for key, value := range options {
 		if value == "" {

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -3,28 +3,11 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 
 	"github.com/convox/rack/Godeps/_workspace/src/github.com/codegangsta/cli"
 	"github.com/convox/rack/cmd/convox/stdcli"
 )
-
-type Service struct {
-	Name     string
-	Password string
-	Type     string
-	Status   string
-	URL      string
-
-	App string
-
-	Stack string
-
-	Outputs    map[string]string
-	Parameters map[string]string
-	Tags       map[string]string
-}
-
-type Services []Service
 
 func init() {
 	stdcli.RegisterCommand(cli.Command{
@@ -70,8 +53,6 @@ func init() {
 	})
 }
 
-var EncryptedInstances = "db.m4.large, db.m4.xlarge, db.m4.2xlarge, db.m4.4xlarge, db.m4.10xlarge, db.r3.large, db.r3.xlarge, db.r3.2xlarge, db.r3.4xlarge, db.r3.8xlarge, db.t2.large, db.cr1.8xlarge, db.m3.medium, db.m3.large, db.m3.xlarge, db.m3.2xlarge"
-
 func cmdServices(c *cli.Context) {
 	services, err := rackClient(c).GetServices()
 
@@ -98,17 +79,28 @@ func cmdServiceCreate(c *cli.Context) {
 	t := c.Args()[0]
 
 	options := stdcli.ParseOpts(c.Args()[1:])
-	fmt.Println("config:", options)
-
-	name := options["name"]
-
-	if name == "" {
-		name = fmt.Sprintf("%s-%d", t, (rand.Intn(8999) + 1000))
+	for key, value := range options {
+		if value == "" {
+			options[key] = "true"
+		}
 	}
 
-	fmt.Printf("Creating %s (%s)... ", name, t)
+	var optionsList []string
+	for key, val := range options {
+		optionsList = append(optionsList, fmt.Sprintf("%s=%q", key, val))
+	}
 
-	_, err := rackClient(c).CreateService(t, name, options)
+	if options["name"] == "" {
+		options["name"] = fmt.Sprintf("%s-%d", t, (rand.Intn(8999) + 1000))
+	}
+
+	fmt.Printf("Creating %s (%s", options["name"], t)
+	if len(optionsList) > 0 {
+		fmt.Printf(": %s", strings.Join(optionsList, " "))
+	}
+	fmt.Printf(")... ")
+
+	_, err := rackClient(c).CreateService(t, options)
 
 	if err != nil {
 		stdcli.Error(err)
@@ -155,7 +147,18 @@ func cmdServiceInfo(c *cli.Context) {
 
 	fmt.Printf("Name    %s\n", service.Name)
 	fmt.Printf("Status  %s\n", service.Status)
-	fmt.Printf("URL     %s\n", service.URL)
+
+	if service.Status == "failed" {
+		fmt.Printf("Reason  %s\n", service.StatusReason)
+	}
+
+	if len(service.Exports) > 0 {
+		fmt.Printf("Exports\n")
+	}
+
+	for key, value := range service.Exports {
+		fmt.Printf("  %s: %s\n", key, value)
+	}
 }
 
 func cmdLinkCreate(c *cli.Context) {

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -180,3 +180,26 @@ func queryExecCommand(bin string, args ...string) ([]byte, error) {
 func tagTimeUnix() string {
 	return fmt.Sprintf("%v", time.Now().Unix())
 }
+
+func ParseOpts(args []string) map[string]string {
+	options := make(map[string]string)
+	var key string
+
+	for _, token := range args {
+		isFlag := strings.HasPrefix(token, "--")
+		if isFlag {
+			key = token[2:]
+			value := ""
+			if strings.Contains(key, "=") {
+				pivot := strings.Index(key, "=")
+				value = key[pivot+1:]
+				key = key[0:pivot]
+			}
+			options[key] = value
+		} else {
+			options[key] = strings.TrimSpace(options[key] + " " + token)
+		}
+	}
+
+	return options
+}

--- a/cmd/convox/stdcli/stdcli_test.go
+++ b/cmd/convox/stdcli/stdcli_test.go
@@ -19,4 +19,9 @@ func TestParseOptions(t *testing.T) {
 
 	opts = stdcli.ParseOpts([]string{"--foo=this", "is", "a bad idea"})
 	assert.Equal(t, "this is a bad idea", opts["foo"])
+
+	opts = stdcli.ParseOpts([]string{"--this", "--is=even", "worse"})
+	assert.Equal(t, "even worse", opts["is"])
+	_, ok := opts["this"]
+	assert.Equal(t, true, ok)
 }

--- a/cmd/convox/stdcli/stdcli_test.go
+++ b/cmd/convox/stdcli/stdcli_test.go
@@ -1,0 +1,22 @@
+package stdcli_test
+
+import (
+	"testing"
+
+	"github.com/convox/rack/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+	"github.com/convox/rack/cmd/convox/stdcli"
+)
+
+func TestParseOptions(t *testing.T) {
+	var opts map[string]string
+	opts = stdcli.ParseOpts([]string{"--foo", "bar", "--key", "value"})
+	assert.Equal(t, "bar", opts["foo"])
+	assert.Equal(t, "value", opts["key"])
+
+	opts = stdcli.ParseOpts([]string{"--foo=bar", "--key", "value"})
+	assert.Equal(t, "bar", opts["foo"])
+	assert.Equal(t, "value", opts["key"])
+
+	opts = stdcli.ParseOpts([]string{"--foo=this", "is", "a bad idea"})
+	assert.Equal(t, "this is a bad idea", opts["foo"])
+}


### PR DESCRIPTION
- parses any cli option passed to service create
- passes options through to CF template
- reports errors from CF so we don't need to validate presence, etc in models
- adds status reason to service model
- abstracts service creation to hopefully make definition, addition easier
- changes "URL" return to "exports" key/value pairs for future compatibility

- fixes service tagging as well