### PR TITLE
don't try to get terminal size when not a tty

### DIFF
--- a/cmd/convox/run.go
+++ b/cmd/convox/run.go
@@ -108,8 +108,6 @@ func runAttached(c *cli.Context, app, ps, args, release string) (int, error) {
 	var w, h int
 
 	if terminal.IsTerminal(int(fd)) {
-		fmt.Println("isterm")
-
 		stdinState, err := terminal.GetState(int(fd))
 
 		if err != nil {

--- a/cmd/convox/run.go
+++ b/cmd/convox/run.go
@@ -105,7 +105,11 @@ func cmdRunDetached(c *cli.Context) {
 func runAttached(c *cli.Context, app, ps, args, release string) (int, error) {
 	fd := os.Stdin.Fd()
 
+	var w, h int
+
 	if terminal.IsTerminal(int(fd)) {
+		fmt.Println("isterm")
+
 		stdinState, err := terminal.GetState(int(fd))
 
 		if err != nil {
@@ -113,12 +117,12 @@ func runAttached(c *cli.Context, app, ps, args, release string) (int, error) {
 		}
 
 		defer terminal.Restore(int(fd), stdinState)
-	}
 
-	w, h, err := terminal.GetSize(int(fd))
+		w, h, err = terminal.GetSize(int(fd))
 
-	if err != nil {
-		return -1, err
+		if err != nil {
+			return -1, err
+		}
 	}
 
 	code, err := rackClient(c).RunProcessAttached(app, ps, args, release, h, w, os.Stdin, os.Stdout)


### PR DESCRIPTION
When `convox run` is run outside of a TTY it is currently returning this error:

    ERROR: operation not supported by device

## Release Playbook
- [ ] Rebase against master
- [ ] Pass checks
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI

