### PR TITLE
add support for docker-compose's `dockerfile` config option

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -37,6 +37,7 @@ type Manifest map[string]ManifestEntry
 
 type ManifestEntry struct {
 	Build       string      `yaml:"build,omitempty"`
+	Dockerfile  string      `yaml:"dockerfile,omitempty"`
 	Image       string      `yaml:"image,omitempty"`
 	Command     interface{} `yaml:"command,omitempty"`
 	Entrypoint  string      `yaml:"entrypoint,omitempty"`
@@ -143,7 +144,7 @@ func Read(dir, filename string) (*Manifest, error) {
 	return &m, nil
 }
 
-func buildSync(source, tag string, cache bool) error {
+func buildSync(source, tag string, cache bool, dockerfile string) error {
 	args := []string{"build", "-t", tag}
 
 	// if called with `convox build --no-cache`, assume intent to build from scratch.
@@ -151,6 +152,11 @@ func buildSync(source, tag string, cache bool) error {
 	if !cache {
 		args = append(args, "--pull")
 		args = append(args, "--no-cache")
+	}
+
+	if dockerfile != "" {
+		args = append(args, "-f")
+		args = append(args, dockerfile)
 	}
 
 	args = append(args, source)
@@ -182,6 +188,7 @@ func (m *Manifest) Build(app, dir string, cache bool) []error {
 	builds := map[string]string{}
 	pulls := []string{}
 	tags := map[string]string{}
+	dockerfiles := map[string]string{}
 
 	for name, entry := range *m {
 		tag := fmt.Sprintf("%s/%s", app, name)
@@ -204,6 +211,12 @@ func (m *Manifest) Build(app, dir string, cache bool) []error {
 			}
 
 			tags[tag] = builds[sym]
+
+			// Dockerfile can only be specified if Build is also specified
+			if entry.Dockerfile != "" {
+				dockerfiles[sym] = entry.Dockerfile
+			}
+
 		case entry.Image != "":
 			pulls = append(pulls, entry.Image)
 			tags[tag] = entry.Image
@@ -213,7 +226,7 @@ func (m *Manifest) Build(app, dir string, cache bool) []error {
 	errors := []error{}
 
 	for source, tag := range builds {
-		err := buildSync(source, tag, cache)
+		err := buildSync(source, tag, cache, dockerfiles[source])
 
 		if err != nil {
 			return []error{err}


### PR DESCRIPTION
Continuing from @gmelika https://github.com/convox/rack/pull/295

```
$ cat docker-compose.yml 
web:
  build: .
  dockerfile: Dockerfile-alternate
  ports:
    - 80:80

$ cat Dockerfile-alternate 
FROM httpd

$ convox start
RUNNING: docker build -t qqxbugklpa -f Dockerfile-alternate /Users/noah/dev/httpd
Sending build context to Docker daemon 33.79 kB
Step 1 : FROM httpd
...
```