### PR TITLE
Fix ps CPU output

### DIFF
--- a/cmd/convox/ps.go
+++ b/cmd/convox/ps.go
@@ -59,7 +59,7 @@ func cmdPs(c *cli.Context) {
 		t := stdcli.NewTable("ID", "NAME", "RELEASE", "SIZE", "CPU", "MEM", "STARTED", "COMMAND")
 
 		for _, p := range ps {
-			t.AddRow(prettyId(p), p.Name, p.Release, fmt.Sprintf("%d", p.Size), fmt.Sprintf("%0.2f%%", p.Cpu*100), fmt.Sprintf("%0.2f%%", p.Memory*100), humanizeTime(p.Started), p.Command)
+			t.AddRow(prettyId(p), p.Name, p.Release, fmt.Sprintf("%d", p.Size), fmt.Sprintf("%0.2f%%", p.Cpu), fmt.Sprintf("%0.2f%%", p.Memory*100), humanizeTime(p.Started), p.Command)
 		}
 
 		t.Print()
@@ -100,7 +100,7 @@ func cmdPsInfo(c *cli.Context) {
 	fmt.Printf("Name     %s\n", p.Name)
 	fmt.Printf("Release  %s\n", p.Release)
 	fmt.Printf("Size     %d\n", p.Size)
-	fmt.Printf("CPU      %0.2f%%\n", p.Cpu*100)
+	fmt.Printf("CPU      %0.2f%%\n", p.Cpu)
 	fmt.Printf("Memory   %0.2f%%\n", p.Memory*100)
 	fmt.Printf("Started  %s\n", humanizeTime(p.Started))
 	fmt.Printf("Command  %s\n", p.Command)


### PR DESCRIPTION
## Release Playbook
- [ ] Rebase against master
- [ ] Pass checks
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI

Seems like the `* 100` isn't needed - not sure why memory calculation works correctly, haven't dug into where the actual process data is coming from. Current output:

```
$ convox ps --stats
ID            NAME  RELEASE      SIZE  CPU       MEM     STARTED       COMMAND
1b4885590648  main  RUANWMCWUMQ  1280  6853.04%  87.02%  17 hours ago  sh -c bin/web
42431c5c2849  main  RUANWMCWUMQ  1280  2316.98%  87.18%  17 hours ago  sh -c bin/web
da4d710b8e3b  main  RUANWMCWUMQ  1280  4430.57%  79.85%  17 hours ago  sh -c bin/web
```

```
$ convox ps info 1b4885590648
Id       1b4885590648
Name     main
Release  RUANWMCWUMQ
Size     1280
CPU      7207.11%
Memory   81.57%
Started  17 hours ago
Command  sh -c bin/web
```