### PR TITLE
convox proxy

### DIFF
--- a/api/controllers/proxy.go
+++ b/api/controllers/proxy.go
@@ -30,8 +30,8 @@ func Proxy(ws *websocket.Conn) *httperr.Error {
 	var wg sync.WaitGroup
 
 	wg.Add(2)
-	copyAsync(ws, conn, &wg)
-	copyAsync(conn, ws, &wg)
+	go copyAsync(ws, conn, &wg)
+	go copyAsync(conn, ws, &wg)
 	wg.Wait()
 
 	return nil

--- a/api/controllers/proxy.go
+++ b/api/controllers/proxy.go
@@ -1,0 +1,43 @@
+package controllers
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/convox/rack/Godeps/_workspace/src/github.com/gorilla/mux"
+	"github.com/convox/rack/Godeps/_workspace/src/golang.org/x/net/websocket"
+	"github.com/convox/rack/api/httperr"
+)
+
+func Proxy(ws *websocket.Conn) *httperr.Error {
+	vars := mux.Vars(ws.Request())
+	host := vars["host"]
+	port := vars["port"]
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%s", host, port), 3*time.Second)
+
+	if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
+		return httperr.Errorf(403, "timeout")
+	}
+
+	if err != nil {
+		return httperr.Server(err)
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	copyAsync(ws, conn, &wg)
+	copyAsync(conn, ws, &wg)
+	wg.Wait()
+
+	return nil
+}
+
+func copyAsync(dst io.Writer, src io.Reader, wg *sync.WaitGroup) {
+	defer wg.Done()
+	io.Copy(dst, src)
+}

--- a/api/controllers/routes.go
+++ b/api/controllers/routes.go
@@ -71,6 +71,7 @@ func NewRouter() (router *mux.Router) {
 	router.Handle("/apps/{app}/processes/{pid}/exec", ws("process.exec.attach", ProcessExecAttached)).Methods("GET")
 	router.Handle("/apps/{app}/processes/{process}/run", ws("process.run.attach", ProcessRunAttached)).Methods("GET")
 	router.Handle("/instances/{id}/ssh", ws("instance.ssh", InstanceSSH)).Methods("GET")
+	router.Handle("/proxy/{host}/{port}", ws("proxy", Proxy)).Methods("GET")
 	router.Handle("/services/{service}/logs", ws("service.logs", ServiceLogs)).Methods("GET")
 
 	// utility

--- a/client/proxy.go
+++ b/client/proxy.go
@@ -1,0 +1,10 @@
+package client
+
+import (
+	"fmt"
+	"io"
+)
+
+func (c *Client) Proxy(host string, port int, rw io.ReadWriteCloser) error {
+	return c.Stream(fmt.Sprintf("/proxy/%s/%d", host, port), nil, rw, rw)
+}

--- a/cmd/convox/proxy.go
+++ b/cmd/convox/proxy.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/convox/rack/Godeps/_workspace/src/github.com/codegangsta/cli"
+	"github.com/convox/rack/client"
+	"github.com/convox/rack/cmd/convox/stdcli"
+)
+
+func init() {
+	stdcli.RegisterCommand(cli.Command{
+		Name:        "proxy",
+		Description: "proxy local ports into a rack",
+		Usage:       "<port:host:hostport> [port:host:hostport]...",
+		Action:      cmdProxy,
+	})
+}
+
+func cmdProxy(c *cli.Context) {
+	if len(c.Args()) == 0 {
+		stdcli.Usage(c, "proxy")
+	}
+
+	ch := make(chan error)
+
+	for _, arg := range c.Args() {
+		parts := strings.SplitN(arg, ":", 3)
+
+		if len(parts) != 3 {
+			stdcli.Error(fmt.Errorf("invalid argument: %s", arg))
+			return
+		}
+
+		port, err := strconv.Atoi(parts[0])
+
+		if err != nil {
+			stdcli.Error(err)
+			return
+		}
+
+		hostport, err := strconv.Atoi(parts[2])
+
+		if err != nil {
+			stdcli.Error(err)
+			return
+		}
+
+		go proxy(port, parts[1], hostport, rackClient(c))
+	}
+
+	for range c.Args() {
+		err := <-ch
+
+		if err != nil {
+			stdcli.Error(err)
+			return
+		}
+	}
+}
+
+func proxy(port int, host string, hostport int, client *client.Client) {
+	fmt.Printf("proxying localhost:%d to %s:%d\n", port, host, hostport)
+
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+
+	if err != nil {
+		fmt.Printf("error: %s\n", err)
+		return
+	}
+
+	defer listener.Close()
+
+	for {
+		conn, err := listener.Accept()
+
+		if err != nil {
+			fmt.Printf("error: %s\n", err)
+			return
+		}
+
+		defer conn.Close()
+
+		fmt.Printf("connect: %d\n", port)
+
+		go func() {
+			err := client.Proxy(host, port, conn)
+
+			if err != nil {
+				fmt.Printf("error: %s\n", err)
+				conn.Close()
+				return
+			}
+		}()
+	}
+}

--- a/cmd/convox/proxy.go
+++ b/cmd/convox/proxy.go
@@ -25,8 +25,6 @@ func cmdProxy(c *cli.Context) {
 		stdcli.Usage(c, "proxy")
 	}
 
-	ch := make(chan error)
-
 	for _, arg := range c.Args() {
 		parts := strings.SplitN(arg, ":", 3)
 
@@ -74,14 +72,8 @@ func cmdProxy(c *cli.Context) {
 		go proxy(port, host, hostport, rackClient(c))
 	}
 
-	for range c.Args() {
-		err := <-ch
-
-		if err != nil {
-			stdcli.Error(err)
-			return
-		}
-	}
+	// block forever
+	select {}
 }
 
 func proxy(port int, host string, hostport int, client *client.Client) {

--- a/cmd/convox/proxy.go
+++ b/cmd/convox/proxy.go
@@ -87,7 +87,7 @@ func proxy(port int, host string, hostport int, client *client.Client) {
 		fmt.Printf("connect: %d\n", port)
 
 		go func() {
-			err := client.Proxy(host, port, conn)
+			err := client.Proxy(host, hostport, conn)
 
 			if err != nil {
 				fmt.Printf("error: %s\n", err)


### PR DESCRIPTION
Adds a `convox proxy` command to make it easier to connect to services running isolated inside a Rack.

`convox proxy 5432:my-postgres.rds.amazon.org:5432`

## Release Playbook
- [x] Rebase against master
- [x] Pass checks
- [x] Release branch (20160323164322-proxy)
- [x] Pass CI (https://circleci.com/gh/convox/rack/670)
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI

