### PR TITLE
PS Throttle

### DIFF
--- a/api/controllers/processes_test.go
+++ b/api/controllers/processes_test.go
@@ -27,15 +27,16 @@ func TestProcessesList(t *testing.T) {
 		test.DescribeAppStackCycle("convox-test-myapp-staging"),
 		test.DescribeAppStackCycle("convox-test-myapp-staging"),
 		test.DescribeAppStackResourcesCycle("convox-test-myapp-staging"),
+
+		test.ListContainerInstancesCycle("convox-test-cluster"),
+		test.DescribeContainerInstancesCycle("convox-test-cluster"),
+
 		test.ListTasksCycle("convox-test-cluster", "convox-test-myapp-staging-worker-SCELGCIYSKF"),
 		test.DescribeTasksCycle("convox-test-cluster"),
 		test.DescribeTaskDefinitionCycle("convox-test-cluster"),
-		test.DescribeContainerInstancesFilteredCycle("convox-test-cluster"),
 		test.DescribeInstancesFilteredCycle(),
 		test.DescribeAppStackResourcesCycle("convox-test-myapp-staging"),
 		test.DescribeServicesCycle("convox-test-cluster"),
-		test.ListContainerInstancesCycle("convox-test-cluster"),
-		test.DescribeContainerInstancesCycle("convox-test-cluster"),
 		test.DescribeInstancesCycle(),
 	)
 	defer aws.Close()
@@ -73,16 +74,17 @@ func TestGetProcessesWithDeployments(t *testing.T) {
 		test.DescribeAppStackCycle("convox-test-myapp-staging"),
 		test.DescribeAppStackCycle("convox-test-myapp-staging"),
 		test.DescribeAppStackResourcesCycle("convox-test-myapp-staging"),
+
+		test.ListContainerInstancesCycle("convox-test-cluster"),
+		test.DescribeContainerInstancesCycle("convox-test-cluster"),
+
 		test.ListTasksCycle("convox-test-cluster", "convox-test-myapp-staging-worker-SCELGCIYSKF"),
 		test.DescribeTasksCycle("convox-test-cluster"),
 		test.DescribeTaskDefinitionCycle("convox-test-cluster"),
-		test.DescribeContainerInstancesFilteredCycle("convox-test-cluster"),
 		test.DescribeInstancesFilteredCycle(),
 		test.DescribeAppStackResourcesCycle("convox-test-myapp-staging"),
 		test.DescribeServicesWithDeploymentsCycle("convox-test-cluster"),
 		test.DescribeTaskDefinition3Cycle("convox-test-cluster"),
-		test.ListContainerInstancesCycle("convox-test-cluster"),
-		test.DescribeContainerInstancesCycle("convox-test-cluster"),
 		test.DescribeInstancesCycle(),
 		test.DescribeTaskDefinition1Cycle("convox-test-cluster"),
 	)

--- a/api/controllers/processes_test.go
+++ b/api/controllers/processes_test.go
@@ -30,14 +30,14 @@ func TestProcessesList(t *testing.T) {
 
 		test.ListContainerInstancesCycle("convox-test-cluster"),
 		test.DescribeContainerInstancesCycle("convox-test-cluster"),
+		test.DescribeInstancesCycle(),
 
 		test.ListTasksCycle("convox-test-cluster", "convox-test-myapp-staging-worker-SCELGCIYSKF"),
 		test.DescribeTasksCycle("convox-test-cluster"),
 		test.DescribeTaskDefinitionCycle("convox-test-cluster"),
-		test.DescribeInstancesFilteredCycle(),
+
 		test.DescribeAppStackResourcesCycle("convox-test-myapp-staging"),
 		test.DescribeServicesCycle("convox-test-cluster"),
-		test.DescribeInstancesCycle(),
 	)
 	defer aws.Close()
 
@@ -77,15 +77,15 @@ func TestGetProcessesWithDeployments(t *testing.T) {
 
 		test.ListContainerInstancesCycle("convox-test-cluster"),
 		test.DescribeContainerInstancesCycle("convox-test-cluster"),
+		test.DescribeInstancesCycle(),
 
 		test.ListTasksCycle("convox-test-cluster", "convox-test-myapp-staging-worker-SCELGCIYSKF"),
 		test.DescribeTasksCycle("convox-test-cluster"),
 		test.DescribeTaskDefinitionCycle("convox-test-cluster"),
-		test.DescribeInstancesFilteredCycle(),
+
 		test.DescribeAppStackResourcesCycle("convox-test-myapp-staging"),
 		test.DescribeServicesWithDeploymentsCycle("convox-test-cluster"),
 		test.DescribeTaskDefinition3Cycle("convox-test-cluster"),
-		test.DescribeInstancesCycle(),
 		test.DescribeTaskDefinition1Cycle("convox-test-cluster"),
 	)
 	defer aws.Close()

--- a/api/models/models.go
+++ b/api/models/models.go
@@ -83,7 +83,9 @@ func ECR() *ecr.ECR {
 }
 
 func ECS() *ecs.ECS {
-	return ecs.New(session.New(), awsConfig())
+	c := awsConfig()
+	c.MaxRetries = aws.Int(10)
+	return ecs.New(session.New(), c)
 }
 
 func ELB() *elb.ELB {

--- a/test/aws_cycles.go
+++ b/test/aws_cycles.go
@@ -90,9 +90,9 @@ func DescribeContainerInstancesCycle(clusterName string) awsutil.Cycle {
 		awsutil.Request{"/", "AmazonEC2ContainerServiceV20141113.DescribeContainerInstances",
 			`{"cluster":"` + clusterName + `",
 				"containerInstances": [
-					"arn:aws:ecs:us-east-1:938166070011:container-instance/0ac4bb1c-be98-4202-a9c1-03153e91c05e",
-					"arn:aws:ecs:us-east-1:938166070011:container-instance/38a59629-6f5d-4d02-8733-fdb49500ae45",
-					"arn:aws:ecs:us-east-1:938166070011:container-instance/e7c311ae-968f-4125-8886-f9b724860d4c"
+					"arn:aws:ecs:us-east-1:901416387788:container-instance/0ac4bb1c-be98-4202-a9c1-03153e91c05e",
+					"arn:aws:ecs:us-east-1:901416387788:container-instance/38a59629-6f5d-4d02-8733-fdb49500ae45",
+					"arn:aws:ecs:us-east-1:901416387788:container-instance/e7c311ae-968f-4125-8886-f9b724860d4c"
 				]
 		}`},
 		awsutil.Response{200, describeContainerInstancesResponse()},
@@ -162,7 +162,7 @@ func ListContainerInstancesCycle(clusterName string) awsutil.Cycle {
 		awsutil.Request{"/", "AmazonEC2ContainerServiceV20141113.ListContainerInstances",
 			`{"cluster":"` + clusterName + `"}`},
 		awsutil.Response{200,
-			`{"containerInstanceArns":["arn:aws:ecs:us-east-1:938166070011:container-instance/0ac4bb1c-be98-4202-a9c1-03153e91c05e","arn:aws:ecs:us-east-1:938166070011:container-instance/38a59629-6f5d-4d02-8733-fdb49500ae45","arn:aws:ecs:us-east-1:938166070011:container-instance/e7c311ae-968f-4125-8886-f9b724860d4c"]}`},
+			`{"containerInstanceArns":["arn:aws:ecs:us-east-1:901416387788:container-instance/0ac4bb1c-be98-4202-a9c1-03153e91c05e","arn:aws:ecs:us-east-1:901416387788:container-instance/38a59629-6f5d-4d02-8733-fdb49500ae45","arn:aws:ecs:us-east-1:901416387788:container-instance/e7c311ae-968f-4125-8886-f9b724860d4c"]}`},
 	}
 }
 
@@ -278,20 +278,6 @@ func DescribeTaskDefinition1Cycle(clusterName string) awsutil.Cycle {
 	}
 }
 
-func DescribeContainerInstancesFilteredCycle(clusterName string) awsutil.Cycle {
-	return awsutil.Cycle{
-		awsutil.Request{"/", "AmazonEC2ContainerServiceV20141113.DescribeContainerInstances",
-			`{"cluster":"` + clusterName + `",
-        "containerInstances": [
-          "arn:aws:ecs:us-east-1:901416387788:container-instance/0ac4bb1c-be98-4202-a9c1-03153e91c05e"
-        ]
-    }`},
-		awsutil.Response{200, `{"containerInstances":[
-  {"agentConnected":true,"containerInstanceArn":"arn:aws:ecs:us-east-1:938166070011:container-instance/0ac4bb1c-be98-4202-a9c1-03153e91c05e","ec2InstanceId":"i-4a5513f4","pendingTasksCount":0,"registeredResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"remainingResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"runningTasksCount":0,"status":"ACTIVE","versionInfo":{"agentHash":"4ab1051","agentVersion":"1.4.0","dockerVersion":"DockerVersion: 1.7.1"}}
-],"failures":[]}`},
-	}
-}
-
 func DescribeInstancesFilteredCycle() awsutil.Cycle {
 	return awsutil.Cycle{
 		awsutil.Request{"/", "", `Action=DescribeInstances&Filter.1.Name=instance-id&Filter.1.Value.1=i-4a5513f4&Version=2015-10-01`},
@@ -303,7 +289,7 @@ func convoxStackXML(stackName string) string {
 	return `
       <member>
         <Tags/>
-        <StackId>arn:aws:cloudformation:us-east-1:938166070011:stack/` + stackName + `/9a10bbe0-51d5-11e5-b85a-5001dc3ed8d2</StackId>
+        <StackId>arn:aws:cloudformation:us-east-1:901416387788:stack/` + stackName + `/9a10bbe0-51d5-11e5-b85a-5001dc3ed8d2</StackId>
         <StackStatus>CREATE_COMPLETE</StackStatus>
         <StackName>` + stackName + `</StackName>
         <NotificationARNs/>
@@ -405,7 +391,7 @@ func appStackXML(appName string, status string) string {
             <Key>Name</Key>
           </member>
         </Tags>
-        <StackId>arn:aws:cloudformation:us-east-1:938166070011:stack/` + appName + `/9a10bbe0-51d5-11e5-b85a-5001dc3ed8d2</StackId>
+        <StackId>arn:aws:cloudformation:us-east-1:901416387788:stack/` + appName + `/9a10bbe0-51d5-11e5-b85a-5001dc3ed8d2</StackId>
         <StackStatus>` + status + `</StackStatus>
         <StackName>` + appName + `</StackName>
         <NotificationARNs/>
@@ -416,7 +402,7 @@ func appStackXML(appName string, status string) string {
             <ParameterKey>Environment</ParameterKey>
           </member>
           <member>
-            <ParameterValue>arn:aws:kms:us-east-1:938166070011:key/e4c9e19c-7410-4e0f-88bf-ac7ac085625d</ParameterValue>
+            <ParameterValue>arn:aws:kms:us-east-1:901416387788:key/e4c9e19c-7410-4e0f-88bf-ac7ac085625d</ParameterValue>
             <ParameterKey>Key</ParameterKey>
           </member>
           <member>
@@ -621,7 +607,7 @@ func describeInstancesResponse() string {
     <reservationSet>
         <item>
             <reservationId>r-8d7e2072</reservationId>
-            <ownerId>938166070011</ownerId>
+            <ownerId>901416387788</ownerId>
             <groupSet/>
             <instancesSet>
                 <item>
@@ -680,7 +666,7 @@ func describeInstancesResponse() string {
                         </item>
                         <item>
                             <key>aws:cloudformation:stack-id</key>
-                            <value>arn:aws:cloudformation:us-east-1:938166070011:stack/convox-dev/538ae350-8815-11e5-8a2d-5001b34fc89a</value>
+                            <value>arn:aws:cloudformation:us-east-1:901416387788:stack/convox-dev/538ae350-8815-11e5-8a2d-5001b34fc89a</value>
                         </item>
                         <item>
                             <key>Rack</key>
@@ -706,7 +692,7 @@ func describeInstancesResponse() string {
                             <subnetId>subnet-21bab178</subnetId>
                             <vpcId>vpc-e948f08d</vpcId>
                             <description/>
-                            <ownerId>938166070011</ownerId>
+                            <ownerId>901416387788</ownerId>
                             <status>in-use</status>
                             <macAddress>0e:d6:3e:c3:21:15</macAddress>
                             <privateIpAddress>10.0.3.248</privateIpAddress>
@@ -743,7 +729,7 @@ func describeInstancesResponse() string {
                         </item>
                     </networkInterfaceSet>
                     <iamInstanceProfile>
-                        <arn>arn:aws:iam::938166070011:instance-profile/convox-dev-InstanceProfile-HJBF2SIK0R6W</arn>
+                        <arn>arn:aws:iam::901416387788:instance-profile/convox-dev-InstanceProfile-HJBF2SIK0R6W</arn>
                         <id>AIPAIR7O43WTX246KVAIM</id>
                     </iamInstanceProfile>
                     <ebsOptimized>false</ebsOptimized>
@@ -753,7 +739,7 @@ func describeInstancesResponse() string {
         </item>
         <item>
             <reservationId>r-835b392a</reservationId>
-            <ownerId>938166070011</ownerId>
+            <ownerId>901416387788</ownerId>
             <groupSet/>
             <instancesSet>
                 <item>
@@ -812,7 +798,7 @@ func describeInstancesResponse() string {
                         </item>
                         <item>
                             <key>aws:cloudformation:stack-id</key>
-                            <value>arn:aws:cloudformation:us-east-1:938166070011:stack/convox-dev/538ae350-8815-11e5-8a2d-5001b34fc89a</value>
+                            <value>arn:aws:cloudformation:us-east-1:901416387788:stack/convox-dev/538ae350-8815-11e5-8a2d-5001b34fc89a</value>
                         </item>
                         <item>
                             <key>Name</key>
@@ -838,7 +824,7 @@ func describeInstancesResponse() string {
                             <subnetId>subnet-97ab91bc</subnetId>
                             <vpcId>vpc-e948f08d</vpcId>
                             <description/>
-                            <ownerId>938166070011</ownerId>
+                            <ownerId>901416387788</ownerId>
                             <status>in-use</status>
                             <macAddress>12:51:78:a6:f5:13</macAddress>
                             <privateIpAddress>10.0.1.182</privateIpAddress>
@@ -875,7 +861,7 @@ func describeInstancesResponse() string {
                         </item>
                     </networkInterfaceSet>
                     <iamInstanceProfile>
-                        <arn>arn:aws:iam::938166070011:instance-profile/convox-dev-InstanceProfile-HJBF2SIK0R6W</arn>
+                        <arn>arn:aws:iam::901416387788:instance-profile/convox-dev-InstanceProfile-HJBF2SIK0R6W</arn>
                         <id>AIPAIR7O43WTX246KVAIM</id>
                     </iamInstanceProfile>
                     <ebsOptimized>false</ebsOptimized>
@@ -885,7 +871,7 @@ func describeInstancesResponse() string {
         </item>
         <item>
             <reservationId>r-da7b7c0a</reservationId>
-            <ownerId>938166070011</ownerId>
+            <ownerId>901416387788</ownerId>
             <groupSet/>
             <instancesSet>
                 <item>
@@ -940,7 +926,7 @@ func describeInstancesResponse() string {
                     <tagSet>
                         <item>
                             <key>aws:cloudformation:stack-id</key>
-                            <value>arn:aws:cloudformation:us-east-1:938166070011:stack/convox-dev/538ae350-8815-11e5-8a2d-5001b34fc89a</value>
+                            <value>arn:aws:cloudformation:us-east-1:901416387788:stack/convox-dev/538ae350-8815-11e5-8a2d-5001b34fc89a</value>
                         </item>
                         <item>
                             <key>aws:cloudformation:logical-id</key>
@@ -970,7 +956,7 @@ func describeInstancesResponse() string {
                             <subnetId>subnet-8ff000f9</subnetId>
                             <vpcId>vpc-e948f08d</vpcId>
                             <description/>
-                            <ownerId>938166070011</ownerId>
+                            <ownerId>901416387788</ownerId>
                             <status>in-use</status>
                             <macAddress>0a:2d:91:ea:29:49</macAddress>
                             <privateIpAddress>10.0.2.236</privateIpAddress>
@@ -1007,7 +993,7 @@ func describeInstancesResponse() string {
                         </item>
                     </networkInterfaceSet>
                     <iamInstanceProfile>
-                        <arn>arn:aws:iam::938166070011:instance-profile/convox-dev-InstanceProfile-HJBF2SIK0R6W</arn>
+                        <arn>arn:aws:iam::901416387788:instance-profile/convox-dev-InstanceProfile-HJBF2SIK0R6W</arn>
                         <id>AIPAIR7O43WTX246KVAIM</id>
                     </iamInstanceProfile>
                     <ebsOptimized>false</ebsOptimized>
@@ -1025,7 +1011,7 @@ func describeInstancesFilteredResponse() string {
     <reservationSet>
         <item>
             <reservationId>r-8d7e2072</reservationId>
-            <ownerId>938166070011</ownerId>
+            <ownerId>901416387788</ownerId>
             <groupSet/>
             <instancesSet>
                 <item>
@@ -1084,7 +1070,7 @@ func describeInstancesFilteredResponse() string {
                         </item>
                         <item>
                             <key>aws:cloudformation:stack-id</key>
-                            <value>arn:aws:cloudformation:us-east-1:938166070011:stack/convox-dev/538ae350-8815-11e5-8a2d-5001b34fc89a</value>
+                            <value>arn:aws:cloudformation:us-east-1:901416387788:stack/convox-dev/538ae350-8815-11e5-8a2d-5001b34fc89a</value>
                         </item>
                         <item>
                             <key>Rack</key>
@@ -1110,7 +1096,7 @@ func describeInstancesFilteredResponse() string {
                             <subnetId>subnet-21bab178</subnetId>
                             <vpcId>vpc-e948f08d</vpcId>
                             <description/>
-                            <ownerId>938166070011</ownerId>
+                            <ownerId>901416387788</ownerId>
                             <status>in-use</status>
                             <macAddress>0e:d6:3e:c3:21:15</macAddress>
                             <privateIpAddress>10.0.3.248</privateIpAddress>
@@ -1147,7 +1133,7 @@ func describeInstancesFilteredResponse() string {
                         </item>
                     </networkInterfaceSet>
                     <iamInstanceProfile>
-                        <arn>arn:aws:iam::938166070011:instance-profile/convox-dev-InstanceProfile-HJBF2SIK0R6W</arn>
+                        <arn>arn:aws:iam::901416387788:instance-profile/convox-dev-InstanceProfile-HJBF2SIK0R6W</arn>
                         <id>AIPAIR7O43WTX246KVAIM</id>
                     </iamInstanceProfile>
                     <ebsOptimized>false</ebsOptimized>
@@ -1160,9 +1146,9 @@ func describeInstancesFilteredResponse() string {
 }
 
 func describeContainerInstancesResponse() string {
-	return `{"containerInstances":[{"agentConnected":true,"containerInstanceArn":"arn:aws:ecs:us-east-1:938166070011:container-instance/0ac4bb1c-be98-4202-a9c1-03153e91c05e","ec2InstanceId":"i-4a5513f4","pendingTasksCount":0,"registeredResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"remainingResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"runningTasksCount":0,"status":"ACTIVE","versionInfo":{"agentHash":"4ab1051","agentVersion":"1.4.0","dockerVersion":"DockerVersion: 1.7.1"}},
-{"agentConnected":true,"containerInstanceArn":"arn:aws:ecs:us-east-1:938166070011:container-instance/38a59629-6f5d-4d02-8733-fdb49500ae45","ec2InstanceId":"i-3963798e","pendingTasksCount":0,"registeredResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"remainingResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"runningTasksCount":0,"status":"ACTIVE","versionInfo":{"agentHash":"4ab1051","agentVersion":"1.4.0","dockerVersion":"DockerVersion: 1.7.1"}},
-{"agentConnected":true,"containerInstanceArn":"arn:aws:ecs:us-east-1:938166070011:container-instance/e7c311ae-968f-4125-8886-f9b724860d4c","ec2InstanceId":"i-c6a72b76","pendingTasksCount":0,"registeredResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"remainingResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":1620,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","3101","3001","3100","51678","3000"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"runningTasksCount":1,"status":"ACTIVE","versionInfo":{"agentHash":"4ab1051","agentVersion":"1.4.0","dockerVersion":"DockerVersion: 1.7.1"}}],"failures":[]}`
+	return `{"containerInstances":[{"agentConnected":true,"containerInstanceArn":"arn:aws:ecs:us-east-1:901416387788:container-instance/0ac4bb1c-be98-4202-a9c1-03153e91c05e","ec2InstanceId":"i-4a5513f4","pendingTasksCount":0,"registeredResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"remainingResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"runningTasksCount":0,"status":"ACTIVE","versionInfo":{"agentHash":"4ab1051","agentVersion":"1.4.0","dockerVersion":"DockerVersion: 1.7.1"}},
+{"agentConnected":true,"containerInstanceArn":"arn:aws:ecs:us-east-1:901416387788:container-instance/38a59629-6f5d-4d02-8733-fdb49500ae45","ec2InstanceId":"i-3963798e","pendingTasksCount":0,"registeredResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"remainingResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"runningTasksCount":0,"status":"ACTIVE","versionInfo":{"agentHash":"4ab1051","agentVersion":"1.4.0","dockerVersion":"DockerVersion: 1.7.1"}},
+{"agentConnected":true,"containerInstanceArn":"arn:aws:ecs:us-east-1:901416387788:container-instance/e7c311ae-968f-4125-8886-f9b724860d4c","ec2InstanceId":"i-c6a72b76","pendingTasksCount":0,"registeredResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":2004,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","51678"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"remainingResources":[{"doubleValue":0.0,"integerValue":1024,"longValue":0,"name":"CPU","type":"INTEGER"},{"doubleValue":0.0,"integerValue":1620,"longValue":0,"name":"MEMORY","type":"INTEGER"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS","stringSetValue":["22","2376","2375","3101","3001","3100","51678","3000"],"type":"STRINGSET"},{"doubleValue":0.0,"integerValue":0,"longValue":0,"name":"PORTS_UDP","stringSetValue":[],"type":"STRINGSET"}],"runningTasksCount":1,"status":"ACTIVE","versionInfo":{"agentHash":"4ab1051","agentVersion":"1.4.0","dockerVersion":"DockerVersion: 1.7.1"}}],"failures":[]}`
 }
 
 func describeServicesResponse(clusterName string) string {

--- a/test/aws_cycles.go
+++ b/test/aws_cycles.go
@@ -110,7 +110,7 @@ func DescribeConvoxStackCycle(stackName string) awsutil.Cycle {
 
 func DescribeInstancesCycle() awsutil.Cycle {
 	return awsutil.Cycle{
-		awsutil.Request{"/", "", `Action=DescribeInstances&Filter.1.Name=instance-id&Filter.1.Value.1=i-4a5513f4&Filter.1.Value.2=i-3963798e&Filter.1.Value.3=i-c6a72b76&Version=2015-10-01`},
+		awsutil.Request{"/", "", `Action=DescribeInstances&InstanceId.1=i-4a5513f4&InstanceId.2=i-3963798e&InstanceId.3=i-c6a72b76&Version=2015-10-01`},
 		awsutil.Response{200, describeInstancesResponse()},
 	}
 }


### PR DESCRIPTION
Addresses this error which happens frequently on bigger apps:

```
$ convox ps
ERROR: ThrottlingException: Rate exceeded
    status code: 400, request id: 155f75b2-dac8-11e5-8038-cb0464aa31e7
```

* Increase ECS client retries to better deal with throttling
* Describe ECS instances only once
* Describe EC2 instances only once

This results in less requests total, and more time to backoff/retry if throttled.