### PR TITLE
More link vars

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -349,8 +349,14 @@ func (me *ManifestEntry) ResolvedLinkVars(m *Manifest) (map[string]string, error
 			linkUrl.User = url.UserPassword(linkEntryEnv["LINK_USERNAME"], linkEntryEnv["LINK_PASSWORD"])
 		}
 
-		varName := strings.ToUpper(link) + "_URL"
-		linkVars[varName] = linkUrl.String()
+		prefix := strings.ToUpper(link) + "_"
+		linkVars[prefix+"URL"] = linkUrl.String()
+		linkVars[prefix+"HOST"] = host
+		linkVars[prefix+"SCHEME"] = scheme
+		linkVars[prefix+"PORT"] = port
+		linkVars[prefix+"USERNAME"] = linkEntryEnv["LINK_USERNAME"]
+		linkVars[prefix+"PASSWORD"] = linkEntryEnv["LINK_PASSWORD"]
+		linkVars[prefix+"PATH"] = linkEntryEnv["LINK_PATH"]
 	}
 
 	return linkVars, nil

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -283,6 +283,8 @@ func (me *ManifestEntry) ResolvedEnvironment(m *Manifest) ([]string, error) {
 		r = append([]string{env}, r...)
 	}
 
+	sort.Strings(r)
+
 	return r, nil
 }
 

--- a/api/manifest/manifest_test.go
+++ b/api/manifest/manifest_test.go
@@ -131,7 +131,7 @@ func TestRun(t *testing.T) {
 	stdout, stderr := testRun(m, "compose")
 
 	cases := Cases{
-		{stdout, fmt.Sprintf("\x1b[36mpostgres |\x1b[0m running: docker run -i --name compose-postgres -p 5432:5432 compose/postgres\n\x1b[33mweb      |\x1b[0m running: docker run -i --name compose-web -e POSTGRES_URL=tcp://1.1.1.1:5432 -p 5000:3000 -v %s:/app compose/web\n", destDir)},
+		{stdout, fmt.Sprintf("\x1b[36mpostgres |\x1b[0m running: docker run -i --name compose-postgres -p 5432:5432 compose/postgres\n\x1b[33mweb      |\x1b[0m running: docker run -i --name compose-web -e POSTGRES_HOST=1.1.1.1 -e POSTGRES_PASSWORD= -e POSTGRES_PATH= -e POSTGRES_PORT=5432 -e POSTGRES_SCHEME=tcp -e POSTGRES_URL=tcp://1.1.1.1:5432 -e POSTGRES_USERNAME= -p 5000:3000 -v %s:/app compose/web\n", destDir)},
 		{stderr, ""},
 	}
 

--- a/api/models/fixtures/web_redis.json
+++ b/api/models/fixtures/web_redis.json
@@ -711,7 +711,10 @@
                   "KINESIS": {
                     "Ref": "Kinesis"
                   },
+                  "LINK_PASSWORD": "pass-the-word",
+                  "LINK_PATH": "/0",
                   "LINK_SCHEME": "redis",
+                  "LINK_USERNAME": "user",
                   "LOG_GROUP": {
                     "Ref": "LogGroup"
                   },
@@ -940,13 +943,23 @@
                     "Ref": "LogGroup"
                   },
                   "PROCESS": "web",
+                  "REDIS_HOST": {
+                    "Fn::GetAtt": [
+                      "BalancerRedisInternal",
+                      "DNSName"
+                    ]
+                  },
+                  "REDIS_PASSWORD": "pass-the-word",
+                  "REDIS_PATH": "/0",
+                  "REDIS_PORT": "6379",
+                  "REDIS_SCHEME": "redis",
                   "REDIS_URL": {
                     "Fn::Join": [
                       "",
                       [
                         "redis",
                         "://",
-                        "",
+                        "user:pass-the-word@",
                         {
                           "Fn::GetAtt": [
                             "BalancerRedisInternal",
@@ -955,10 +968,11 @@
                         },
                         ":",
                         "6379",
-                        ""
+                        "/0"
                       ]
                     ]
-                  }
+                  },
+                  "REDIS_USERNAME": "user"
                 },
                 "Image": "/web-web:DEADBEEF",
                 "Memory": {

--- a/api/models/fixtures/web_redis.yml
+++ b/api/models/fixtures/web_redis.yml
@@ -8,5 +8,8 @@ redis:
   image: convox/redis
   environment:
     - LINK_SCHEME=redis
+    - LINK_USERNAME=user
+    - LINK_PASSWORD=pass-the-word
+    - LINK_PATH=/0
   ports:
     - 6379

--- a/api/models/release.go
+++ b/api/models/release.go
@@ -407,9 +407,15 @@ func (r *Release) resolveLinks(manifest *Manifest) (Manifest, error) {
 			html := fmt.Sprintf(`{ "Fn::Join": [ "", [ "%s", "://", "%s", %s, ":", "%s", "%s" ] ] }`,
 				scheme, userInfo, host, port, path)
 
-			varName := strings.ToUpper(link) + "_URL"
+			prefix := strings.ToUpper(link) + "_"
 
-			entry.LinkVars[varName] = template.HTML(html)
+			entry.LinkVars[prefix+"HOST"] = template.HTML(host)
+			entry.LinkVars[prefix+"SCHEME"] = template.HTML(scheme)
+			entry.LinkVars[prefix+"PORT"] = template.HTML(port)
+			entry.LinkVars[prefix+"PASSWORD"] = template.HTML(other.Exports["LINK_PASSWORD"])
+			entry.LinkVars[prefix+"USERNAME"] = template.HTML(other.Exports["LINK_USERNAME"])
+			entry.LinkVars[prefix+"PATH"] = template.HTML(path)
+			entry.LinkVars[prefix+"URL"] = template.HTML(html)
 			m[i] = entry
 		}
 	}

--- a/api/models/release.go
+++ b/api/models/release.go
@@ -410,11 +410,11 @@ func (r *Release) resolveLinks(manifest *Manifest) (Manifest, error) {
 			prefix := strings.ToUpper(link) + "_"
 
 			entry.LinkVars[prefix+"HOST"] = template.HTML(host)
-			entry.LinkVars[prefix+"SCHEME"] = template.HTML(scheme)
-			entry.LinkVars[prefix+"PORT"] = template.HTML(port)
-			entry.LinkVars[prefix+"PASSWORD"] = template.HTML(other.Exports["LINK_PASSWORD"])
-			entry.LinkVars[prefix+"USERNAME"] = template.HTML(other.Exports["LINK_USERNAME"])
-			entry.LinkVars[prefix+"PATH"] = template.HTML(path)
+			entry.LinkVars[prefix+"SCHEME"] = template.HTML(fmt.Sprintf("%q", scheme))
+			entry.LinkVars[prefix+"PORT"] = template.HTML(fmt.Sprintf("%q", port))
+			entry.LinkVars[prefix+"PASSWORD"] = template.HTML(fmt.Sprintf("%q", other.Exports["LINK_PASSWORD"]))
+			entry.LinkVars[prefix+"USERNAME"] = template.HTML(fmt.Sprintf("%q", other.Exports["LINK_USERNAME"]))
+			entry.LinkVars[prefix+"PATH"] = template.HTML(fmt.Sprintf("%q", path))
 			entry.LinkVars[prefix+"URL"] = template.HTML(html)
 			m[i] = entry
 		}


### PR DESCRIPTION
adds env vars for links that fit a URL scheme. for a link named `redis` this will expose:

- `REDIS_URL`
- `REDIS_SCHEME`
- `REDIS_HOST`
- `REDIS_PORT`
- `REDIS_PATH`
- `REDIS_USERNAME`
- `REDIS_PASSWORD`

```bash
$ docker exec -it 57025814486e env | grep REDIS
REDIS_HOST=172.17.0.1
REDIS_PASSWORD=password
REDIS_PATH=/0
REDIS_PORT=6379
REDIS_SCHEME=redis
REDIS_URL=redis://:password@172.17.0.1:6379/0
REDIS_USERNAME=
```