### PR TITLE
Agent Flags via InstanceBootCommand parameter

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -853,6 +853,7 @@
         "UserData": { "Fn::Base64":
           { "Fn::Join": [ "\n", [
             "#!/bin/bash",
+            "set -e",
             "fallocate -l 5G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile",
             "yum -y update",
             "yum -y install aws-cfn-bootstrap",

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -153,6 +153,11 @@
       "Description": "SSL certificate",
       "Default": ""
     },
+    "CustomUserData": {
+      "Type": "String",
+      "Description": "A single line of shell script to run as UserData before the instance boots.",
+      "Default": ""
+    },
     "Development": {
       "Type": "String",
       "Description": "Development mode",
@@ -868,6 +873,7 @@
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
             "curl -s https://convox.s3.amazonaws.com/agent/0.65/convox.conf > /etc/init/convox.conf",
             "start convox",
+            { "Ref": "CustomUserData" },
             { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
             "sleep 30",
             { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] }

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -153,11 +153,6 @@
       "Description": "SSL certificate",
       "Default": ""
     },
-    "ExtraUserDataCommand": {
-      "Type": "String",
-      "Description": "A single line of extra shell script to run as UserData during instance boot.",
-      "Default": ""
-    },
     "Development": {
       "Type": "String",
       "Description": "Development mode",
@@ -189,6 +184,11 @@
       "Description": "Encrypt secrets with KMS",
       "Default": "Yes",
       "AllowedValues": [ "Yes", "No" ]
+    },
+    "InstanceBootCommand": {
+      "Type": "String",
+      "Description": "A single line of extra shell script to run as UserData during instance boot.",
+      "Default": ""
     },
     "InstanceCount": {
       "Default": "3",
@@ -874,7 +874,7 @@
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
             "curl -s https://convox.s3.amazonaws.com/agent/0.66/convox.conf > /etc/init/convox.conf",
             "start convox",
-            { "Ref": "ExtraUserDataCommand" },
+            { "Ref": "InstanceBootCommand" },
             { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
             "sleep 30",
             { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] }

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -871,7 +871,7 @@
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
-            "curl -s https://convox.s3.amazonaws.com/agent/0.65/convox.conf > /etc/init/convox.conf",
+            "curl -s https://convox.s3.amazonaws.com/agent/0.66/convox.conf > /etc/init/convox.conf",
             "start convox",
             { "Ref": "CustomUserData" },
             { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -153,9 +153,9 @@
       "Description": "SSL certificate",
       "Default": ""
     },
-    "CustomUserData": {
+    "ExtraUserDataCommand": {
       "Type": "String",
-      "Description": "A single line of shell script to run as UserData before the instance boots.",
+      "Description": "A single line of extra shell script to run as UserData during instance boot.",
       "Default": ""
     },
     "Development": {
@@ -873,7 +873,7 @@
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
             "curl -s https://convox.s3.amazonaws.com/agent/0.66/convox.conf > /etc/init/convox.conf",
             "start convox",
-            { "Ref": "CustomUserData" },
+            { "Ref": "ExtraUserDataCommand" },
             { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
             "sleep 30",
             { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] }


### PR DESCRIPTION
* Use agent 0.66 (PR: https://github.com/convox/agent/pull/18)
* Add InstanceBootCommand Parameter
* Add set -e to UserData to guard against failures in InstanceBootCommand or anything else really

The new parameter opens up a new ability to configure individual racks differently. I want this to do agent experiments on a specific rack that is having problems at production scale. 

I.e. `InstanceBootCommand='curl -s https://convox.s3.amazonaws.com/agent/0.66-experimental/convox.conf > /etc/init/convox.conf ; restart convox'`

This also opens up lots of possibilities to configure a logging container on every instance, install extra packages, etc. See: https://github.com/convox/rack/issues/356

## Release Playbook
- [x] Rebase against master
- [x] Pass checks
- [x] Code review
- [ ] Merge into master
- [ ] Follow Multi-PR Release Playbook
