### PR TITLE
amzn-ami-2016.03.a-amazon-ecs-optimized

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -13,14 +13,14 @@
   },
   "Mappings": {
     "RegionConfig": {
-      "us-east-1": { "Ami": "ami-33b48a59" },
-      "us-west-1": { "Ami": "ami-26f78746" },
-      "us-west-2": { "Ami": "ami-65866a05" },
-      "eu-west-1": { "Ami": "ami-77ab1504" },
-      "eu-central-1": { "Ami": "ami-341efb5b" },
-      "ap-northeast-1": { "Ami": "ami-b3afa2dd" },
-      "ap-southeast-1": { "Ami": "ami-0cb0786f" },
-      "ap-southeast-2": { "Ami": "ami-cf6342ac" }
+      "us-east-1": { "Ami": "ami-67a3a90d" },
+      "us-west-1": { "Ami": "ami-b7d5a8d7" },
+      "us-west-2": { "Ami": "ami-c7a451a7" },
+      "eu-west-1": { "Ami": "ami-9c9819ef" },
+      "eu-central-1": { "Ami": "ami-9aeb0af5" },
+      "ap-northeast-1": { "Ami": "ami-7e4a5b10" },
+      "ap-southeast-1": { "Ami": "ami-be63a9dd" },
+      "ap-southeast-2": { "Ami": "ami-b8cbe8db" }
     }
   },
   "Outputs": {


### PR DESCRIPTION
Followup to https://github.com/convox/rack/pull/512, releasing with https://github.com/convox/rack/pull/509