### PR TITLE
Prefix app and service StackNames with the rack name.

### DIFF
--- a/api/controllers/apps.go
+++ b/api/controllers/apps.go
@@ -47,11 +47,15 @@ func AppShow(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 func AppCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	name := r.FormValue("name")
 
-	app := &models.App{
-		Name: name,
+	// Early check for unbound app only.
+	app, err := models.GetAppFast(name, false, true)
+
+	if awsError(err) == "ValidationError" {
+		// If unbound check fails this will result in a bound app.
+		app = &models.App{Name: name}
 	}
 
-	err := app.Create()
+	err = app.Create()
 
 	if awsError(err) == "AlreadyExistsException" {
 		app, err := models.GetApp(name)

--- a/api/controllers/apps.go
+++ b/api/controllers/apps.go
@@ -48,14 +48,13 @@ func AppCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	name := r.FormValue("name")
 
 	// Early check for unbound app only.
-	app, err := models.GetAppFast(name, false, true)
-
-	if awsError(err) == "ValidationError" {
-		// If unbound check fails this will result in a bound app.
-		app = &models.App{Name: name}
+	if app, err := models.GetAppUnbound(name); err == nil {
+		return httperr.Errorf(403, "there is already a legacy app named %s (%s). We recommend you delete this app and create it again.", name, app.Status)
 	}
 
-	err = app.Create()
+	// If unbound check fails this will result in a bound app.
+	app := &models.App{Name: name}
+	err := app.Create()
 
 	if awsError(err) == "AlreadyExistsException" {
 		app, err := models.GetApp(name)

--- a/api/controllers/processes_test.go
+++ b/api/controllers/processes_test.go
@@ -24,16 +24,15 @@ func TestProcessesList(t *testing.T) {
 	os.Setenv("TEST", "true")
 
 	aws := test.StubAws(
-		test.DescribeStackNotFound("convox-test-myapp-staging"),
-		test.DescribeAppStackCycle("myapp-staging"),
-		test.DescribeAppStackCycle("myapp-staging"),
-		test.DescribeAppStackResourcesCycle("myapp-staging"),
-		test.ListTasksCycle("convox-test-cluster", "myapp-staging-worker-SCELGCIYSKF"),
+		test.DescribeAppStackCycle("convox-test-myapp-staging"),
+		test.DescribeAppStackCycle("convox-test-myapp-staging"),
+		test.DescribeAppStackResourcesCycle("convox-test-myapp-staging"),
+		test.ListTasksCycle("convox-test-cluster", "convox-test-myapp-staging-worker-SCELGCIYSKF"),
 		test.DescribeTasksCycle("convox-test-cluster"),
 		test.DescribeTaskDefinitionCycle("convox-test-cluster"),
 		test.DescribeContainerInstancesFilteredCycle("convox-test-cluster"),
 		test.DescribeInstancesFilteredCycle(),
-		test.DescribeAppStackResourcesCycle("myapp-staging"),
+		test.DescribeAppStackResourcesCycle("convox-test-myapp-staging"),
 		test.DescribeServicesCycle("convox-test-cluster"),
 		test.ListContainerInstancesCycle("convox-test-cluster"),
 		test.DescribeContainerInstancesCycle("convox-test-cluster"),
@@ -71,16 +70,15 @@ func TestGetProcessesWithDeployments(t *testing.T) {
 	os.Setenv("TEST", "true")
 
 	aws := test.StubAws(
-		test.DescribeStackNotFound("convox-test-myapp-staging"),
-		test.DescribeAppStackCycle("myapp-staging"),
-		test.DescribeAppStackCycle("myapp-staging"),
-		test.DescribeAppStackResourcesCycle("myapp-staging"),
-		test.ListTasksCycle("convox-test-cluster", "myapp-staging-worker-SCELGCIYSKF"),
+		test.DescribeAppStackCycle("convox-test-myapp-staging"),
+		test.DescribeAppStackCycle("convox-test-myapp-staging"),
+		test.DescribeAppStackResourcesCycle("convox-test-myapp-staging"),
+		test.ListTasksCycle("convox-test-cluster", "convox-test-myapp-staging-worker-SCELGCIYSKF"),
 		test.DescribeTasksCycle("convox-test-cluster"),
 		test.DescribeTaskDefinitionCycle("convox-test-cluster"),
 		test.DescribeContainerInstancesFilteredCycle("convox-test-cluster"),
 		test.DescribeInstancesFilteredCycle(),
-		test.DescribeAppStackResourcesCycle("myapp-staging"),
+		test.DescribeAppStackResourcesCycle("convox-test-myapp-staging"),
 		test.DescribeServicesWithDeploymentsCycle("convox-test-cluster"),
 		test.DescribeTaskDefinition3Cycle("convox-test-cluster"),
 		test.ListContainerInstancesCycle("convox-test-cluster"),

--- a/api/controllers/processes_test.go
+++ b/api/controllers/processes_test.go
@@ -24,6 +24,7 @@ func TestProcessesList(t *testing.T) {
 	os.Setenv("TEST", "true")
 
 	aws := test.StubAws(
+		test.DescribeStackNotFound("convox-test-myapp-staging"),
 		test.DescribeAppStackCycle("myapp-staging"),
 		test.DescribeAppStackCycle("myapp-staging"),
 		test.DescribeAppStackResourcesCycle("myapp-staging"),
@@ -70,6 +71,7 @@ func TestGetProcessesWithDeployments(t *testing.T) {
 	os.Setenv("TEST", "true")
 
 	aws := test.StubAws(
+		test.DescribeStackNotFound("convox-test-myapp-staging"),
 		test.DescribeAppStackCycle("myapp-staging"),
 		test.DescribeAppStackCycle("myapp-staging"),
 		test.DescribeAppStackResourcesCycle("myapp-staging"),

--- a/api/controllers/services.go
+++ b/api/controllers/services.go
@@ -55,10 +55,16 @@ func ServiceCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	kind := params["type"]
 	delete(params, "type")
 
-	service := &models.Service{
-		Name:       name,
-		Type:       kind,
-		Parameters: models.CFParams(params),
+	// Early check for unbound service only.
+	service, err := models.GetServiceFast(name, false, true)
+
+	if awsError(err) == "ValidationError" {
+		// If unbound check fails this will result in a bound service.
+		service = &models.Service{
+			Name:       name,
+			Type:       kind,
+			Parameters: models.CFParams(params),
+		}
 	}
 
 	err = service.Create()

--- a/api/controllers/services.go
+++ b/api/controllers/services.go
@@ -56,7 +56,11 @@ func ServiceCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	delete(params, "type")
 
 	// Early check for unbound service only.
-	service, err := models.GetServiceFast(name, false, true)
+	service, err := models.GetServiceUnbound(name)
+
+	if err != nil {
+		return httperr.Errorf(403, "there is already a legacy service named %s (%s). We recommend you delete this service and create it again.", name, service.Status)
+	}
 
 	if awsError(err) == "ValidationError" {
 		// If unbound check fails this will result in a bound service.

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -59,45 +59,35 @@ func ListApps() (Apps, error) {
 }
 
 func GetApp(name string) (*App, error) {
-	return GetAppFast(name, true, true)
-}
-
-func GetAppFast(name string, bound bool, unbound bool) (*App, error) {
 	stackName := shortNameToStackName(name)
+	app, err := getAppByStackName(stackName)
 
-	switch {
-	case !bound && !unbound:
-		// User requested no lookups, return empty App.
-		return &App{Name: name}, nil
-	case bound && !unbound:
-		// User requested bound lookup only, reset short name.
-		name = stackName
-	case !bound && unbound:
-		// User requested unbound lookup only, reset long name.
-		stackName = name
-	}
-
-	res, err := DescribeStack(stackName)
-
-	// Setting to the same value results in at most a single lookup.
 	if name != stackName && awsError(err) == "ValidationError" {
 		// Only lookup an unbound app if the name/stackName differ and the
 		// bound lookup fails.
-		res, err = DescribeStack(name)
+		app, err = getAppByStackName(name)
 	}
+
+	if app != nil && app.Tags["Rack"] != "" && app.Tags["Rack"] != os.Getenv("RACK") {
+		return nil, fmt.Errorf("no such app: %s", name)
+	}
+
+	return app, err
+}
+
+func GetAppBound(name string) (*App, error) {
+	return getAppByStackName(shortNameToStackName(name))
+}
+
+func GetAppUnbound(name string) (*App, error) {
+	return getAppByStackName(name)
+}
+
+func getAppByStackName(stackName string) (*App, error) {
+	res, err := DescribeStack(stackName)
 
 	if err != nil {
 		return nil, err
-	}
-
-	if len(res.Stacks) != 1 {
-		return nil, fmt.Errorf("could not load stack for app: %s", name)
-	}
-
-	tags := stackTags(res.Stacks[0])
-
-	if tags["Rack"] != "" && tags["Rack"] != os.Getenv("RACK") {
-		return nil, fmt.Errorf("no such app: %s", name)
 	}
 
 	app := appFromStack(res.Stacks[0])

--- a/api/models/app_test.go
+++ b/api/models/app_test.go
@@ -1,0 +1,48 @@
+package models_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/convox/rack/api/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	os.Setenv("RACK", "convox-test")
+}
+
+func TestRackStackName(t *testing.T) {
+	r := models.App{
+		Name: "convox-test",
+	}
+
+	assert.Equal(t, "convox-test", r.StackName())
+}
+
+func TestAppStackName(t *testing.T) {
+	// unbound app (no rack prefix)
+	a := models.App{
+		Name: "httpd",
+		Tags: map[string]string{
+			"Type":   "app",
+			"System": "convox",
+			"Rack":   "convox-test",
+		},
+	}
+
+	assert.Equal(t, "httpd", a.StackName())
+
+	// bound app (rack prefix, and Name tag)
+	a = models.App{
+		Name: "httpd",
+		Tags: map[string]string{
+			"Name":   "httpd",
+			"Type":   "app",
+			"System": "convox",
+			"Rack":   "convox-test",
+		},
+	}
+
+	assert.Equal(t, "convox-test-httpd", a.StackName())
+}

--- a/api/models/cluster_test.go
+++ b/api/models/cluster_test.go
@@ -115,5 +115,5 @@ func TestGetAppServices(t *testing.T) {
 	assert.Equal(t, 1, len(services))
 
 	s := services[0]
-	assert.Equal(t, "arn:aws:ecs:us-west-2:901416387788:service/httpd-web-SRZPVERKQOL", *s.ServiceArn)
+	assert.Equal(t, "arn:aws:ecs:us-west-2:901416387788:service/convox-test-httpd-web-SRZPVERKQOL", *s.ServiceArn)
 }

--- a/api/models/helpers.go
+++ b/api/models/helpers.go
@@ -326,6 +326,17 @@ func stackTags(stack *cloudformation.Stack) map[string]string {
 	return tags
 }
 
+func shortNameToStackName(appName string) string {
+	rack := os.Getenv("RACK")
+
+	if rack == appName {
+		// Do no prefix the rack itself.
+		return appName
+	}
+
+	return rack + "-" + appName
+}
+
 func templateHelpers() template.FuncMap {
 	return template.FuncMap{
 		"upper": func(s string) string {

--- a/api/models/models.go
+++ b/api/models/models.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/convox/rack/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws"
+	"github.com/convox/rack/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/convox/rack/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/convox/rack/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws/session"
 	"github.com/convox/rack/Godeps/_workspace/src/github.com/aws/aws-sdk-go/service/autoscaling"
@@ -28,6 +29,14 @@ import (
 )
 
 var SortableTime = "20060102.150405.000000000"
+
+func awsError(err error) string {
+	if ae, ok := err.(awserr.Error); ok {
+		return ae.Code()
+	}
+
+	return ""
+}
 
 func awsConfig() *aws.Config {
 	config := &aws.Config{

--- a/api/models/release.go
+++ b/api/models/release.go
@@ -224,7 +224,7 @@ func (r *Release) Promote() error {
 
 	req := &cloudformation.UpdateStackInput{
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
-		StackName:    aws.String(r.App),
+		StackName:    aws.String(app.StackName()),
 		TemplateURL:  aws.String(url),
 		Parameters:   params,
 	}
@@ -432,7 +432,7 @@ var regexpPrimaryProcess = regexp.MustCompile(`\[":",\["TCP",\{"Ref":"([A-Za-z]+
 // try to determine which process to map to the main load balancer
 func primaryProcess(app string) (string, error) {
 	res, err := CloudFormation().GetTemplate(&cloudformation.GetTemplateInput{
-		StackName: aws.String(app),
+		StackName: aws.String(shortNameToStackName(app)),
 	})
 
 	if err != nil {

--- a/api/models/resource.go
+++ b/api/models/resource.go
@@ -21,9 +21,17 @@ type Resource struct {
 type Resources map[string]Resource
 
 func ListResources(app string) (Resources, error) {
+	stackName := shortNameToStackName(app)
+
 	res, err := CloudFormation().DescribeStackResources(&cloudformation.DescribeStackResourcesInput{
-		StackName: aws.String(app),
+		StackName: aws.String(stackName),
 	})
+
+	if app != stackName && awsError(err) == "ValidationError" {
+		res, err = CloudFormation().DescribeStackResources(&cloudformation.DescribeStackResourcesInput{
+			StackName: aws.String(app),
+		})
+	}
 
 	if err != nil {
 		return nil, err

--- a/api/models/service-datastore.go
+++ b/api/models/service-datastore.go
@@ -20,7 +20,7 @@ func (s *Service) CreateDatastore() (*cloudformation.CreateStackInput, error) {
 
 	req := &cloudformation.CreateStackInput{
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
-		StackName:    aws.String(s.Name),
+		StackName:    aws.String(s.StackName()),
 		TemplateBody: aws.String(formation),
 	}
 

--- a/api/models/service-papertrail.go
+++ b/api/models/service-papertrail.go
@@ -24,7 +24,7 @@ func (s *Service) CreatePapertrail() (*cloudformation.CreateStackInput, error) {
 
 	req := &cloudformation.CreateStackInput{
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
-		StackName:    aws.String(s.Name),
+		StackName:    aws.String(s.StackName()),
 		TemplateBody: aws.String(formation),
 	}
 
@@ -89,7 +89,7 @@ func (s *Service) UpdatePapertrail(arns map[string]string) error {
 
 	// Update stack with all linked ARNs and EventSourceMappings
 	_, err = UpdateStack(&cloudformation.UpdateStackInput{
-		StackName:    aws.String(s.Name),
+		StackName:    aws.String(s.StackName()),
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
 		Parameters: []*cloudformation.Parameter{
 			&cloudformation.Parameter{

--- a/api/models/service-webhook.go
+++ b/api/models/service-webhook.go
@@ -39,7 +39,7 @@ func (s *Service) CreateWebhook() (*cloudformation.CreateStackInput, error) {
 	req := &cloudformation.CreateStackInput{
 		//TODO: do i need this?
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
-		StackName:    aws.String(s.Name),
+		StackName:    aws.String(s.StackName()),
 		TemplateBody: aws.String(formation),
 	}
 

--- a/api/models/ssl.go
+++ b/api/models/ssl.go
@@ -87,7 +87,7 @@ func CreateSSL(app, process string, port int, body, key string, chain string, se
 	}
 
 	req := &cloudformation.UpdateStackInput{
-		StackName:    aws.String(a.Name),
+		StackName:    aws.String(a.StackName()),
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
 		TemplateBody: aws.String(tmpl),
 	}
@@ -164,7 +164,7 @@ func DeleteSSL(app, process string, port int) (*SSL, error) {
 
 			if a.Status == "running" {
 				params := &iam.DeleteServerCertificateInput{
-					ServerCertificateName: aws.String(certName(a.Name, process, port)),
+					ServerCertificateName: aws.String(certName(a.StackName(), process, port)),
 				}
 
 				resp, err := IAM().DeleteServerCertificate(params)
@@ -209,7 +209,7 @@ func ListSSLs(a string) (SSLs, error) {
 			}
 
 			resp, err := IAM().GetServerCertificate(&iam.GetServerCertificateInput{
-				ServerCertificateName: aws.String(certName(a, matches[1], port)),
+				ServerCertificateName: aws.String(certName(app.StackName(), matches[1], port)),
 			})
 
 			if err != nil {
@@ -302,7 +302,7 @@ func UpdateSSL(app, process string, port int, body, key string, chain string) (*
 
 	// update cloudformation
 	req := &cloudformation.UpdateStackInput{
-		StackName:           aws.String(a.Name),
+		StackName:           aws.String(a.StackName()),
 		Capabilities:        []*string{aws.String("CAPABILITY_IAM")},
 		UsePreviousTemplate: aws.Bool(true),
 	}
@@ -482,7 +482,7 @@ func uploadCert(a *App, process string, port int, body, key string, chain string
 
 	timestamp := currentTime.Format("20060102150405")
 
-	name := fmt.Sprintf("%s%s%d-%s", UpperName(a.Name), UpperName(process), port, timestamp)
+	name := fmt.Sprintf("%s%s%d-%s", UpperName(a.StackName()), UpperName(process), port, timestamp)
 
 	input := &iam.UploadServerCertificateInput{
 		CertificateBody:       aws.String(body),

--- a/ci/tests/example-app
+++ b/ci/tests/example-app
@@ -73,7 +73,7 @@ wait_for_app_deployment
 convox apps info --app $APP_NAME
 
 #note: would like to do something like: `convox apps endpoint web --port 80`
-url=http://$(convox apps info --app $APP_NAME | egrep -o "${EXAMPLE_NAME}.*.amazonaws.com:80")
+url=http://$(convox apps info --app $APP_NAME | egrep -o "[^ ]*${EXAMPLE_NAME}.*.amazonaws.com:80")
 
 wait_for_app_response $url
 

--- a/test/aws_cycles.go
+++ b/test/aws_cycles.go
@@ -189,7 +189,7 @@ func DescribeTasksCycle(clusterName string) awsutil.Cycle {
 		},
 		Response: awsutil.Response{
 			StatusCode: 200,
-			Body:       `{"tasks":[{"containerInstanceArn":"arn:aws:ecs:us-east-1:901416387788:container-instance/0ac4bb1c-be98-4202-a9c1-03153e91c05e","containers":[{"containerArn":"arn:aws:ecs:us-east-1:901416387788:container/821cc6e1-b120-422c-9092-4932cce0897b","name":"worker"}], "taskArn":"arn:aws:ecs:us-east-1:901416387788:task/320a8b6a-c243-47d3-a1d1-6db5dfcb3f58","taskDefinitionArn":"arn:aws:ecs:us-east-1:901416387788:task-definition/myapp-staging-worker:3","lastStatus":"RUNNING"}]}`,
+			Body:       `{"tasks":[{"containerInstanceArn":"arn:aws:ecs:us-east-1:901416387788:container-instance/0ac4bb1c-be98-4202-a9c1-03153e91c05e","containers":[{"containerArn":"arn:aws:ecs:us-east-1:901416387788:container/821cc6e1-b120-422c-9092-4932cce0897b","name":"worker"}], "taskArn":"arn:aws:ecs:us-east-1:901416387788:task/320a8b6a-c243-47d3-a1d1-6db5dfcb3f58","taskDefinitionArn":"arn:aws:ecs:us-east-1:901416387788:task-definition/convox-test-myapp-staging-worker:3","lastStatus":"RUNNING"}]}`,
 		},
 	}
 }
@@ -199,11 +199,11 @@ func DescribeTaskDefinitionCycle(clusterName string) awsutil.Cycle {
 		Request: awsutil.Request{
 			RequestURI: "/",
 			Operation:  "AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition",
-			Body:       `{"taskDefinition":"arn:aws:ecs:us-east-1:901416387788:task-definition/myapp-staging-worker:3"}`,
+			Body:       `{"taskDefinition":"arn:aws:ecs:us-east-1:901416387788:task-definition/convox-test-myapp-staging-worker:3"}`,
 		},
 		Response: awsutil.Response{
 			StatusCode: 200,
-			Body:       `{"taskDefinition":{"volumes":[{"host":{"sourcePath":"/var/run/docker.sock"},"name":"myapp-staging-0-0"}],"containerDefinitions":[{"name":"worker","cpu":200,"memory":256,"image":"test-image","environment":[{"name":"PROCESS","value":"worker"}],"mountPoints":[{"sourceVolume":"worker-0-0","readOnly":false,"containerPath":"/var/run/docker.sock"}]}],"family":"myapp-staging-worker"}}`,
+			Body:       `{"taskDefinition":{"volumes":[{"host":{"sourcePath":"/var/run/docker.sock"},"name":"convox-test-myapp-staging-0-0"}],"containerDefinitions":[{"name":"worker","cpu":200,"memory":256,"image":"test-image","environment":[{"name":"PROCESS","value":"worker"}],"mountPoints":[{"sourceVolume":"worker-0-0","readOnly":false,"containerPath":"/var/run/docker.sock"}]}],"family":"convox-test-myapp-staging-worker"}}`,
 		},
 	}
 }
@@ -217,7 +217,7 @@ func ListServicesCycle(clusterName string) awsutil.Cycle {
 		},
 		Response: awsutil.Response{
 			StatusCode: 200,
-			Body:       `{"serviceArns":["arn:aws:ecs:us-west-2:901416387788:service/myapp-staging-worker-SCELGCIYSKF"]}`,
+			Body:       `{"serviceArns":["arn:aws:ecs:us-west-2:901416387788:service/convox-test-myapp-staging-worker-SCELGCIYSKF"]}`,
 		},
 	}
 }
@@ -227,7 +227,7 @@ func DescribeServicesCycle(clusterName string) awsutil.Cycle {
 		Request: awsutil.Request{
 			RequestURI: "/",
 			Operation:  "AmazonEC2ContainerServiceV20141113.DescribeServices",
-			Body:       `{"cluster":"` + clusterName + `", "services":["arn:aws:ecs:us-west-2:901416387788:service/myapp-staging-worker-SCELGCIYSKF"]}`,
+			Body:       `{"cluster":"` + clusterName + `", "services":["arn:aws:ecs:us-west-2:901416387788:service/convox-test-myapp-staging-worker-SCELGCIYSKF"]}`,
 		},
 		Response: awsutil.Response{
 			StatusCode: 200,
@@ -241,7 +241,7 @@ func DescribeServicesWithDeploymentsCycle(clusterName string) awsutil.Cycle {
 		Request: awsutil.Request{
 			RequestURI: "/",
 			Operation:  "AmazonEC2ContainerServiceV20141113.DescribeServices",
-			Body:       `{"cluster":"` + clusterName + `", "services":["arn:aws:ecs:us-west-2:901416387788:service/myapp-staging-worker-SCELGCIYSKF"]}`,
+			Body:       `{"cluster":"` + clusterName + `", "services":["arn:aws:ecs:us-west-2:901416387788:service/convox-test-myapp-staging-worker-SCELGCIYSKF"]}`,
 		},
 		Response: awsutil.Response{
 			StatusCode: 200,
@@ -255,11 +255,11 @@ func DescribeTaskDefinition3Cycle(clusterName string) awsutil.Cycle {
 		Request: awsutil.Request{
 			RequestURI: "/",
 			Operation:  "AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition",
-			Body:       `{"taskDefinition":"arn:aws:ecs:us-east-1:901416387788:task-definition/myapp-staging-worker:3"}`,
+			Body:       `{"taskDefinition":"arn:aws:ecs:us-east-1:901416387788:task-definition/convox-test-myapp-staging-worker:3"}`,
 		},
 		Response: awsutil.Response{
 			StatusCode: 200,
-			Body:       `{"taskDefinition":{"volumes":[{"host":{"sourcePath":"/var/run/docker.sock"},"name":"myapp-staging-0-0"}],"containerDefinitions":[{"name":"worker","cpu":200,"memory":256,"image":"test-image","environment":[{"name":"PROCESS","value":"worker"}],"mountPoints":[{"sourceVolume":"worker-0-0","readOnly":false,"containerPath":"/var/run/docker.sock"}]}],"family":"myapp-staging-worker"}}`,
+			Body:       `{"taskDefinition":{"volumes":[{"host":{"sourcePath":"/var/run/docker.sock"},"name":"convox-test-myapp-staging-0-0"}],"containerDefinitions":[{"name":"worker","cpu":200,"memory":256,"image":"test-image","environment":[{"name":"PROCESS","value":"worker"}],"mountPoints":[{"sourceVolume":"worker-0-0","readOnly":false,"containerPath":"/var/run/docker.sock"}]}],"family":"convox-test-myapp-staging-worker"}}`,
 		},
 	}
 }
@@ -269,11 +269,11 @@ func DescribeTaskDefinition1Cycle(clusterName string) awsutil.Cycle {
 		Request: awsutil.Request{
 			RequestURI: "/",
 			Operation:  "AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition",
-			Body:       `{"taskDefinition":"arn:aws:ecs:us-east-1:901416387788:task-definition/myapp-staging-worker:1"}`,
+			Body:       `{"taskDefinition":"arn:aws:ecs:us-east-1:901416387788:task-definition/convox-test-myapp-staging-worker:1"}`,
 		},
 		Response: awsutil.Response{
 			StatusCode: 200,
-			Body:       `{"taskDefinition":{"volumes":[{"host":{"sourcePath":"/var/run/docker.sock"},"name":"myapp-staging-0-0"}],"containerDefinitions":[{"name":"worker","cpu":200,"memory":256,"image":"test-image","environment":[{"name":"PROCESS","value":"worker"}],"mountPoints":[{"sourceVolume":"worker-0-0","readOnly":false,"containerPath":"/var/run/docker.sock"}]}],"family":"myapp-staging-worker"}}`,
+			Body:       `{"taskDefinition":{"volumes":[{"host":{"sourcePath":"/var/run/docker.sock"},"name":"convox-test-myapp-staging-0-0"}],"containerDefinitions":[{"name":"worker","cpu":200,"memory":256,"image":"test-image","environment":[{"name":"PROCESS","value":"worker"}],"mountPoints":[{"sourceVolume":"worker-0-0","readOnly":false,"containerPath":"/var/run/docker.sock"}]}],"family":"convox-test-myapp-staging-worker"}}`,
 		},
 	}
 }
@@ -381,7 +381,7 @@ func appStackXML(appName string, status string) string {
 	rack := os.Getenv("RACK")
 	shortName := appName
 
-	if strings.HasPrefix(appName, rack + "-") {
+	if strings.HasPrefix(appName, rack+"-") {
 		shortName = appName[len(rack)+1:]
 	}
 
@@ -1171,27 +1171,27 @@ func describeServicesResponse(clusterName string) string {
     "services": [
         {
             "status": "ACTIVE",
-            "taskDefinition": "arn:aws:ecs:us-west-2:901416387788:task-definition/myapp-staging-worker:1",
+            "taskDefinition": "arn:aws:ecs:us-west-2:901416387788:task-definition/convox-test-myapp-staging-worker:1",
             "pendingCount": 0,
             "loadBalancers": [
                 {
                     "containerName": "worker",
                     "containerPort": 80,
-                    "loadBalancerName": "myapp-staging"
+                    "loadBalancerName": "convox-test-myapp-staging"
                 }
             ],
-            "roleArn": "arn:aws:iam::901416387788:role/myapp-staging-ServiceRole-1HNRHXNKGNLT9",
+            "roleArn": "arn:aws:iam::901416387788:role/convox-test-myapp-staging-ServiceRole-1HNRHXNKGNLT9",
             "desiredCount": 1,
-            "serviceName": "myapp-staging-worker-SCELGCIYSKF",
+            "serviceName": "convox-test-myapp-staging-worker-SCELGCIYSKF",
             "clusterArn": "` + clusterName + `",
-            "serviceArn": "arn:aws:ecs:us-west-2:901416387788:service/myapp-staging-worker-SCELGCIYSKF",
+            "serviceArn": "arn:aws:ecs:us-west-2:901416387788:service/convox-test-myapp-staging-worker-SCELGCIYSKF",
             "deployments": [
                 {
                     "status": "ACTIVE",
                     "pendingCount": 0,
                     "createdAt": 1449511658.683,
                     "desiredCount": 1,
-                    "taskDefinition": "arn:aws:ecs:us-east-1:901416387788:task-definition/myapp-staging-worker:1",
+                    "taskDefinition": "arn:aws:ecs:us-east-1:901416387788:task-definition/convox-test-myapp-staging-worker:1",
                     "updatedAt": 1449511869.412,
                     "id": "ecs-svc/9223370587343117124",
                     "runningCount": 1
@@ -1199,7 +1199,7 @@ func describeServicesResponse(clusterName string) string {
             ],
             "events": [
                 {
-                    "message": "(service myapp-staging-worker-SCELGCIYSKF) has started 1 tasks: (task f120ddee-5aa5-434e-b765-30503080078b).",
+                    "message": "(service convox-test-myapp-staging-worker-SCELGCIYSKF) has started 1 tasks: (task f120ddee-5aa5-434e-b765-30503080078b).",
                     "id": "d84b8245-9653-453f-a449-27d7c7cfdc0a",
                     "createdAt": 1449003339.092
                 }
@@ -1217,27 +1217,27 @@ func describeServicesWithDeploymentsResponse(clusterName string) string {
     "services": [
         {
             "status": "ACTIVE",
-            "taskDefinition": "arn:aws:ecs:us-west-2:901416387788:task-definition/myapp-staging-worker:3",
+            "taskDefinition": "arn:aws:ecs:us-west-2:901416387788:task-definition/convox-test-myapp-staging-worker:3",
             "pendingCount": 0,
             "loadBalancers": [
                 {
                     "containerName": "worker",
                     "containerPort": 80,
-                    "loadBalancerName": "myapp-staging"
+                    "loadBalancerName": "convox-test-myapp-staging"
                 }
             ],
-            "roleArn": "arn:aws:iam::901416387788:role/myapp-staging-ServiceRole-1HNRHXNKGNLT9",
+            "roleArn": "arn:aws:iam::901416387788:role/convox-test-myapp-staging-ServiceRole-1HNRHXNKGNLT9",
             "desiredCount": 1,
-            "serviceName": "myapp-staging-worker-SCELGCIYSKF",
+            "serviceName": "convox-test-myapp-staging-worker-SCELGCIYSKF",
             "clusterArn": "` + clusterName + `",
-            "serviceArn": "arn:aws:ecs:us-west-2:901416387788:service/myapp-staging-worker-SCELGCIYSKF",
+            "serviceArn": "arn:aws:ecs:us-west-2:901416387788:service/convox-test-myapp-staging-worker-SCELGCIYSKF",
             "deployments": [
                 {
                     "status": "PRIMARY",
                     "pendingCount": 0,
                     "createdAt": 1449559137.768,
                     "desiredCount": 1,
-                    "taskDefinition": "arn:aws:ecs:us-east-1:901416387788:task-definition/myapp-staging-worker:3",
+                    "taskDefinition": "arn:aws:ecs:us-east-1:901416387788:task-definition/convox-test-myapp-staging-worker:3",
                     "updatedAt": 1449559137.768,
                     "id": "ecs-svc/9223370587295638039",
                     "runningCount": 0
@@ -1247,7 +1247,7 @@ func describeServicesWithDeploymentsResponse(clusterName string) string {
                     "pendingCount": 0,
                     "createdAt": 1449511658.683,
                     "desiredCount": 1,
-                    "taskDefinition": "arn:aws:ecs:us-east-1:901416387788:task-definition/myapp-staging-worker:1",
+                    "taskDefinition": "arn:aws:ecs:us-east-1:901416387788:task-definition/convox-test-myapp-staging-worker:1",
                     "updatedAt": 1449511869.412,
                     "id": "ecs-svc/9223370587343117124",
                     "runningCount": 1
@@ -1255,12 +1255,12 @@ func describeServicesWithDeploymentsResponse(clusterName string) string {
             ],
             "events": [
                 {
-                    "message": "(service myapp-staging-worker-SCELGCIYSKF) was unable to place a task because no container instance met all of its requirements. The closest matching (container-instance b1a73168-f8a6-4ed9-b69e-94adc7a0f1e0) has insufficient memory available. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide.",
+                    "message": "(service convox-test-myapp-staging-worker-SCELGCIYSKF) was unable to place a task because no container instance met all of its requirements. The closest matching (container-instance b1a73168-f8a6-4ed9-b69e-94adc7a0f1e0) has insufficient memory available. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide.",
                     "id": "3890020b-7e55-4d25-9694-ba823cc34822",
                     "createdAt": 1449760390.037
                 },
                 {
-                    "message": "(service myapp-staging-worker-SCELGCIYSKF) has started 1 tasks: (task f120ddee-5aa5-434e-b765-30503080078b).",
+                    "message": "(service convox-test-myapp-staging-worker-SCELGCIYSKF) has started 1 tasks: (task f120ddee-5aa5-434e-b765-30503080078b).",
                     "id": "d84b8245-9653-453f-a449-27d7c7cfdc0a",
                     "createdAt": 1449003339.092
                 }

--- a/test/aws_cycles.go
+++ b/test/aws_cycles.go
@@ -3,6 +3,7 @@ package test
 import (
 	"net/http/httptest"
 	"os"
+	"strings"
 
 	"github.com/convox/rack/api/awsutil"
 )
@@ -377,6 +378,13 @@ func convoxStackXML(stackName string) string {
 }
 
 func appStackXML(appName string, status string) string {
+	rack := os.Getenv("RACK")
+	shortName := appName
+
+	if strings.HasPrefix(appName, rack + "-") {
+		shortName = appName[len(rack)+1:]
+	}
+
 	return `
       <member>
 				<Tags>
@@ -387,6 +395,14 @@ func appStackXML(appName string, status string) string {
           <member>
             <Value>convox</Value>
             <Key>System</Key>
+          </member>
+          <member>
+            <Value>convox-test</Value>
+            <Key>Rack</Key>
+          </member>
+          <member>
+            <Value>` + shortName + `</Value>
+            <Key>Name</Key>
           </member>
         </Tags>
         <StackId>arn:aws:cloudformation:us-east-1:938166070011:stack/` + appName + `/9a10bbe0-51d5-11e5-b85a-5001dc3ed8d2</StackId>

--- a/test/aws_httpd_cycles.go
+++ b/test/aws_httpd_cycles.go
@@ -2,21 +2,21 @@ package test
 
 import "github.com/convox/rack/api/awsutil"
 
-// $ aws cloudformation describe-stack-resources --stack-name httpd --debug
+// $ aws cloudformation describe-stack-resources --stack-name convox-test-httpd --debug
 func HttpdDescribeStackResourcesCycle() awsutil.Cycle {
 	return awsutil.Cycle{
-		awsutil.Request{"/", "", `Action=DescribeStackResources&StackName=httpd&Version=2010-05-15`},
+		awsutil.Request{"/", "", `Action=DescribeStackResources&StackName=convox-test-httpd&Version=2010-05-15`},
 		awsutil.Response{200, httpdDescribeStackResourcesResponse()},
 	}
 }
 
-// $ aws ecs describe-services --cluster convox-Cluster-1NCWX9EC0JOV4 --services httpd-web-SRZPVERKQOL
+// $ aws ecs describe-services --cluster convox-Cluster-1NCWX9EC0JOV4 --services convox-test-httpd-web-SRZPVERKQOL
 func HttpdDescribeServicesCycle() awsutil.Cycle {
 	return awsutil.Cycle{
 		Request: awsutil.Request{
 			RequestURI: "/",
 			Operation:  "AmazonEC2ContainerServiceV20141113.DescribeServices",
-			Body:       `{"cluster":"convox-test", "services":["arn:aws:ecs:us-west-2:901416387788:service/httpd-web-SRZPVERKQOL"]}`,
+			Body:       `{"cluster":"convox-test", "services":["arn:aws:ecs:us-west-2:901416387788:service/convox-test-httpd-web-SRZPVERKQOL"]}`,
 		},
 		Response: awsutil.Response{
 			StatusCode: 200,
@@ -35,7 +35,7 @@ func HttpdListServicesCycle() awsutil.Cycle {
 		},
 		Response: awsutil.Response{
 			StatusCode: 200,
-			Body:       `{"serviceArns": ["arn:aws:ecs:us-west-2:901416387788:service/httpd-web-SRZPVERKQOL"]}`,
+			Body:       `{"serviceArns": ["arn:aws:ecs:us-west-2:901416387788:service/convox-test-httpd-web-SRZPVERKQOL"]}`,
 		},
 	}
 }
@@ -45,7 +45,7 @@ func HttpdDescribeServicesResponse() string {
     "services": [
         {
             "status": "ACTIVE", 
-            "taskDefinition": "arn:aws:ecs:us-west-2:901416387788:task-definition/httpd-web:1", 
+            "taskDefinition": "arn:aws:ecs:us-west-2:901416387788:task-definition/convox-test-httpd-web:1", 
             "pendingCount": 0, 
             "loadBalancers": [
                 {
@@ -54,18 +54,18 @@ func HttpdDescribeServicesResponse() string {
                     "loadBalancerName": "httpd"
                 }
             ], 
-            "roleArn": "arn:aws:iam::901416387788:role/httpd-ServiceRole-1K9DGK9MPLXZO", 
+            "roleArn": "arn:aws:iam::901416387788:role/convox-test-httpd-ServiceRole-1K9DGK9MPLXZO", 
             "desiredCount": 1, 
             "serviceName": "httpd-web-SRZPVERKQOL", 
             "clusterArn": "arn:aws:ecs:us-west-2:901416387788:cluster/convox-Cluster-1NCWX9EC0JOV4", 
-            "serviceArn": "arn:aws:ecs:us-west-2:901416387788:service/httpd-web-SRZPVERKQOL", 
+            "serviceArn": "arn:aws:ecs:us-west-2:901416387788:service/convox-test-httpd-web-SRZPVERKQOL", 
             "deployments": [
                 {
                     "status": "PRIMARY", 
                     "pendingCount": 0, 
                     "createdAt": 1450120203.716, 
                     "desiredCount": 1, 
-                    "taskDefinition": "arn:aws:ecs:us-west-2:901416387788:task-definition/httpd-web:1", 
+                    "taskDefinition": "arn:aws:ecs:us-west-2:901416387788:task-definition/convox-test-httpd-web:1", 
                     "updatedAt": 1450120203.716, 
                     "id": "ecs-svc/9223370586734572091", 
                     "runningCount": 1
@@ -73,22 +73,22 @@ func HttpdDescribeServicesResponse() string {
             ], 
             "events": [
                 {
-                    "message": "(service httpd-web-SRZPVERKQOL) has reached a steady state.", 
+                    "message": "(service convox-test-httpd-web-SRZPVERKQOL) has reached a steady state.", 
                     "id": "7a8cd970-01ff-4d34-aa34-fa0deff70e48", 
                     "createdAt": 1450120334.038
                 }, 
                 {
-                    "message": "(service httpd-web-SRZPVERKQOL) registered 1 instances in (elb httpd)", 
+                    "message": "(service convox-test-httpd-web-SRZPVERKQOL) registered 1 instances in (elb httpd)", 
                     "id": "6f89b306-87b3-41a4-8f92-68491f4941a7", 
                     "createdAt": 1450120220.028
                 }, 
                 {
-                    "message": "(service httpd-web-SRZPVERKQOL) deregistered 1 instances in (elb httpd)", 
+                    "message": "(service convox-test-httpd-web-SRZPVERKQOL) deregistered 1 instances in (elb httpd)", 
                     "id": "16099f01-abaa-4389-b7e6-e7c4b1b78c30", 
                     "createdAt": 1450120209.495
                 }, 
                 {
-                    "message": "(service httpd-web-SRZPVERKQOL) has started 1 tasks: (task 04394454-6c7e-4879-a826-d576a47c7fdc).", 
+                    "message": "(service convox-test-httpd-web-SRZPVERKQOL) has started 1 tasks: (task 04394454-6c7e-4879-a826-d576a47c7fdc).", 
                     "id": "2636ed0e-05c0-4945-93da-cf44f964cb3d", 
                     "createdAt": 1450120209.495
                 }
@@ -106,100 +106,100 @@ func httpdDescribeStackResourcesResponse() string {
       <member>
         <Timestamp>2015-12-14T19:10:00.038Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>Balancer</LogicalResourceId>
-        <StackName>httpd</StackName>
-        <PhysicalResourceId>httpd</PhysicalResourceId>
+        <StackName>convox-test-httpd</StackName>
+        <PhysicalResourceId>convox-test-httpd</PhysicalResourceId>
         <ResourceType>AWS::ElasticLoadBalancing::LoadBalancer</ResourceType>
       </member>
       <member>
         <Timestamp>2015-12-14T19:09:55.792Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>BalancerSecurityGroup</LogicalResourceId>
-        <StackName>httpd</StackName>
+        <StackName>convox-test-httpd</StackName>
         <PhysicalResourceId>sg-d5fdc1b1</PhysicalResourceId>
         <ResourceType>AWS::EC2::SecurityGroup</ResourceType>
       </member>
       <member>
         <Timestamp>2015-12-14T19:04:00.683Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>CustomTopic</LogicalResourceId>
-        <StackName>httpd</StackName>
-        <PhysicalResourceId>httpd-CustomTopic-1XKD0E3PM22G6</PhysicalResourceId>
+        <StackName>convox-test-httpd</StackName>
+        <PhysicalResourceId>convox-test-httpd-CustomTopic-1XKD0E3PM22G6</PhysicalResourceId>
         <ResourceType>AWS::Lambda::Function</ResourceType>
       </member>
       <member>
         <Timestamp>2015-12-14T19:03:56.985Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>CustomTopicRole</LogicalResourceId>
-        <StackName>httpd</StackName>
-        <PhysicalResourceId>httpd-CustomTopicRole-EOP193O880F7</PhysicalResourceId>
+        <StackName>convox-test-httpd</StackName>
+        <PhysicalResourceId>convox-test-httpd-CustomTopicRole-EOP193O880F7</PhysicalResourceId>
         <ResourceType>AWS::IAM::Role</ResourceType>
       </member>
       <member>
         <Timestamp>2015-12-14T19:04:07.586Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>Kinesis</LogicalResourceId>
-        <StackName>httpd</StackName>
-        <PhysicalResourceId>httpd-Kinesis-1MM7WF087XN4A</PhysicalResourceId>
+        <StackName>convox-test-httpd</StackName>
+        <PhysicalResourceId>convox-test-httpd-Kinesis-1MM7WF087XN4A</PhysicalResourceId>
         <ResourceType>AWS::Kinesis::Stream</ResourceType>
       </member>
       <member>
         <Timestamp>2015-12-14T19:09:43.075Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>LogsAccess</LogicalResourceId>
-        <StackName>httpd</StackName>
+        <StackName>convox-test-httpd</StackName>
         <PhysicalResourceId>AKIAJKMHFYRRAA6FNNNQ</PhysicalResourceId>
         <ResourceType>AWS::IAM::AccessKey</ResourceType>
       </member>
       <member>
         <Timestamp>2015-12-14T19:09:40.392Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>LogsUser</LogicalResourceId>
-        <StackName>httpd</StackName>
-        <PhysicalResourceId>httpd-LogsUser-LMMTUSLEH0J3</PhysicalResourceId>
+        <StackName>convox-test-httpd</StackName>
+        <PhysicalResourceId>convox-test-httpd-LogsUser-LMMTUSLEH0J3</PhysicalResourceId>
         <ResourceType>AWS::IAM::User</ResourceType>
       </member>
       <member>
         <Timestamp>2015-12-14T19:03:57.144Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>ServiceRole</LogicalResourceId>
-        <StackName>httpd</StackName>
-        <PhysicalResourceId>httpd-ServiceRole-1K9DGK9MPLXZO</PhysicalResourceId>
+        <StackName>convox-test-httpd</StackName>
+        <PhysicalResourceId>convox-test-httpd-ServiceRole-1K9DGK9MPLXZO</PhysicalResourceId>
         <ResourceType>AWS::IAM::Role</ResourceType>
       </member>
       <member>
         <Timestamp>2015-12-14T19:04:17.594Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>Settings</LogicalResourceId>
-        <StackName>httpd</StackName>
-        <PhysicalResourceId>httpd-settings-gclooujvfwww</PhysicalResourceId>
+        <StackName>convox-test-httpd</StackName>
+        <PhysicalResourceId>convox-test-httpd-settings-gclooujvfwww</PhysicalResourceId>
         <ResourceType>AWS::S3::Bucket</ResourceType>
       </member>
       <member>
         <Timestamp>2015-12-14T19:10:05.312Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>WebECSService</LogicalResourceId>
-        <StackName>httpd</StackName>
-        <PhysicalResourceId>arn:aws:ecs:us-west-2:901416387788:service/httpd-web-SRZPVERKQOL</PhysicalResourceId>
+        <StackName>convox-test-httpd</StackName>
+        <PhysicalResourceId>arn:aws:ecs:us-west-2:901416387788:service/convox-test-httpd-web-SRZPVERKQOL</PhysicalResourceId>
         <ResourceType>Custom::ECSService</ResourceType>
       </member>
       <member>
         <Timestamp>2015-12-14T19:09:44.343Z</Timestamp>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
-        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
+        <StackId>arn:aws:cloudformation:us-west-2:901416387788:stack/convox-test-httpd/58c3c540-a295-11e5-bb58-50d50031c6e0</StackId>
         <LogicalResourceId>WebECSTaskDefinition</LogicalResourceId>
-        <StackName>httpd</StackName>
-        <PhysicalResourceId>arn:aws:ecs:us-west-2:901416387788:task-definition/httpd-web:1</PhysicalResourceId>
+        <StackName>convox-test-httpd</StackName>
+        <PhysicalResourceId>arn:aws:ecs:us-west-2:901416387788:task-definition/convox-test-httpd-web:1</PhysicalResourceId>
         <ResourceType>Custom::ECSTaskDefinition</ResourceType>
       </member>
     </StackResources>


### PR DESCRIPTION
Calls to `GetApp` and `GetService` attempt to resolve `name` then `rack-name`.
This preserves backwards compatibility with apps and services created before
this patch. A side-effect of this behavior is rack names will continue
conflicting with app names until we can be certain no "prefix-less" apps exist.

Patch introduces a new model helper, `shortNameToStackName`, and two new
methods, `App.StackName` and `Service.StackName`.