### PR TITLE
CI Stability

### DIFF
--- a/ci/dependencies-pre.sh
+++ b/ci/dependencies-pre.sh
@@ -5,7 +5,7 @@ VERSION=${VERSION:-ci}
 
 # install utilities
 curl -O http://stedolan.github.io/jq/download/linux64/jq && chmod +x jq && sudo mv jq /usr/local/bin
-sudo pip install awscli
+sudo pip install awscli --upgrade
 
 # build and install with VERSION
 go get -d github.com/convox/rack/cmd/convox

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,8 @@ test:
     - ci/tests/create-httpd.sh
   post:
     - ci/delete-all-apps.sh
-    - ci/test-post.sh
+    - ci/test-post.sh:
+        timeout: 1800
     - ci/test-cleanup.sh
 
 general:

--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,3 @@ test:
     - ci/test-post.sh:
         timeout: 1800
     - ci/test-cleanup.sh
-
-general:
-  branches:
-     only:
-       - master

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,5 @@ test:
     - ci/tests/create-httpd.sh
   post:
     - ci/delete-all-apps.sh
-    - ci/test-post.sh:
-        timeout: 1800
+    - ci/test-post.sh
     - ci/test-cleanup.sh

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -605,7 +605,7 @@ func displayProgress(stack string, CloudFormation *cloudformation.CloudFormation
 
 			fmt.Printf("Skipped %s: %s\n", name, id)
 		case "DELETE_FAILED":
-			return fmt.Errorf("stack deletion failed")
+			fmt.Printf("Failed to delete %s: %s\n", name, id)
 		case "ROLLBACK_IN_PROGRESS", "ROLLBACK_COMPLETE":
 		case "UPDATE_IN_PROGRESS", "UPDATE_COMPLETE", "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS", "UPDATE_FAILED", "UPDATE_ROLLBACK_IN_PROGRESS", "UPDATE_ROLLBACK_COMPLETE", "UPDATE_ROLLBACK_FAILED":
 		default:

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -605,6 +605,12 @@ func displayProgress(stack string, CloudFormation *cloudformation.CloudFormation
 
 			fmt.Printf("Skipped %s: %s\n", name, id)
 		case "DELETE_FAILED":
+			id := *event.PhysicalResourceId
+
+			if strings.HasPrefix(id, "arn:") {
+				id = *event.LogicalResourceId
+			}
+
 			fmt.Printf("Failed to delete %s: %s\n", name, id)
 		case "ROLLBACK_IN_PROGRESS", "ROLLBACK_COMPLETE":
 		case "UPDATE_IN_PROGRESS", "UPDATE_COMPLETE", "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS", "UPDATE_FAILED", "UPDATE_ROLLBACK_IN_PROGRESS", "UPDATE_ROLLBACK_COMPLETE", "UPDATE_ROLLBACK_FAILED":

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -428,8 +428,23 @@ func cmdUninstall(c *cli.Context) {
 	_, err = waitForCompletion(stackId, CloudFormation, true)
 
 	if err != nil {
-		handleError("uninstall", distinctId, err)
-		return
+		sendMixpanelEvent("convox-uninstall-retry", "")
+
+		_, err = CloudFormation.DeleteStack(&cloudformation.DeleteStackInput{
+			StackName: aws.String(stackId),
+		})
+
+		if err != nil {
+			handleError("uninstall", distinctId, err)
+			return
+		}
+
+		_, err = waitForCompletion(stackId, CloudFormation, true)
+
+		if err != nil {
+			handleError("uninstall", distinctId, err)
+			return
+		}
 	}
 
 	host := ""

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -392,6 +392,14 @@ func cmdUninstall(c *cli.Context) {
 
 	fmt.Println("Uninstalling Convox...")
 
+	// CF Stack Delete and Retry could take 30+ minutes. Periodically generate more progress output.
+	go func() {
+		t := time.Tick(2 * time.Minute)
+		for range t {
+			fmt.Println("Uninstalling Convox...")
+		}
+	}()
+
 	distinctId := randomString(10)
 
 	CloudFormation := cloudformation.New(session.New(), awsConfig(region, creds))


### PR DESCRIPTION
* Retry CF Delete Stack to work around known VPC DELETE_FAILED problem
* Print generic uninstall progress message every 2m to address log CF wait periods and CircleCI timeouts
* Upgrade awscli
* Use `aws` to delete S3 buckets, Log Groups, and Registries after test

This builds on top of https://github.com/convox/rack/pull/280

* Split out deleting apps to it's own step
* Split out post-uninstall cleanup into it's own step
* Spin until CF stack updates finish
* Spin until app ELB is avilable

And https://github.com/convox/rack/pull/281

* Tweak CF DependsOn to try to fix GatewayAttachment DELETE_FAILED

The GatewayAttachment DELETE_FAILED still happens occasionally, which means a CI test may take up to 50 minutes. I have opened up a support ticket to further root cause this problem.


