### PR TITLE
SSL chain fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 
 RUN apk-install gcc libc-dev libtool libgcc
-RUN go get github.com/cloudflare/cfssl/cmd/cfssl
+RUN go get github.com/convox/cfssl/cmd/cfssl
 
 RUN go get github.com/ddollar/init
 RUN go get github.com/ddollar/rerun

--- a/api/models/ssl.go
+++ b/api/models/ssl.go
@@ -30,6 +30,9 @@ type SSL struct {
 type SSLs []SSL
 
 func CreateSSL(app, process string, port int, body, key string, chain string, secure bool) (*SSL, error) {
+	endEntityCert, _ := pem.Decode([]byte(body))
+	body = string(pem.EncodeToMemory(endEntityCert))
+
 	a, err := GetApp(app)
 
 	if err != nil {

--- a/api/models/ssl.go
+++ b/api/models/ssl.go
@@ -30,6 +30,7 @@ type SSL struct {
 type SSLs []SSL
 
 func CreateSSL(app, process string, port int, body, key string, chain string, secure bool) (*SSL, error) {
+	// strip off any intermediate certs from the body
 	endEntityCert, _ := pem.Decode([]byte(body))
 	body = string(pem.EncodeToMemory(endEntityCert))
 

--- a/api/models/ssl.go
+++ b/api/models/ssl.go
@@ -85,15 +85,19 @@ func CreateSSL(app, process string, port int, body, key string, chain string, se
 
 	name := certName(a.Name, process, port)
 
-	// return nil, fmt.Errorf("foo")
-
-	// upload certificate
-	resp, err := IAM().UploadServerCertificate(&iam.UploadServerCertificateInput{
+	input := &iam.UploadServerCertificateInput{
 		CertificateBody:       aws.String(body),
-		CertificateChain:      aws.String(chain),
 		PrivateKey:            aws.String(key),
 		ServerCertificateName: aws.String(name),
-	})
+	}
+
+	// Only include chain if it's not an empty string
+	if chain != "" {
+		input.CertificateChain = aws.String(chain)
+	}
+
+	// upload certificate
+	resp, err := IAM().UploadServerCertificate(input)
 
 	// cleanup old certificate, will fail if dependencies
 	if err != nil && strings.Contains(err.Error(), "already exists") {
@@ -105,11 +109,7 @@ func CreateSSL(app, process string, port int, body, key string, chain string, se
 			return nil, fmt.Errorf("could not create certificate: %s", name)
 		}
 
-		resp, err = IAM().UploadServerCertificate(&iam.UploadServerCertificateInput{
-			CertificateBody:       aws.String(body),
-			PrivateKey:            aws.String(key),
-			ServerCertificateName: aws.String(name),
-		})
+		resp, err = IAM().UploadServerCertificate(input)
 	}
 
 	if err != nil {
@@ -283,6 +283,19 @@ type CfsslCertificateBundle struct {
 // use cfssl bundle to generate the certificate chain
 // return the whole list minus the first one
 func resolveCertificateChain(body string) (string, error) {
+	bl, _ := pem.Decode([]byte(body))
+	crt, err := x509.ParseCertificate(bl.Bytes)
+
+	if err != nil {
+		return "", err
+	}
+
+	// return if this is a self-signed cert
+	// a cert is self-signed if the issuer and subject are the same
+	if string(crt.RawIssuer) == string(crt.RawSubject) {
+		return "", nil
+	}
+
 	cmd := exec.Command("cfssl", "bundle", "-cert", "-")
 
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Automatic intermediate cert chain generation was causing problems with the `convox ssl create` command for:

* Manually-created self-signed certs
* Self signed-certs created with the `--self-signed` option
* Any other cert with the full chain already bundled

The fixes for these were:

* Detect if the cert is self-signed, and if so, don't try to complete the chain and don't upload a chain to AWS
* For non-self-signed, strip away everything except the end-entity cert and then regenerate the chain