### PR TITLE
Fix #448: Add params for redis multi-AZ support

### DIFF
--- a/api/models/templates/service/redis.tmpl
+++ b/api/models/templates/service/redis.tmpl
@@ -2,6 +2,11 @@
   {
     "AWSTemplateFormatVersion" : "2010-09-09",
     "Parameters": {
+      "AutomaticFailoverEnabled": {
+        "Type": "String",
+        "Default": "false",
+        "Description": "Indicates whether Multi-AZ is enabled"
+      },
       "Database": {
         "Type" : "String",
         "Default" : "0",
@@ -11,6 +16,11 @@
         "Type": "String",
         "Default": "cache.t2.micro",
         "Description": "The type of instance to use"
+      },
+      "NumCacheClusters": {
+        "Type": "String",
+        "Default": "1",
+        "Description": "The number of cache clusters for this replication group"
       },
       "Password": {
         "Type" : "String",
@@ -51,12 +61,12 @@
       "ReplicationGroup": {
         "Type": "AWS::ElastiCache::ReplicationGroup",
         "Properties": {
-          "AutomaticFailoverEnabled": false,
+          "AutomaticFailoverEnabled": { "Ref": "AutomaticFailoverEnabled" },
           "AutoMinorVersionUpgrade": true,
           "CacheNodeType": { "Ref": "InstanceType" },
           "CacheSubnetGroupName": { "Ref": "CacheSubnetGroup" },
           "Engine": "redis",
-          "NumCacheClusters": "1",
+          "NumCacheClusters": { "Ref": "NumCacheClusters" },
           "Port": "6379",
           "ReplicationGroupDescription": { "Ref": "AWS::StackName" },
           "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ]

--- a/api/models/templates/service/redis.tmpl
+++ b/api/models/templates/service/redis.tmpl
@@ -4,7 +4,8 @@
     "Parameters": {
       "AutomaticFailoverEnabled": {
         "Type": "String",
-        "Default": "false",
+        "Default": "No",
+        "AllowedValues": [ "Yes", "No" ],
         "Description": "Indicates whether Multi-AZ is enabled"
       },
       "Database": {


### PR DESCRIPTION
Fixes #448 

Add params:

* `AutomaticFailoverEnabled` - default: No
* `NumCacheClusters` - default: 1

## Release Playbook
- [ ] Rebase against master
- [ ] Pass checks
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI