### PR TITLE
add support for MultiAZ parameter in the db CF templates

### DIFF
--- a/api/models/templates/service/mysql.tmpl
+++ b/api/models/templates/service/mysql.tmpl
@@ -17,6 +17,11 @@
         "Default" : "db.t2.micro",
         "Description" : "Instance class for database nodes"
       },
+      "MultiAZ": {
+        "Type" : "String",
+        "Default" : "false",
+        "Description" : "Multiple availability zone"
+      },
       "Password": {
         "Type" : "String",
         "Description" : "Server password"
@@ -71,6 +76,7 @@
           "Engine": "mysql",
           "MasterUsername": { "Ref": "Username" },
           "MasterUserPassword": { "Ref": "Password" },
+          "MultiAZ": { "Ref": "MultiAZ" },
           "Port": "3306",
           "PubliclyAccessible": "false",
           "StorageType": "gp2",

--- a/api/models/templates/service/postgres.tmpl
+++ b/api/models/templates/service/postgres.tmpl
@@ -17,6 +17,11 @@
         "Default" : "db.t2.micro",
         "Description" : "Instance class for database nodes"
       },
+      "MultiAZ": {
+        "Type" : "String",
+        "Default" : "false",
+        "Description" : "Multiple availability zone"
+      },
       "Password": {
         "Type" : "String",
         "Description" : "Server password"
@@ -71,6 +76,7 @@
           "Engine": "postgres",
           "MasterUsername": { "Ref": "Username" },
           "MasterUserPassword": { "Ref": "Password" },
+          "MultiAZ": { "Ref": "MultiAZ" },
           "Port": "5432",
           "PubliclyAccessible": "false",
           "StorageType": "gp2",


### PR DESCRIPTION
not sure what else is required to expose the MultiAZ parameter to `convox service create`
Seems like support for this param is already there in api.go