### PR TITLE
Fixes #161: Adds a `password` option to `convox install`

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -115,6 +115,12 @@ func init() {
 				Usage:  "email address to receive project updates",
 			},
 			cli.StringFlag{
+				Name:   "password",
+				EnvVar: "PASSWORD",
+				Value: randomString(30),
+				Usage:  "custom password for rack",
+			},
+			cli.StringFlag{
 				Name:   "version",
 				EnvVar: "VERSION",
 				Value:  "latest",
@@ -308,7 +314,7 @@ func cmdInstall(c *cli.Context) {
 		fmt.Println("(Private Network Edition)")
 	}
 
-	password := randomString(30)
+	password := c.String("password")
 
 	CloudFormation := cloudformation.New(session.New(), awsConfig(region, creds))
 


### PR DESCRIPTION
## Release Playbook
- [ ] Rebase against master
- [ ] Pass checks
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI

Not really sure how to set up my environment to work / test this locally, so I'm winging it a little bit here.
I believe this should handle either `--password` or `ENV[PASSWORD]`, as per the ticket description.