### PR TITLE
install from template in S3 assuming VERSION build parameter is set

### DIFF
--- a/ci/cleanup.sh
+++ b/ci/cleanup.sh
@@ -5,7 +5,6 @@ export CIRCLE_ARTIFACTS=${CIRCLE_ARTIFACTS:-/tmp}
 export CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM:-0}
 
 export STACK_NAME=convox-${CIRCLE_BUILD_NUM}
-export TEMPLATE_FILE=api/dist/kernel.json
 
 case $CIRCLE_NODE_INDEX in
   1)

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -6,7 +6,6 @@ export CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM:-0}
 
 export CONVOX_EMAIL=ci@convox.com
 export STACK_NAME=convox-${CIRCLE_BUILD_NUM}
-export TEMPLATE_FILE=api/dist/kernel.json
 
 case $CIRCLE_NODE_INDEX in
   1)

--- a/ci/report.sh
+++ b/ci/report.sh
@@ -5,7 +5,6 @@ export CIRCLE_ARTIFACTS=${CIRCLE_ARTIFACTS:-/tmp}
 export CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM:-0}
 
 export STACK_NAME=convox-${CIRCLE_BUILD_NUM}
-export TEMPLATE_FILE=api/dist/kernel.json
 
 case $CIRCLE_NODE_INDEX in
   1)

--- a/ci/uninstall.sh
+++ b/ci/uninstall.sh
@@ -5,7 +5,6 @@ export CIRCLE_ARTIFACTS=${CIRCLE_ARTIFACTS:-/tmp}
 export CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM:-0}
 
 export STACK_NAME=convox-${CIRCLE_BUILD_NUM}
-export TEMPLATE_FILE=api/dist/kernel.json
 
 case $CIRCLE_NODE_INDEX in
   1)


### PR DESCRIPTION
Quick fix for CI error. Install from template in S3 like everyone else.

```
'...' at 'templateBody' failed to satisfy constraint: Member must have length less than or equal to 51200
	status code: 400, request id: 72837ebe-033c-11e6-8678-5b203d139953

ci/install.sh returned exit code 1
```