### PR TITLE
proxy protocol via label

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -94,7 +94,7 @@ $ docker-machine start default
 $ eval $(docker-machine env default)
 
 $ convox start
-RUNNING: docker build -t convox-start-icytafnqqb /Users/noah/go/src/github.com/convox/rack
+RUNNING: docker build -t convox-icytafnqqb /Users/noah/go/src/github.com/convox/rack
 web      | running: docker run -i --name rack-web...
 web      | [negroni] listening on :3000
 ```

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ release:
 	jq '.Parameters.Version.Default |= "$(VERSION)"' api/dist/kernel.json > kernel.json
 	aws s3 cp kernel.json s3://convox/release/$(VERSION)/formation.json --acl public-read
 
+templates:
+	make -C api templates
+
 test-deps:
 	go get -t -u ./...
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ cd $GOPATH/src/github.com/convox/rack
 
 $ docker-machine start default
 $ convox start
-RUNNING: docker build -t convox-start-icytafnqqb /Users/noah/go/src/github.com/convox/rack
+RUNNING: docker build -t convox-icytafnqqb /Users/noah/go/src/github.com/convox/rack
 web      | running: docker run -i --name rack-web...
 web      | [negroni] listening on :3000
 

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -715,7 +715,7 @@ func (me ManifestEntry) runAsync(m *Manifest, prefix, app, process string, cache
 		switch me.Label(fmt.Sprintf("com.convox.port.%s.protocol", container)) {
 		case "proxy":
 			rnd := RandomPort()
-			go proxyPort(host, fmt.Sprintf("%s:%d", gateway, rnd), ch)
+			go proxyPort(host, fmt.Sprintf("%s:%d", gateway, rnd))
 			host = strconv.Itoa(rnd)
 		}
 
@@ -821,7 +821,7 @@ func exists(filename string) bool {
 	return true
 }
 
-func proxyPort(from, to string, ch chan error) {
+func proxyPort(from, to string) {
 	cmd := Execer("docker", "run", "-p", fmt.Sprintf("%s:%s", from, from), "convox/proxy", from, to, "proxy")
 	go cmd.Run()
 }

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -745,8 +745,6 @@ func (me ManifestEntry) Label(key string) string {
 				}
 			}
 		}
-	default:
-		fmt.Printf("unknown %+v\n", labels)
 	}
 
 	return ""

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -822,8 +822,7 @@ func exists(filename string) bool {
 }
 
 func proxyPort(from, to string) {
-	cmd := Execer("docker", "run", "-p", fmt.Sprintf("%s:%s", from, from), "convox/proxy", from, to, "proxy")
-	go cmd.Run()
+	Execer("docker", "run", "-p", fmt.Sprintf("%s:%s", from, from), "convox/proxy", from, to, "proxy").Run()
 }
 
 func injectDockerfile(dir string) error {

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -35,6 +35,10 @@ var (
 	SignalWaiter = waitForSignal
 )
 
+var RandomPort = func() int {
+	return 10000 + rand.Intn(50000)
+}
+
 var Colors = []color.Attribute{color.FgCyan, color.FgYellow, color.FgGreen, color.FgMagenta, color.FgBlue}
 
 type Manifest map[string]ManifestEntry
@@ -693,11 +697,11 @@ func (me ManifestEntry) runAsync(m *Manifest, prefix, app, process string, cache
 	for _, port := range ports {
 		switch len(strings.Split(port, ":")) {
 		case 1:
-			alt := randomPort()
+			alt := RandomPort()
 			args = append(args, "-p", fmt.Sprintf("%d:%s", alt, port))
 			go forwardPort(me.Protocol(port), port, fmt.Sprintf("%s:%d", gateway, alt), ch)
 		case 2:
-			alt := randomPort()
+			alt := RandomPort()
 			dest := strings.Split(port, ":")[1]
 			args = append(args, "-p", fmt.Sprintf("%d:%s", alt, dest))
 			go forwardPort(me.Protocol(dest), strings.Split(port, ":")[0], fmt.Sprintf("%s:%d", gateway, alt), ch)
@@ -910,10 +914,6 @@ func randomString(prefix string, size int) string {
 		b[i] = randomAlphabet[rand.Intn(len(randomAlphabet))]
 	}
 	return prefix + string(b)
-}
-
-func randomPort() int {
-	return rand.Intn(50000) + 10000
 }
 
 var exposeEntryRegexp = regexp.MustCompile(`^EXPOSE\s+(\d+)`)

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -216,7 +216,7 @@ func (m *Manifest) Build(app, dir string, cache bool) []error {
 				return []error{err}
 			}
 			if _, ok := builds[sym]; !ok {
-				builds[sym] = randomString("convox-start-", 10)
+				builds[sym] = randomString("convox-", 10)
 			}
 
 			tags[tag] = builds[sym]

--- a/api/manifest/manifest_test.go
+++ b/api/manifest/manifest_test.go
@@ -108,6 +108,10 @@ func TestRun(t *testing.T) {
 			Output: `1.1.1.1`},
 	}
 
+	RandomPort = func() int {
+		return 20000
+	}
+
 	//NOTE: this is a compromise on top of another compromise
 	Execer = func(bin string, args ...string) *exec.Cmd {
 		found := false
@@ -131,7 +135,7 @@ func TestRun(t *testing.T) {
 	stdout, stderr := testRun(m, "compose")
 
 	cases := Cases{
-		{stdout, fmt.Sprintf("\x1b[36mpostgres |\x1b[0m running: docker run -i --name compose-postgres -p 5432:5432 compose/postgres\n\x1b[33mweb      |\x1b[0m running: docker run -i --name compose-web -e POSTGRES_HOST=1.1.1.1 -e POSTGRES_PASSWORD= -e POSTGRES_PATH= -e POSTGRES_PORT=5432 -e POSTGRES_SCHEME=tcp -e POSTGRES_URL=tcp://1.1.1.1:5432 -e POSTGRES_USERNAME= -p 5000:3000 -v %s:/app compose/web\n", destDir)},
+		{stdout, fmt.Sprintf("\x1b[36mpostgres |\x1b[0m running: docker run -i --name compose-postgres -p 20000:5432 compose/postgres\n\x1b[33mweb      |\x1b[0m running: docker run -i --name compose-web -e POSTGRES_HOST=1.1.1.1 -e POSTGRES_PASSWORD= -e POSTGRES_PATH= -e POSTGRES_PORT=5432 -e POSTGRES_SCHEME=tcp -e POSTGRES_URL=tcp://1.1.1.1:5432 -e POSTGRES_USERNAME= -p 20000:3000 -v %s:/app compose/web\n", destDir)},
 		{stderr, ""},
 	}
 

--- a/api/manifest/manifest_test.go
+++ b/api/manifest/manifest_test.go
@@ -108,10 +108,6 @@ func TestRun(t *testing.T) {
 			Output: `1.1.1.1`},
 	}
 
-	RandomPort = func() int {
-		return 20000
-	}
-
 	//NOTE: this is a compromise on top of another compromise
 	Execer = func(bin string, args ...string) *exec.Cmd {
 		found := false
@@ -135,7 +131,7 @@ func TestRun(t *testing.T) {
 	stdout, stderr := testRun(m, "compose")
 
 	cases := Cases{
-		{stdout, fmt.Sprintf("\x1b[36mpostgres |\x1b[0m running: docker run -i --name compose-postgres -p 20000:5432 compose/postgres\n\x1b[33mweb      |\x1b[0m running: docker run -i --name compose-web -e POSTGRES_HOST=1.1.1.1 -e POSTGRES_PASSWORD= -e POSTGRES_PATH= -e POSTGRES_PORT=5432 -e POSTGRES_SCHEME=tcp -e POSTGRES_URL=tcp://1.1.1.1:5432 -e POSTGRES_USERNAME= -p 20000:3000 -v %s:/app compose/web\n", destDir)},
+		{stdout, fmt.Sprintf("\x1b[36mpostgres |\x1b[0m running: docker run -i --name compose-postgres -p 5432:5432 compose/postgres\n\x1b[33mweb      |\x1b[0m running: docker run -i --name compose-web -e POSTGRES_HOST=1.1.1.1 -e POSTGRES_PASSWORD= -e POSTGRES_PATH= -e POSTGRES_PORT=5432 -e POSTGRES_SCHEME=tcp -e POSTGRES_URL=tcp://1.1.1.1:5432 -e POSTGRES_USERNAME= -p 5000:3000 -v %s:/app compose/web\n", destDir)},
 		{stderr, ""},
 	}
 

--- a/api/models/manifest.go
+++ b/api/models/manifest.go
@@ -26,6 +26,7 @@ type ManifestEntry struct {
 	Env        []string                 `yaml:"environment"`
 	Exports    map[string]string        `yaml:"-"`
 	Image      string                   `yaml:"image"`
+	Labels     interface{}              `yaml:"labels"`
 	Links      []string                 `yaml:"links"`
 	LinkVars   map[string]template.HTML `yaml:"-"`
 	Ports      []string                 `yaml:"ports"`
@@ -306,6 +307,27 @@ func (me *ManifestEntry) CommandString() string {
 		fmt.Fprintf(os.Stderr, "unexpected type for command: %T\n", cmd)
 		return ""
 	}
+}
+
+func (me ManifestEntry) Label(key string) string {
+	switch labels := me.Labels.(type) {
+	case map[interface{}]interface{}:
+		for k, v := range labels {
+			if k.(string) == key {
+				return v.(string)
+			}
+		}
+	case []interface{}:
+		for _, label := range labels {
+			if parts := strings.SplitN(label.(string), "=", 2); len(parts) == 2 {
+				if parts[0] == key {
+					return parts[1]
+				}
+			}
+		}
+	}
+
+	return ""
 }
 
 func (me ManifestEntry) InternalPorts() []string {


### PR DESCRIPTION
This change automatically sets up a TCP proxy in front of your listeners in `convox start`. It looks for labels to decide whether or not to use `PROXY` protocol:

`com.convox.port.NNNN.protocol=<http|tcp|proxy>`

If you set a `docker-compose.yml` like this:

```
web:
  build: .
  labels:
    - "com.convox.port.5000.protocol=proxy"
  ports:
    443:5000
```

Then the following will happen:
* `convox start` will inject a TCP proxy in front of your app that sends the `PROXY` header to your app
* The `WebPort443ProxyProtocol` will be set to `Yes` during release promotion.

The `http` and `tcp` values for this label are not yet handled but they could potentially be used to switch between HTTP and TCP listener types.

## Release Playbook
- [x] Rebase against master
- [x] Pass checks
- [x] Release branch (20160402173618-proxy-protocol-start)
- [x] Pass CI (https://circleci.com/gh/convox/rack/686)
- [x] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI
