### PR TITLE
Include ecr:GetAuthorizationToken permission

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -453,6 +453,10 @@
                   "Action": [
                     "autoscaling:DescribeAutoScalingInstances",
                     "autoscaling:SetInstanceHealth",
+                    "ecr:GetAuthorizationToken",
+                    "ecr:GetDownloadUrlForLayer",
+                    "ecr:BatchGetImage",
+                    "ecr:BatchCheckLayerAvailability",
                     "ec2:DescribeInstances",
                     "ecs:CreateCluster",
                     "ecs:DeregisterContainerInstance",


### PR DESCRIPTION
This isn't an integration with ECR, it simply allows ECS to pull images from ECR. This is important for continuous integration of a local convox build chain (we deploy automated convox builds to ECR so CloudFormation is able to boot them).

This change allows ECR to be used with `convox/api` and `convox/registry` images.