### PR TITLE
remove coveralls and special travis config in favor of `make test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,11 @@ language: go
 go:
 - 1.5
 
-env:
-  - PROVIDER=test
-
 before_install:
-- go get -u golang.org/x/tools/cmd/cover
-- go get -u github.com/axw/gocov/gocov
-- go get -u github.com/mattn/goveralls
 - go get -u github.com/convox/release/version
 
 script:
-- go install ./...
-- goveralls -gocovdata <(gocov test -v ./...) -service travis-ci
+- make test
 
 notifications:
   slack:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Convox Rack
 
 [![Build Status](https://travis-ci.org/convox/rack.svg?branch=master)](https://travis-ci.org/convox/rack)
-[![Coverage Status](https://coveralls.io/repos/convox/rack/badge.svg?branch=master&service=github)](https://coveralls.io/github/convox/rack?branch=master)
 
 ## Projects
 


### PR DESCRIPTION
Coveralls has been down a lot. We also are not getting any value out of coverage analysis in general. Remove for now.