### PR TITLE
Custom::EC2NatGateway update doesnt error

### DIFF
--- a/api/cmd/formation/handler/ec2.go
+++ b/api/cmd/formation/handler/ec2.go
@@ -131,7 +131,7 @@ func EC2NatGatewayCreate(req Request) (string, map[string]string, error) {
 }
 
 func EC2NatGatewayUpdate(req Request) (string, map[string]string, error) {
-	return req.PhysicalResourceId, nil, fmt.Errorf("could not update")
+	return req.PhysicalResourceId, nil, nil
 }
 
 func EC2NatGatewayDelete(req Request) (string, map[string]string, error) {


### PR DESCRIPTION
Similar to https://github.com/convox/rack/pull/524, I observed CloudFormation errors updating the Custom::EC2NatGateway:

```
18:35:13 UTC-0700	UPDATE_ROLLBACK_FAILED	AWS::CloudFormation::Stack	convox	The following resource(s) failed to update: [NatGateway2, NatGateway1].
18:35:11 UTC-0700	UPDATE_FAILED	Custom::EC2NatGateway	NatGateway1	Failed to update resource. could not update
18:35:10 UTC-0700	UPDATE_FAILED	Custom::EC2NatGateway	NatGateway2	Failed to update resource. could not update
```
