### PR TITLE
Respect DockerImageApi parameter in ECS definitions

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -1041,7 +1041,10 @@
               "SUBNETS": { "Fn::Join": [ ",", [ { "Ref": "Subnet0" }, { "Ref": "Subnet1" }, { "Ref": "Subnet2" } ] ] },
               "VPC": { "Ref": "Vpc" }
             },
-            "Image": { "Fn::Join": [ ":", [ "convox/api", { "Ref": "Version" } ] ] },
+            "Image": { "Fn::If": [ "BlankDockerImageApi",
+              { "Fn::Join": [ ":", [ "convox/api", { "Ref": "Version" } ] ] },
+              { "Ref": "DockerImageApi" }
+            ] },
             "Links": [],
             "Memory": "128",
             "Name": "web",
@@ -1126,7 +1129,10 @@
               "SUBNETS": { "Fn::Join": [ ",", [ { "Ref": "Subnet0" }, { "Ref": "Subnet1" }, { "Ref": "Subnet2" } ] ] },
               "VPC": { "Ref": "Vpc" }
             },
-            "Image": { "Fn::Join": [ ":", [ "convox/api", { "Ref": "Version" } ] ] },
+            "Image": { "Fn::If": [ "BlankDockerImageApi",
+              { "Fn::Join": [ ":", [ "convox/api", { "Ref": "Version" } ] ] },
+              { "Ref": "DockerImageApi" }
+            ] },
             "Links": [],
             "Memory": "64",
             "Name": "monitor",


### PR DESCRIPTION
Maybe there is a reason for this I'm missing, but as-is, I can't use the `DockerImageApi` param to test new convox api builds (by pointing it at my own ECR repos). This makes it hard to quickly switch a rack between builds for testing.

Side-note, why does this param have a `Development` condition? How does that come into play exactly?