### PR TITLE
Set EnableDnsSupport and EnableDnsHostnames for rack VPC

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -452,6 +452,8 @@
     "Vpc": {
       "Type": "AWS::EC2::VPC",
       "Properties": {
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true",
         "CidrBlock": { "Ref": "VPCCIDR" },
         "InstanceTenancy": "default",
         "Tags": [


### PR DESCRIPTION
http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html

Allows host instances within the rack to have internal hostnames only resolvable
from within the VPC. The host uses an Amazon provided DNS server configured via
DHCP. Containers mount /etc/resolv.conf from the host giving them the same
resolution. This allows unrelated EC2 instances to join the VPC, such as a mail
server, under a common local name (eg. mail.internal) for service discovery or
to simplify some configuration.