### PR TITLE
Save Rack versions in the Releases table

### DIFF
--- a/api/controllers/routes.go
+++ b/api/controllers/routes.go
@@ -55,6 +55,7 @@ func NewRouter() (router *mux.Router) {
 	router.HandleFunc("/sns", SNSConfirm).Methods("POST").Headers("X-Amz-Sns-Message-Type", "SubscriptionConfirmation")
 	router.HandleFunc("/system", api("system.show", SystemShow)).Methods("GET")
 	router.HandleFunc("/system", api("system.update", SystemUpdate)).Methods("PUT")
+	router.HandleFunc("/system/releases", api("system.release.list", SystemReleaseList)).Methods("GET")
 	router.HandleFunc("/switch", api("switch", Switch)).Methods("POST")
 
 	// websockets

--- a/api/controllers/system.go
+++ b/api/controllers/system.go
@@ -9,7 +9,24 @@ import (
 	"github.com/convox/rack/api/models"
 )
 
-func init() {
+func SystemReleaseList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
+	rack, err := models.GetSystem()
+
+	if awsError(err) == "ValidationError" {
+		return httperr.Errorf(404, "no such stack: %s", rack)
+	}
+
+	if err != nil {
+		return httperr.Server(err)
+	}
+
+	releases, err := models.ListReleases(rack.Name)
+
+	if err != nil {
+		return httperr.Server(err)
+	}
+
+	return RenderJson(rw, releases)
 }
 
 func SystemShow(rw http.ResponseWriter, r *http.Request) *httperr.Error {

--- a/client/system.go
+++ b/client/system.go
@@ -49,6 +49,18 @@ func (c *Client) GetSystem() (*System, error) {
 	return &system, nil
 }
 
+func (c *Client) GetSystemReleases() (Releases, error) {
+	var releases Releases
+
+	err := c.Get("/system/releases", &releases)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return releases, nil
+}
+
 func (c *Client) restoreVersionCheck(check bool) {
 	c.skipVersionCheck = check
 }

--- a/cmd/convox/rack.go
+++ b/cmd/convox/rack.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"sort"
 	"strings"
 
 	"github.com/convox/rack/Godeps/_workspace/src/github.com/codegangsta/cli"
@@ -105,6 +104,9 @@ func cmdRackUpdate(c *cli.Context) {
 	fmt.Printf("Version  %s\n", system.Version)
 	fmt.Printf("Count    %d\n", system.Count)
 	fmt.Printf("Type     %s\n", system.Type)
+
+	fmt.Println()
+	fmt.Printf("Updating to version: %s\n", version.Version)
 }
 
 func cmdRackScale(c *cli.Context) {
@@ -134,31 +136,50 @@ func cmdRackScale(c *cli.Context) {
 }
 
 func cmdRackReleases(c *cli.Context) {
-	vs, err := version.All()
+	system, err := rackClient(c).GetSystem()
+
+	if err != nil {
+		stdcli.Error(err)
+		return
+	}
+
+	pendingVersion := system.Version
+
+	releases, err := rackClient(c).GetSystemReleases()
+
+	if err != nil {
+		stdcli.Error(err)
+		return
+	}
+
+	t := stdcli.NewTable("VERSION", "UPDATED", "STATUS")
+
+	for i, r := range releases {
+		status := ""
+
+		if system.Status == "updating" && i == 0 {
+			pendingVersion = r.Id
+			status = "updating"
+		}
+
+		if system.Version == r.Id {
+			status = "active"
+		}
+
+		t.AddRow(r.Id, humanizeTime(r.Created), status)
+	}
+
+	t.Print()
+
+	next, err := version.Next(system.Version)
 
 	if err != nil {
 		return
 	}
 
-	selected := version.Versions{}
-
-	for _, v := range vs {
-		switch {
-		case !v.Published && c.Bool("unpublished"):
-			selected = append(selected, v)
-		case v.Published:
-			selected = append(selected, v)
-		}
-	}
-
-	sort.Sort(sort.Reverse(selected))
-
-	if len(selected) > 20 {
-		selected = selected[0:20]
-	}
-
-	for _, v := range selected {
-		fmt.Println(v.Version)
+	if strings.Compare(next, pendingVersion) == 1 {
+		fmt.Println()
+		fmt.Printf("New version available: %s\n", next)
 	}
 }
 

--- a/cmd/convox/rack.go
+++ b/cmd/convox/rack.go
@@ -177,7 +177,8 @@ func cmdRackReleases(c *cli.Context) {
 		return
 	}
 
-	if strings.Compare(next, pendingVersion) == 1 {
+	if next > pendingVersion {
+		// if strings.Compare(next, pendingVersion) == 1 {
 		fmt.Println()
 		fmt.Printf("New version available: %s\n", next)
 	}

--- a/cmd/convox/rack_test.go
+++ b/cmd/convox/rack_test.go
@@ -32,7 +32,7 @@ func TestRackUpdateStable(t *testing.T) {
 		test.ExecRun{
 			Command: "convox rack update",
 			Exit:    0,
-			Stdout:  "Name     mysystem\nStatus   \nVersion  ver\nCount    1\nType     type\n",
+			Stdout:  fmt.Sprintf("Name     mysystem\nStatus   \nVersion  ver\nCount    1\nType     type\n\nUpdating to version: %s\n", stable.Version),
 		},
 	)
 }
@@ -53,7 +53,7 @@ func TestRackUpdateSpecified(t *testing.T) {
 		test.ExecRun{
 			Command: "convox rack update 20150909014908",
 			Exit:    0,
-			Stdout:  "Name     mysystem\nStatus   \nVersion  ver\nCount    1\nType     type\n",
+			Stdout:  "Name     mysystem\nStatus   \nVersion  ver\nCount    1\nType     type\n\nUpdating to version: 20150909014908\n",
 		},
 	)
 }


### PR DESCRIPTION
This is one step towards an automated `convox rack rollback` procedure: storing the rack version history. Update to this, and the next and future updates will be stored in dynamodb.

* On system version update, save new version in the releases table for the RACK app
* SystemReleaseList endpoint
* `convox rack releases` prints a table of current and historical saved releases
* `convox rack releases` prints the next release if available