### PR TITLE
RFC: Manifest refactor / rewrite

### DIFF
--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -135,10 +135,22 @@ func BuildUpdate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		return httperr.Server(err)
 	}
 
-	b.Ended = time.Now()
-	b.Manifest = r.FormValue("manifest")
-	b.Reason = r.FormValue("reason")
-	b.Status = r.FormValue("status")
+	if d := r.FormValue("description"); d != "" {
+		b.Description = d
+	}
+
+	if m := r.FormValue("manifest"); m != "" {
+		b.Manifest = m
+	}
+
+	if r := r.FormValue("reason"); r != "" {
+		b.Reason = r
+	}
+
+	if s := r.FormValue("status"); s != "" {
+		b.Status = s
+		b.Ended = time.Now()
+	}
 
 	// if build was successful create a release
 	if b.Status == "complete" && b.Manifest != "" {
@@ -146,8 +158,11 @@ func BuildUpdate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		if err != nil {
 			return httperr.Server(err)
 		}
-	} else {
-		provider.BuildSave(b)
+	}
+
+	err = provider.BuildSave(b)
+	if err != nil {
+		return httperr.Server(err)
 	}
 
 	return RenderJson(rw, b)

--- a/api/manifest.yml
+++ b/api/manifest.yml
@@ -191,6 +191,48 @@ paths:
           description: not found
           schema:
             $ref: '#/definitions/error'
+    put:
+      description: Update build status
+      parameters:
+      - name: app
+        description: app name
+        type: string
+        in: path
+        required: true
+      - name: build
+        description: build id
+        type: string
+        in: path
+        required: true
+      - name: description
+        description: build description
+        type: string
+        in: formData
+        required: false
+      - name: manifest
+        description: release manifest extracted during build
+        type: string
+        in: formData
+        required: false
+      - name: reason
+        description: reason with status "failed"
+        type: string
+        in: formData
+        required: false
+      - name: status
+        description: final build status "complete" or "failed"
+        type: string
+        in: formData
+        required: false
+      responses:
+        200:
+          description: build
+          schema:
+            $ref: '#/definitions/build'
+        404:
+          description: not found
+          schema:
+            $ref: '#/definitions/error'
   /apps/{app}/environment:
     get:
       description: List environment for an app

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -35,6 +35,8 @@ var (
 	Stderr       = io.Writer(os.Stderr)
 	Execer       = exec.Command
 	SignalWaiter = waitForSignal
+
+	regexValidProcessName = regexp.MustCompile(`\A[a-zA-Z0-9][-a-zA-Z0-9]{0,29}\z`) // 'web', '1', 'web-1' valid; '-', 'web_1' invalid
 )
 
 var (
@@ -157,6 +159,10 @@ func Read(dir, filename string) (*Manifest, error) {
 	}
 
 	for name, entry := range m {
+		if !regexValidProcessName.MatchString(name) {
+			return &m, fmt.Errorf("process name %q is invalid. It should contain only alphanumeric characters and dashes.", name)
+		}
+
 		for i, volume := range entry.Volumes {
 			parts := strings.Split(volume, ":")
 

--- a/composure/Readme.md
+++ b/composure/Readme.md
@@ -1,0 +1,13 @@
+# composure
+
+The composure package defines structure to describe everything about an app, and tooling to take an app seamlessly from development to production.
+
+This package borrows a lot of ideas and functionality from `docker-compose`, but executes everything "the convox way" which:
+
+* Has strong opinions about how apps will run in production, and works backwards to development
+* Uses conventions (not configuration) to build and run apps
+* Removes Docker options (like networks and linking) that do not work well in production
+* Follows 12 factor, especially using environment variables to connect to backing services
+* Adds simple things to a development environment that mimic production, like a TCP load balancer
+
+This package facilitates a universal `convox build` that runs as part of `convox start` on a local machine, and `convox deploy` on a production Rack API. It also defines a canonical app configuration that can be turned into production resources on cloud provider.

--- a/composure/compose_test.go
+++ b/composure/compose_test.go
@@ -1,12 +1,13 @@
 package composure
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/convox/rack/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/docker"
 	"github.com/docker/libcompose/project"
+	"github.com/docker/libcompose/yaml"
 )
 
 func TestNewProject(t *testing.T) {
@@ -16,8 +17,57 @@ func TestNewProject(t *testing.T) {
 			ProjectName:  "httpd",
 		},
 	})
-
 	assert.Nil(t, err)
 
-	fmt.Printf("PROJECT: %+v\n", project)
+	s, ok := project.Configs.Get("web")
+	assert.True(t, ok)
+	assert.EqualValues(t, &config.ServiceConfig{
+		Build:         "",
+		CapAdd:        []string(nil),
+		CapDrop:       []string(nil),
+		CgroupParent:  "",
+		CPUQuota:      0,
+		CPUSet:        "",
+		CPUShares:     0,
+		Command:       yaml.Command{},
+		ContainerName: "",
+		Devices:       []string(nil),
+		DNS:           yaml.Stringorslice{},
+		DNSSearch:     yaml.Stringorslice{},
+		Dockerfile:    "",
+		DomainName:    "",
+		Entrypoint:    yaml.Command{},
+		EnvFile:       yaml.Stringorslice{},
+		Environment:   yaml.MaporEqualSlice{},
+		Hostname:      "",
+		Image:         "httpd",
+		Labels:        yaml.SliceorMap{},
+		Links:         yaml.MaporColonSlice{},
+		LogDriver:     "",
+		MacAddress:    "",
+		MemLimit:      0,
+		MemSwapLimit:  0,
+		Name:          "",
+		Net:           "",
+		Pid:           "",
+		Uts:           "",
+		Ipc:           "",
+		Ports:         []string{"80:80"},
+		Privileged:    false,
+		Restart:       "",
+		ReadOnly:      false,
+		StdinOpen:     false,
+		SecurityOpt:   []string(nil),
+		Tty:           false,
+		User:          "",
+		VolumeDriver:  "",
+		Volumes:       []string(nil),
+		VolumesFrom:   []string(nil),
+		WorkingDir:    "",
+		Expose:        []string(nil),
+		ExternalLinks: []string(nil),
+		LogOpt:        map[string]string(nil),
+		ExtraHosts:    []string(nil),
+		Ulimits:       yaml.Ulimits{Elements: []yaml.Ulimit(nil)},
+	}, s)
 }

--- a/composure/compose_test.go
+++ b/composure/compose_test.go
@@ -1,0 +1,23 @@
+package composure
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/convox/rack/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+	"github.com/docker/libcompose/docker"
+	"github.com/docker/libcompose/project"
+)
+
+func TestNewProject(t *testing.T) {
+	project, err := docker.NewProject(&docker.Context{
+		Context: project.Context{
+			ComposeFiles: []string{"fixtures/httpd.yml"},
+			ProjectName:  "httpd",
+		},
+	})
+
+	assert.Nil(t, err)
+
+	fmt.Printf("PROJECT: %+v\n", project)
+}

--- a/composure/composure.go
+++ b/composure/composure.go
@@ -1,0 +1,1 @@
+package composure

--- a/composure/composure.go
+++ b/composure/composure.go
@@ -1,1 +1,7 @@
 package composure
+
+import "github.com/convox/rack/composure/provider"
+
+func Start(path, manifestfile string) error {
+	return provider.CurrentProvider.ManifestRun(path, manifestfile)
+}

--- a/composure/composure.go
+++ b/composure/composure.go
@@ -5,3 +5,7 @@ import "github.com/convox/rack/composure/provider"
 func Start(path, manifestfile string) error {
 	return provider.CurrentProvider.ManifestRun(path, manifestfile)
 }
+
+func Archive(path, manifestfile, registry, repository string) error {
+	return provider.CurrentProvider.ManifestPush(path, manifestfile, registry, repository)
+}

--- a/composure/composure_test.go
+++ b/composure/composure_test.go
@@ -4,8 +4,16 @@ import (
 	"testing"
 
 	"github.com/convox/rack/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+	"github.com/convox/rack/composure/provider"
+	"github.com/convox/rack/composure/structs"
 )
 
 func TestNil(t *testing.T) {
 	assert.Nil(t, nil)
+}
+
+func TestPull(t *testing.T) {
+	m, err := provider.CurrentProvider.Load("fixtures/httpd.yml")
+	assert.Nil(t, err)
+	assert.EqualValues(t, &structs.Manifest{}, m)
 }

--- a/composure/composure_test.go
+++ b/composure/composure_test.go
@@ -1,0 +1,11 @@
+package composure
+
+import (
+	"testing"
+
+	"github.com/convox/rack/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+)
+
+func TestNil(t *testing.T) {
+	assert.Nil(t, nil)
+}

--- a/composure/composure_test.go
+++ b/composure/composure_test.go
@@ -12,8 +12,89 @@ func TestNil(t *testing.T) {
 	assert.Nil(t, nil)
 }
 
-func TestPull(t *testing.T) {
-	m, err := provider.CurrentProvider.Load("fixtures/httpd.yml")
+// TestStart asserts the order of interface calls to:
+//  Read a project and manifest from an app directory
+//  Pull, build and tag images
+//  Introspect manifest, network and images to determine LINK_ environment
+//  Run processes with the correct image, command and environment options
+func TestStart(t *testing.T) {
+	// set current provider
+	testProvider := &provider.TestProviderRunner{}
+	provider.CurrentProvider = testProvider
+
+	// Start() with a project directory and docker-compose.yml manifest
+	testProvider.On("ManifestRun", ".", "docker-compose.yml")
+	testProvider.On("ProjectName", ".").Return("myapp", nil)
+	testProvider.On("ManifestLoad", ".", "docker-compose.yml").Return(&structs.Manifest{
+		"web": structs.ManifestEntry{
+			Image:       "httpd",
+			Environment: []string{"REDIS_URL"},
+			Links:       []string{"redis"},
+			Ports:       []string{"80:80"},
+		},
+		"worker": structs.ManifestEntry{
+			Build:       ".",
+			Dockerfile:  "Dockerfile-worker",
+			Command:     []string{"node", "worker.js"},
+			Environment: []string{"REDIS_URL", "MAX_QUEUE_DEPTH=10"},
+			Links:       []string{"redis"},
+		},
+		"redis": structs.ManifestEntry{
+			Image:       "convox/redis",
+			Environment: []string{"LINK_PATH=/1"}, // demonstrate overriding or filling in for a missing LINK_PATH on convox/redis
+			Ports:       []string{"6379"},
+		},
+	}, nil)
+
+	// pull, build and tag all images
+	testProvider.On("ImagePull", "httpd").Return(nil)
+	testProvider.On("ImageTag", "httpd", "myapp/web").Return(nil)
+
+	testProvider.On("ImagePull", "convox/redis").Return(nil)
+	testProvider.On("ImageTag", "convox/redis", "myapp/redis").Return(nil)
+
+	testProvider.On("ImageBuild", ".", "Dockerfile-worker", "convox-xvlbzgbaic").Return(nil)
+	testProvider.On("ImageTag", "convox-xvlbzgbaic", "myapp/worker").Return(nil)
+
+	// introspect runtime options
+	testProvider.On("NetworkInspect").Return("172.17.0.1", nil)
+
+	testProvider.On("ImageInspect", "myapp/redis").Return(map[string]string{
+		"LINK_URL":      "redis://redis:password@172.17.0.1:6379/1",
+		"LINK_HOST":     "172.17.0.1",
+		"LINK_SCHEME":   "redis",
+		"LINK_PORT":     "6379",
+		"LINK_USERNAME": "redis",
+		"LINK_PASSWORD": "password",
+		"LINK_PATH":     "/0",
+	}, nil)
+
+	// run containers
+	testProvider.On("ProcessRun", "myapp/web", []string{}, "myapp-web", []string{"80:80"}, map[string]string{
+		"REDIS_URL":      "redis://redis:password@172.17.0.1:6379/1",
+		"REDIS_HOST":     "172.17.0.1",
+		"REDIS_SCHEME":   "redis",
+		"REDIS_PORT":     "6379",
+		"REDIS_USERNAME": "redis",
+		"REDIS_PASSWORD": "password",
+		"REDIS_PATH":     "/1",
+	}).Return(nil)
+
+	testProvider.On("ProcessRun", "myapp/worker", []string{"node", "worker.js"}, "myapp-worker", []string{}, map[string]string{
+		"MAX_QUEUE_DEPTH": "10",
+		"REDIS_URL":       "redis://redis:password@172.17.0.1:6379/1",
+		"REDIS_HOST":      "172.17.0.1",
+		"REDIS_SCHEME":    "redis",
+		"REDIS_PORT":      "6379",
+		"REDIS_USERNAME":  "redis",
+		"REDIS_PASSWORD":  "password",
+		"REDIS_PATH":      "/1",
+	}).Return(nil)
+
+	testProvider.On("ProcessRun", "myapp/redis", []string{}, "myapp-redis", []string{"6379"}, map[string]string{
+		"LINK_PATH": "/1",
+	}).Return(nil)
+
+	err := Start(".", "docker-compose.yml")
 	assert.Nil(t, err)
-	assert.EqualValues(t, &structs.Manifest{}, m)
 }

--- a/composure/fixtures/httpd.yml
+++ b/composure/fixtures/httpd.yml
@@ -1,0 +1,4 @@
+web:
+  image: httpd
+  ports:
+    - 80:80

--- a/composure/provider/docker/docker.go
+++ b/composure/provider/docker/docker.go
@@ -1,0 +1,27 @@
+package docker
+
+import (
+	"fmt"
+
+	"github.com/convox/rack/composure/structs"
+)
+
+type DockerProvider struct {
+	Host string
+}
+
+func NewProvider() (*DockerProvider, error) {
+	p := &DockerProvider{
+		Host: "tcp://192.168.99.100:2376",
+	}
+
+	return p, nil
+}
+
+func (p *DockerProvider) Load(path string) (*structs.Manifest, error) {
+	return &structs.Manifest{}, fmt.Errorf("can not load")
+}
+
+func (p *DockerProvider) Pull(m *structs.Manifest) error {
+	return fmt.Errorf("can not pull")
+}

--- a/composure/provider/provider.go
+++ b/composure/provider/provider.go
@@ -2,26 +2,36 @@ package provider
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 
-	"github.com/convox/rack/composure/provider/docker"
 	"github.com/convox/rack/composure/structs"
 )
 
 var CurrentProvider Provider
 
 type Provider interface {
-	Load(path string) (*structs.Manifest, error)
+	ImageBuild(string, string, string) error
+	ImageInspect(string) (map[string]string, error)
+	ImagePull(string) error
+	ImageTag(string, string) error
 
-	Pull(*structs.Manifest) error
+	NetworkInspect() (string, error)
+
+	ManifestLoad(string, string) (*structs.Manifest, error)
+	ManifestRun(string, string) error
+
+	ProcessRun(string, []string, string, []string, map[string]string) error
+
+	ProjectName(string) (string, error)
 }
 
 func init() {
 	var err error
 
 	switch os.Getenv("PROVIDER") {
-	case "docker":
-		CurrentProvider, err = docker.NewProvider()
+	// case "docker":
+	// 	CurrentProvider, err = docker.NewProvider()
 	case "test":
 		CurrentProvider = TestProvider
 	default:
@@ -35,12 +45,40 @@ func init() {
 
 /** package-level functions ************************************************************************/
 
-func Load(path string) (*structs.Manifest, error) {
-	return CurrentProvider.Load(path)
+func ImageBuild(path, dockerfile, tag string) error {
+	return CurrentProvider.ImageBuild(path, dockerfile, tag)
 }
 
-func Pull(m *structs.Manifest) error {
-	return CurrentProvider.Pull(m)
+func ImageInspect(tag string) (map[string]string, error) {
+	return CurrentProvider.ImageInspect(tag)
+}
+
+func ImagePull(name string) error {
+	return CurrentProvider.ImagePull(name)
+}
+
+func ImageTag(name, tag string) error {
+	return CurrentProvider.ImageTag(name, tag)
+}
+
+func NetworkInspect() (string, error) {
+	return CurrentProvider.NetworkInspect()
+}
+
+func ManifestLoad(path, manifestfile string) (*structs.Manifest, error) {
+	return CurrentProvider.ManifestLoad(path, manifestfile)
+}
+
+func ManifestRun(path, manifestfile string) error {
+	return CurrentProvider.ManifestRun(path, manifestfile)
+}
+
+func ProcessRun(tag string, args []string, name string, ports []string, env map[string]string) error {
+	return CurrentProvider.ProcessRun(tag, args, name, ports, env)
+}
+
+func ProjectName(path string) (string, error) {
+	return CurrentProvider.ProjectName(path)
 }
 
 /** helpers ****************************************************************************************/
@@ -48,4 +86,14 @@ func Pull(m *structs.Manifest) error {
 func die(err error) {
 	fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 	os.Exit(1)
+}
+
+var randomAlphabet = []rune("abcdefghijklmnopqrstuvwxyz")
+
+func randomString(prefix string, size int) string {
+	b := make([]rune, size)
+	for i := range b {
+		b[i] = randomAlphabet[rand.Intn(len(randomAlphabet))]
+	}
+	return prefix + string(b)
 }

--- a/composure/provider/provider.go
+++ b/composure/provider/provider.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/convox/rack/composure/provider/docker"
+	"github.com/convox/rack/composure/structs"
+)
+
+var CurrentProvider Provider
+
+type Provider interface {
+	Load(path string) (*structs.Manifest, error)
+
+	Pull(*structs.Manifest) error
+}
+
+func init() {
+	var err error
+
+	switch os.Getenv("PROVIDER") {
+	case "docker":
+		CurrentProvider, err = docker.NewProvider()
+	case "test":
+		CurrentProvider = TestProvider
+	default:
+		die(fmt.Errorf("PROVIDER must be one of (docker, test)"))
+	}
+
+	if err != nil {
+		die(err)
+	}
+}
+
+/** package-level functions ************************************************************************/
+
+func Load(path string) (*structs.Manifest, error) {
+	return CurrentProvider.Load(path)
+}
+
+func Pull(m *structs.Manifest) error {
+	return CurrentProvider.Pull(m)
+}
+
+/** helpers ****************************************************************************************/
+
+func die(err error) {
+	fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+	os.Exit(1)
+}

--- a/composure/provider/provider.go
+++ b/composure/provider/provider.go
@@ -14,11 +14,14 @@ type Provider interface {
 	ImageBuild(string, string, string) error
 	ImageInspect(string) (map[string]string, error)
 	ImagePull(string) error
+	ImagePush(string, string) error
 	ImageTag(string, string) error
 
 	NetworkInspect() (string, error)
 
+	ManifestBuild(string, string) (map[string]string, error)
 	ManifestLoad(string, string) (*structs.Manifest, error)
+	ManifestPush(string, string, string, string) error
 	ManifestRun(string, string) error
 
 	ProcessRun(string, []string, string, []string, map[string]string) error
@@ -57,6 +60,10 @@ func ImagePull(name string) error {
 	return CurrentProvider.ImagePull(name)
 }
 
+func ImagePush(name string, url string) error {
+	return CurrentProvider.ImagePush(name, url)
+}
+
 func ImageTag(name, tag string) error {
 	return CurrentProvider.ImageTag(name, tag)
 }
@@ -65,8 +72,16 @@ func NetworkInspect() (string, error) {
 	return CurrentProvider.NetworkInspect()
 }
 
+func ManifestBuild(path, manifestfile string) (map[string]string, error) {
+	return CurrentProvider.ManifestBuild(path, manifestfile)
+}
+
 func ManifestLoad(path, manifestfile string) (*structs.Manifest, error) {
 	return CurrentProvider.ManifestLoad(path, manifestfile)
+}
+
+func ManifestPush(path, manifestfile, registry, repository string) error {
+	return CurrentProvider.ManifestPush(path, manifestfile, registry, repository)
 }
 
 func ManifestRun(path, manifestfile string) error {

--- a/composure/provider/test.go
+++ b/composure/provider/test.go
@@ -1,0 +1,23 @@
+package provider
+
+import (
+	"github.com/convox/rack/composure/structs"
+	"github.com/stretchr/testify/mock"
+)
+
+var TestProvider = &TestProviderRunner{}
+
+type TestProviderRunner struct {
+	mock.Mock
+	Manifest structs.Manifest
+}
+
+func (p *TestProviderRunner) Load(path string) (*structs.Manifest, error) {
+	p.Called(path)
+	return &p.Manifest, nil
+}
+
+func (p *TestProviderRunner) Pull(m *structs.Manifest) error {
+	p.Called(m)
+	return nil
+}

--- a/composure/provider/test.go
+++ b/composure/provider/test.go
@@ -1,6 +1,9 @@
 package provider
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/convox/rack/composure/structs"
 	"github.com/stretchr/testify/mock"
 )
@@ -9,15 +12,167 @@ var TestProvider = &TestProviderRunner{}
 
 type TestProviderRunner struct {
 	mock.Mock
-	Manifest structs.Manifest
 }
 
-func (p *TestProviderRunner) Load(path string) (*structs.Manifest, error) {
-	p.Called(path)
-	return &p.Manifest, nil
-}
-
-func (p *TestProviderRunner) Pull(m *structs.Manifest) error {
-	p.Called(m)
+func (p *TestProviderRunner) ImageBuild(path, dockerfile, tag string) error {
+	p.Called(path, dockerfile, tag)
 	return nil
+}
+
+func (p *TestProviderRunner) ImageInspect(tag string) (map[string]string, error) {
+	args := p.Called(tag)
+	return args.Get(0).(map[string]string), args.Error(1)
+}
+
+func (p *TestProviderRunner) ImagePull(name string) error {
+	p.Called(name)
+	return nil
+}
+
+func (p *TestProviderRunner) ImageTag(name, tag string) error {
+	p.Called(name, tag)
+	return nil
+}
+
+func (p *TestProviderRunner) NetworkInspect() (string, error) {
+	args := p.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (p *TestProviderRunner) ManifestLoad(path, manifestfile string) (*structs.Manifest, error) {
+	args := p.Called(path, manifestfile)
+	return args.Get(0).(*structs.Manifest), args.Error(1)
+}
+
+func (p *TestProviderRunner) ManifestRun(path, manifestfile string) error {
+	p.Called(path, manifestfile)
+
+	projectName, err := p.ProjectName(path)
+	if err != nil {
+		return err
+	}
+
+	m, err := p.ManifestLoad(path, manifestfile)
+	if err != nil {
+		return err
+	}
+
+	// pull, build and tag images
+	nameTags := map[string]string{}
+	for serviceName, entry := range *m {
+		tag := fmt.Sprintf("%s/%s", projectName, serviceName)
+		nameTags[serviceName] = tag
+
+		if entry.Image != "" {
+			p.ImagePull(entry.Image)
+			p.ImageTag(entry.Image, tag)
+		} else if entry.Build != "" {
+			df := entry.Dockerfile
+			if df == "" {
+				df = "Dockerfile"
+			}
+
+			tmpTag := randomString("convox-", 10)
+			p.ImageBuild(path, df, tmpTag)
+			p.ImageTag(tmpTag, tag)
+		}
+	}
+
+	// introspect environment for containers that are linked to
+	nameEnv := map[string]map[string]string{}
+	for serviceName, entry := range *m {
+		for _, l := range entry.Links {
+			tag, ok := nameTags[l]
+			if !ok {
+				return fmt.Errorf("%q link to %q is invalid", serviceName, l)
+			}
+
+			// inspect image for Dockerfile ENV LINK_ vars
+			env, err := p.ImageInspect(tag)
+			if err != nil {
+				return err
+			}
+
+			nameEnv[l] = env
+
+			// inspect manifest entry for overridden or filled in LINK_ vars
+			env = map[string]string{}
+			switch e := (*m)[l].Environment.(type) {
+			case []string:
+				for _, kv := range e {
+					parts := strings.SplitN(kv, "=", 2)
+					if len(parts) == 2 {
+						env[parts[0]] = parts[1]
+					}
+				}
+			}
+
+			for k, v := range env {
+				if strings.HasPrefix(k, "LINK_") {
+					nameEnv[l][k] = v
+				}
+			}
+		}
+	}
+
+	// run containers
+	for serviceName, entry := range *m {
+		name := fmt.Sprintf("%s-%s", projectName, serviceName)
+		tag := fmt.Sprintf("%s/%s", projectName, serviceName)
+
+		cmd := []string{}
+		switch c := entry.Command.(type) {
+		case string:
+			if c != "" {
+				cmd = append(cmd, "sh", "-c", c)
+			}
+		case []string:
+			cmd = append(cmd, c...)
+		}
+
+		ports := []string{}
+		switch p := entry.Ports.(type) {
+		case string:
+			if p != "" {
+				ports = append(ports, p)
+			}
+		case []string:
+			ports = append(ports, p...)
+		}
+
+		env := map[string]string{}
+		switch e := entry.Environment.(type) {
+		case []string:
+			for _, kv := range e {
+				parts := strings.SplitN(kv, "=", 2)
+				if len(parts) == 2 {
+					env[parts[0]] = parts[1]
+				}
+			}
+		}
+
+		for _, l := range entry.Links {
+			for k, v := range nameEnv[l] {
+				rk := strings.Replace(k, "LINK_", fmt.Sprintf("%s_", strings.ToUpper(l)), 1)
+				env[rk] = v
+			}
+		}
+
+		err := p.ProcessRun(tag, cmd, name, ports, env)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *TestProviderRunner) ProcessRun(tag string, args []string, name string, ports []string, env map[string]string) error {
+	p.Called(tag, args, name, ports, env)
+	return nil
+}
+
+func (p *TestProviderRunner) ProjectName(path string) (string, error) {
+	args := p.Called(path)
+	return args.String(0), args.Error(1)
 }

--- a/composure/structs/manifest.go
+++ b/composure/structs/manifest.go
@@ -1,0 +1,22 @@
+package structs
+
+type Manifest map[string]ManifestEntry
+
+type ManifestV2 struct {
+	Version  string
+	Services Manifest
+}
+
+type ManifestEntry struct {
+	Build       string      `yaml:"build,omitempty"`
+	Dockerfile  string      `yaml:"dockerfile,omitempty"`
+	Image       string      `yaml:"image,omitempty"`
+	Command     interface{} `yaml:"command,omitempty"`
+	Entrypoint  string      `yaml:"entrypoint,omitempty"`
+	Environment interface{} `yaml:"environment,omitempty"`
+	Labels      interface{} `yaml:"labels,omitempty"`
+	Links       []string    `yaml:"links,omitempty"`
+	Ports       interface{} `yaml:"ports,omitempty"`
+	Privileged  bool        `yaml:"privileged,omitempty"`
+	Volumes     []string    `yaml:"volumes,omitempty"`
+}


### PR DESCRIPTION
Applies the "provider interface" pattern to the manifest package. The goal is to:

* Easily test the build / start / push steps through a test provider
* Port over a Docker Shell provider
* Lay grounds for a Docker Client provider