### PR TITLE
Cap Docker Logs

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -651,8 +651,8 @@
               { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Ref": "RegistryHost" }, { "Ref": "RegistryPort" } ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] }
             ] },
             { "Fn::If": [ "BlankCertificate",
-              { "Fn::Join": [ "", [ "echo 'OPTIONS=\"${OPTIONS} --insecure-registry=", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, " --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker" ] ] },
-              "echo 'OPTIONS=\"${OPTIONS} --host=unix:///var/run/docker.sock  --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker"
+              { "Fn::Join": [ "", [ "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --insecure-registry=", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, " --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker" ] ] },
+              "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock  --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker"
             ] },
             "service docker restart",
             "mkdir -p /etc/convox",

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -659,7 +659,7 @@
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
-            "curl -s https://convox.s3.amazonaws.com/agent/0.63/convox.conf > /etc/init/convox.conf",
+            "curl -s https://convox.s3.amazonaws.com/agent/0.64/convox.conf > /etc/init/convox.conf",
             "start convox",
             { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
             "sleep 30",


### PR DESCRIPTION
## Observations

I observed instances failing to start new tasks due to a full root partition. The ECS tasks had this error:

> CannotPullContainerError: Error: image myapp-pwslydfenh:web.BHGHDJOBYMU not found

`docker info` showed that the Docker volume was fine, but `df` showed that the root partition was 100% full, with `du` indicating /var/lib/docker/containers was using a lot of disk for log storage

```
[root@ip-10-0-3-4 /]# df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/xvda1      7.8G  7.8G     0 100% /
devtmpfs        7.9G   88K  7.9G   1% /dev
tmpfs           7.9G     0  7.9G   0% /dev/shm

[root@ip-10-0-3-4 /]# du -d4 -h * | sort -hdf
...
230M	var/cache
429M	usr
1.1G	var/lib/docker/containers/e95be0c289d8194c291e3ddb4c91f9028fa50361aa03695ea48bee00900bcc19
1.2G	var/lib
1.2G	var/lib/docker
1.2G	var/lib/docker/containers
1.4G	var
5.1G	swapfile

[root@ip-10-0-3-4 /]# ls -al var/lib/docker/containers/e95be0c289d8194c291e3ddb4c91f9028fa50361aa03695ea48bee00900bcc19
total 1079780
drwx------ 4 root root       4096 Feb 12 02:26 .
drwx------ 8 root root       4096 Feb 12 02:56 ..
-rw-r--r-- 1 root root       3850 Feb 12 02:26 config.json
-rw------- 1 root root 1105646969 Feb 12 15:38 e95be0c289d8194c291e3ddb4c91f9028fa50361aa03695ea48bee00900bcc19-json.log
```

## Steps To Reproduce

Run 'yes' to generate a lot of json logs:

```
[root@ip-10-0-3-141 ec2-user]# docker run -d busybox yes
Unable to find image 'busybox:latest' locally
latest: Pulling from library/busybox
583635769552: Pull complete 
b175bcb79023: Pull complete 
Digest: sha256:c1bc9b4bffe665bf014a305cc6cf3bca0e6effeb69d681d7a208ce741dad58e0
Status: Downloaded newer image for busybox:latest
b5bc32ff2eb1566c609191f3fe80a2518234e1e68a6b0a0bd92c52ae0bd42a27

[root@ip-10-0-3-141 ec2-user]# ls -al /var/lib/docker/containers/b5bc32ff2eb1566c609191f3fe80a2518234e1e68a6b0a0bd92c52ae0bd42a27/
total 64168
drwx------ 4 root root     4096 Feb 12 15:40 .
drwx------ 5 root root     4096 Feb 12 15:40 ..
-rw-r--r-- 1 root root 15660534 Feb 12 15:40 b5bc32ff2eb1566c609191f3fe80a2518234e1e68a6b0a0bd92c52ae0bd42a27-json.log
...
```

Then deploy new ECS tasks. Tasks that get scheduled on this instance will fail to start.

## Manual Detection and Remediation

Terminate the bad instance and wait a few minutes. The Auto Scale Group will boot a new instance. ECS will again be able to schedule the containers.

```
$ convox instances
ID          AGENT  STATUS  STARTED     PS  CPU    MEM   
i-1463129d  on     active  3 days ago  2   0.00%  25.56%
i-29f226a9  on     active  2 days ago  1   0.00%  19.17%
i-16ab80a5  on     active  3 days ago  0   0.00%  0.00%

$ convox api get /instances | jq '.[].id' | xargs -L1 -I% convox instances ssh % du
[one of them is 100% full]

$ convox instances terminate  i-1463129d
```

## Engineering Playbook

- [x] Document Issue
  - [x] Observations
  - [x] Steps to reproduce
  - [x] Manual procedure to work around
- [ ] Add Visibility
  - [x] Log when issue occurs
  - [x] Log metrics around issue
  - [ ] Notify when issue occurs
- [x] Automate work around
  - [x] Log when automation occurs
  - [x] Log metrics around automation
- [x] Remediate root cause (docker log file rotation)
- [ ] Verify fix against metrics around issue and automation

## Release Playbook
- [x] Pass checks
- [ ] Code review
- [x] Release branch (20160212191505-log-opt)
- [x] Pass CI (https://circleci.com/gh/convox/rack/477)
- [ ] Merge into master
- [ ] Release master → pass CI → auto-publish release
- [ ] Update dev and testing racks