### PR TITLE
Custom::EC2AvailabilityZones Bugfix

### DIFF
--- a/api/cmd/formation/handler/ec2.go
+++ b/api/cmd/formation/handler/ec2.go
@@ -101,8 +101,15 @@ func EC2AvailabilityZonesCreate(req Request) (string, map[string]string, error) 
 }
 
 func EC2AvailabilityZonesUpdate(req Request) (string, map[string]string, error) {
+	azs := strings.Split(req.PhysicalResourceId, ",")
+
+	outputs := make(map[string]string)
+	for i, az := range azs {
+		outputs["AvailabilityZone"+strconv.Itoa(i)] = az
+	}
+
 	// nop
-	return req.PhysicalResourceId, nil, nil
+	return req.PhysicalResourceId, outputs, nil
 }
 
 func EC2AvailabilityZonesDelete(req Request) (string, map[string]string, error) {


### PR DESCRIPTION
Updates in us-west-2 were failing because of:

```
UPDATE_IN_PROGRESS	Custom::EC2AvailabilityZones	AvailabilityZones
UPDATE_COMPLETE	Custom::EC2AvailabilityZones	AvailabilityZones	

UPDATE_FAILED	AWS::EC2::Subnet	Subnet1

CustomResource attribute error: Vendor response doesn't contain AvailabilityZone1 key in object arn:aws:cloudformation:us-west-2:132866487567:stack/west/9def75e0-f5da-11e5-95b7-50d5ca2e7cd2|AvailabilityZones|727035d2-aa3d-457c-80bc-2987a3eb9e46 in S3 bucket cloudformation-custom-resource-storage-uswest2
```

It's not clear why `Custom::EC2AvailabilityZones` is getting updated, as this isn't happening in us-east-1 and doesn't make sense. 

However, it is clear that the EC2AvailabilityZones update handler was not returning any data, where the AWS::EC2::Subnet resource is expecting to read AvailabilityZone1, AvailabilityZone2, AvailabilityZone3 from its response.

This patch returns the same handler response in Update as Create.

## Release Playbook
- [x] Rebase against master
- [x] Pass checks
- [x] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI

