### PR TITLE
NAT Gateway

### DIFF
--- a/api/cmd/formation/handler/ec2.go
+++ b/api/cmd/formation/handler/ec2.go
@@ -31,6 +31,27 @@ func HandleEC2AvailabilityZones(req Request) (string, map[string]string, error) 
 	return "", nil, fmt.Errorf("unknown RequestType: %s", req.RequestType)
 }
 
+func HandleEC2NatGateway(req Request) (string, map[string]string, error) {
+	defer recoverFailure(req)
+
+	switch req.RequestType {
+	case "Create":
+		fmt.Println("CREATING NATGATEWAY")
+		fmt.Printf("req %+v\n", req)
+		return EC2NatGatewayCreate(req)
+	case "Update":
+		fmt.Println("UPDATING NATGATEWAY")
+		fmt.Printf("req %+v\n", req)
+		return EC2NatGatewayUpdate(req)
+	case "Delete":
+		fmt.Println("DELETING NATGATEWAY")
+		fmt.Printf("req %+v\n", req)
+		return EC2NatGatewayDelete(req)
+	}
+
+	return "", nil, fmt.Errorf("unknown RequestType: %s", req.RequestType)
+}
+
 var regexMatchAvailabilityZones = regexp.MustCompile(`following availability zones: ([^.]+)`)
 
 func EC2AvailabilityZonesCreate(req Request) (string, map[string]string, error) {
@@ -64,4 +85,29 @@ func EC2AvailabilityZonesUpdate(req Request) (string, map[string]string, error) 
 func EC2AvailabilityZonesDelete(req Request) (string, map[string]string, error) {
 	// nop
 	return req.PhysicalResourceId, nil, nil
+}
+
+func EC2NatGatewayCreate(req Request) (string, map[string]string, error) {
+	res, err := EC2(req).CreateNatGateway(&ec2.CreateNatGatewayInput{
+		AllocationId: aws.String(req.ResourceProperties["AllocationId"].(string)),
+		SubnetId:     aws.String(req.ResourceProperties["SubnetId"].(string)),
+	})
+
+	if err != nil {
+		return "invalid", nil, err
+	}
+
+	return *res.NatGateway.NatGatewayId, nil, nil
+}
+
+func EC2NatGatewayUpdate(req Request) (string, map[string]string, error) {
+	return req.PhysicalResourceId, nil, fmt.Errorf("could not update")
+}
+
+func EC2NatGatewayDelete(req Request) (string, map[string]string, error) {
+	_, err := EC2(req).DeleteNatGateway(&ec2.DeleteNatGatewayInput{
+		NatGatewayId: aws.String(req.PhysicalResourceId),
+	})
+
+	return req.PhysicalResourceId, nil, err
 }

--- a/api/cmd/formation/handler/formation.go
+++ b/api/cmd/formation/handler/formation.go
@@ -166,6 +166,8 @@ func HandleRequest(freq Request) error {
 	switch freq.ResourceType {
 	case "Custom::EC2AvailabilityZones":
 		physical, outputs, err = HandleEC2AvailabilityZones(freq)
+	case "Custom::EC2NatGateway":
+		physical, outputs, err = HandleEC2NatGateway(freq)
 	case "Custom::ECRRepository":
 		physical, outputs, err = HandleECRRepository(freq)
 	case "Custom::ECSCluster":


### PR DESCRIPTION
* Custom handler for EC2 NAT Gateway

Tested working by adding this to kernel.json:

```json
"EIP": {
  "Type": "AWS::EC2::EIP",
  "Properties": {
    "Domain": "vpc"
  }
},
"NatGateway": {
  "Type": "Custom::EC2NatGateway",
  "Properties": {
    "ServiceToken": { "Fn::GetAtt": [ "CustomTopic", "Arn" ] },
    "AllocationId": { "Fn::GetAtt": [ "EIP", "AllocationId" ] },
    "SubnetId": { "Ref": "Subnet0" }
  }
},
```

TODO:
- [ ] [EIP Association](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip-association.html)
- [ ] Integrate with private subnets

![screen shot 2016-02-10 at 5 22 31 pm](https://cloud.githubusercontent.com/assets/147410/12967372/ec61ea90-d01a-11e5-8c00-41ff8cbd9c64.png)

![screen shot 2016-02-10 at 5 26 37 pm](https://cloud.githubusercontent.com/assets/147410/12967453/7b350a22-d01b-11e5-9865-88d304cd71aa.png)
