### PR TITLE
Mwarkentin 161 rack password

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -115,6 +115,12 @@ func init() {
 				Usage:  "email address to receive project updates",
 			},
 			cli.StringFlag{
+				Name:   "password",
+				EnvVar: "PASSWORD",
+				Value: randomString(30),
+				Usage:  "custom password for rack",
+			},
+			cli.StringFlag{
 				Name:   "version",
 				EnvVar: "VERSION",
 				Value:  "latest",
@@ -324,7 +330,7 @@ func cmdInstall(c *cli.Context) {
 		fmt.Println("(Private Network Edition)")
 	}
 
-	password := randomString(30)
+	password := c.String("password")
 
 	CloudFormation := cloudformation.New(session.New(), awsConfig(region, creds))
 

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -117,8 +117,8 @@ func init() {
 			cli.StringFlag{
 				Name:   "password",
 				EnvVar: "PASSWORD",
-				Value: randomString(30),
-				Usage:  "custom password for rack",
+				Value:  "",
+				Usage:  "custom API password. If not set a secure password will be randomly generated.",
 			},
 			cli.StringFlag{
 				Name:   "version",
@@ -331,6 +331,9 @@ func cmdInstall(c *cli.Context) {
 	}
 
 	password := c.String("password")
+	if password == "" {
+		password = randomString(30)
+	}
 
 	CloudFormation := cloudformation.New(session.New(), awsConfig(region, creds))
 


### PR DESCRIPTION
Taking over from https://github.com/convox/rack/pull/404 CC @mwarkentin.

Adds a stylistic change on top of the patch to keep `convox install --help` output static.

## CLI Release Playbook
- [x] Rebase against master
- [x] Pass checks
- [x] Release branch (20160316003001-mwarkentin-161-rack-password)
- [x] Pass CI (https://circleci.com/gh/convox/rack/654)
- [ ] Code review
- [x] Merge into master
- [ ] Release CLI

