### PR TITLE
disable automatic updates of kernel* packages

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -858,6 +858,7 @@
           { "Fn::Join": [ "\n", [
             "#!/bin/bash",
             "fallocate -l 5G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile",
+            "echo 'exclude=kernel*' >> /etc/yum.conf",
             "yum -y update",
             "yum -y install aws-cfn-bootstrap",
             { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },


### PR DESCRIPTION
## Release Playbook
- [ ] Rebase against master
- [ ] Pass checks
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI

Running 'yum update' upgrades the kernel and leaves the OS in an inconsistent state without a reboot and cleanup of old kernel packages. It also causes problems when InstanceBootCommand tries to install e.g. kernel-devel-$(uname -r) which will resolve to the older version of the kernel.

The proposed fix is to disable automatic updates of kernel* packages in yum's config.

This resolves #501 