### PR TITLE
ProxyProtocol fix

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -774,7 +774,7 @@ func (me ManifestEntry) runAsync(m *Manifest, prefix, app, process string, cache
 			return
 		}
 
-		switch me.Label(fmt.Sprintf("com.convox.port.%s.protocol", container)) {
+		switch me.Label(fmt.Sprintf("convox.port.%s.protocol", container)) {
 		case "proxy":
 			rnd := RandomPort()
 			fmt.Println(prefix, special(fmt.Sprintf("proxy protocol enabled for %s:%s", host, container)))

--- a/api/models/release.go
+++ b/api/models/release.go
@@ -181,10 +181,12 @@ func (r *Release) Promote() error {
 		for _, mapping := range entry.PortMappings() {
 			proxyParam := fmt.Sprintf("%sPort%sProxyProtocol", UpperName(entry.Name), mapping.Balancer)
 
-			switch entry.Label(fmt.Sprintf("convox.port.%s.protocol", mapping.Balancer)) {
-			case "proxy":
+			// "com.convox" backwards compatibility. This will be removed soon
+			oldLabel := entry.Label(fmt.Sprintf("com.convox.port.%s.protocol", mapping.Balancer))
+			newLabel := entry.Label(fmt.Sprintf("convox.port.%s.protocol", mapping.Balancer))
+			if (oldLabel == "proxy") || (newLabel == "proxy") {
 				app.Parameters[proxyParam] = "Yes"
-			default:
+			} else {
 				app.Parameters[proxyParam] = "No"
 			}
 		}

--- a/api/models/release.go
+++ b/api/models/release.go
@@ -181,8 +181,11 @@ func (r *Release) Promote() error {
 		for _, mapping := range entry.PortMappings() {
 			proxyParam := fmt.Sprintf("%sPort%sProxyProtocol", UpperName(entry.Name), mapping.Balancer)
 
-			if entry.Label(fmt.Sprintf("convox.port.%s.protocol", mapping.Balancer)) == "proxy" {
+			switch entry.Label(fmt.Sprintf("convox.port.%s.protocol", mapping.Balancer)) {
+			case "proxy":
 				app.Parameters[proxyParam] = "Yes"
+			default:
+				app.Parameters[proxyParam] = "No"
 			}
 		}
 	}

--- a/api/models/release.go
+++ b/api/models/release.go
@@ -181,12 +181,10 @@ func (r *Release) Promote() error {
 		for _, mapping := range entry.PortMappings() {
 			proxyParam := fmt.Sprintf("%sPort%sProxyProtocol", UpperName(entry.Name), mapping.Balancer)
 
-			// "com.convox" backwards compatibility. This will be removed soon
-			oldLabel := entry.Label(fmt.Sprintf("com.convox.port.%s.protocol", mapping.Balancer))
-			newLabel := entry.Label(fmt.Sprintf("convox.port.%s.protocol", mapping.Balancer))
-			if (oldLabel == "proxy") || (newLabel == "proxy") {
+			switch entry.Label(fmt.Sprintf("convox.port.%s.protocol", mapping.Balancer)) {
+			case "proxy":
 				app.Parameters[proxyParam] = "Yes"
-			} else {
+			default:
 				app.Parameters[proxyParam] = "No"
 			}
 		}

--- a/api/models/release.go
+++ b/api/models/release.go
@@ -181,11 +181,8 @@ func (r *Release) Promote() error {
 		for _, mapping := range entry.PortMappings() {
 			proxyParam := fmt.Sprintf("%sPort%sProxyProtocol", UpperName(entry.Name), mapping.Balancer)
 
-			switch entry.Label(fmt.Sprintf("com.convox.port.%s.protocol", mapping.Container)) {
-			case "proxy":
+			if entry.Label(fmt.Sprintf("convox.port.%s.protocol", mapping.Balancer)) == "proxy" {
 				app.Parameters[proxyParam] = "Yes"
-			default:
-				app.Parameters[proxyParam] = "No"
 			}
 		}
 	}


### PR DESCRIPTION
- Call `mapping.Balancer` to get the port, rather than `mapping.Container`

- Drop the "com." from the labels. The format is now:

```
labels:
  - "convox.port.80.protocol=proxy"
```

using the string format or:

```
labels:
  convox.port.80.protocol: "proxy"
```

using the map format.

Fixes #542

## Release Playbook
- [x] Rebase against master
- [ ] Pass checks
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI

