### PR TITLE
update CI to Go 1.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
   - "/^\\d{14}/"
 language: go
 go:
-- 1.6
+- 1.6.1
 before_install:
 - go get -u github.com/convox/version
 script:

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,8 @@ machine:
     INSTALL_DIR: /home/ubuntu/.go_workspace/src/github.com/convox/rack
   post:
     - sudo rm -rf /usr/local/go
-    - curl https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz -O
-    - sudo tar -C /usr/local -xzf go1.6.linux-amd64.tar.gz
+    - curl https://storage.googleapis.com/golang/go1.6.1.linux-amd64.tar.gz -O
+    - sudo tar -C /usr/local -xzf go1.6.1.linux-amd64.tar.gz
 
 dependencies:
   pre:


### PR DESCRIPTION
Update to Go 1.6.1 release: https://groups.google.com/forum/#!topic/golang-nuts/9eqIHqaWvck

* This follows up #539. 
* It appears that 1.6-alpine will pick up 1.6.1 without explicitly specifying it (and presumably later point releases as well). 
* Once gimme supports it, it may make sense to use `stable` for the latest stable version on Travis CI (see https://github.com/travis-ci/gimme/issues/39)

## Release Playbook
- [ ] Rebase against master
- [ ] Pass checks
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI

