### PR TITLE
amzn-ami-2016.03.a-amazon-ecs-optimized + cloud-init

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -13,14 +13,14 @@
   },
   "Mappings": {
     "RegionConfig": {
-      "us-east-1": { "Ami": "ami-33b48a59" },
-      "us-west-1": { "Ami": "ami-26f78746" },
-      "us-west-2": { "Ami": "ami-65866a05" },
-      "eu-west-1": { "Ami": "ami-77ab1504" },
-      "eu-central-1": { "Ami": "ami-341efb5b" },
-      "ap-northeast-1": { "Ami": "ami-b3afa2dd" },
-      "ap-southeast-1": { "Ami": "ami-0cb0786f" },
-      "ap-southeast-2": { "Ami": "ami-cf6342ac" }
+      "us-east-1": { "Ami": "ami-67a3a90d" },
+      "us-west-1": { "Ami": "ami-b7d5a8d7" },
+      "us-west-2": { "Ami": "ami-c7a451a7" },
+      "eu-west-1": { "Ami": "ami-9c9819ef" },
+      "eu-central-1": { "Ami": "ami-9aeb0af5" },
+      "ap-northeast-1": { "Ami": "ami-7e4a5b10" },
+      "ap-southeast-1": { "Ami": "ami-be63a9dd" },
+      "ap-southeast-2": { "Ami": "ami-b8cbe8db" }
     }
   },
   "Outputs": {

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -865,12 +865,9 @@
             "swap:",
             "  filename: /swapfile",
             "  size: 5000000000",
-            "write_files:",
-            "- path: /opt/convox/runcmd.sh",
-            "  permissions: '0755'",
-            "  content: |",
-            { "Fn::Join" : [ "\n      ", [
-              "      #!/bin/bash",
+            "bootcmd:",
+            { "Fn::Join" : [ " ; ", [
+              "- /usr/bin/cloud-init-per once convox_bootcmd false || ( true",
               { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },
               "echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config",
               { "Fn::If": [ "BlankCertificate",
@@ -885,20 +882,18 @@
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
-              "curl -s https://convox.s3.amazonaws.com/agent/0.67/convox.conf > /etc/init/convox.conf"
+              "curl -s https://convox.s3.amazonaws.com/agent/0.67/convox.conf > /etc/init/convox.conf",
+              ")"
             ] ] },
-            "- path: /var/lib/cloud/scripts/per-once/convox.sh",
-            "  permissions: '0755'",
-            "  content: |",
-            { "Fn::Join" : [ "\n      ", [
-              "      #!/bin/bash",
+            "runcmd:",
+            { "Fn::Join" : [ " ; ", [
+              "- /usr/bin/cloud-init-per once convox_runcmd false || ( true",
               { "Ref": "InstanceBootCommand" },
               { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
               "sleep 30",
-              { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] }
-            ] ] },
-            "runcmd:",
-            "- [ cloud-init-per, once, convox_runcmd, /opt/convox/runcmd.sh ]"
+              { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
+              ")"
+            ] ] }
           ] ] }
         }
       }

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -858,6 +858,8 @@
           { "Fn::Join": [ "\n", [
             "#cloud-config",
             "repo_upgrade: all",
+            "repo_upgrade_exclude:",
+            "- kernel*",
             "packages:",
             "- aws-cfn-bootstrap",
             "swap:",

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -883,12 +883,12 @@
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
               "curl -s https://convox.s3.amazonaws.com/agent/0.67/convox.conf > /etc/init/convox.conf",
+              { "Ref": "InstanceBootCommand" },
               ")"
             ] ] },
             "runcmd:",
             { "Fn::Join" : [ " ; ", [
               "- /usr/bin/cloud-init-per once convox_runcmd false || ( true",
-              { "Ref": "InstanceBootCommand" },
               { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
               "sleep 30",
               { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -5,6 +5,7 @@
     "BlankAmi": { "Fn::Equals": [ { "Ref": "Ami" }, "" ] },
     "BlankCertificate": { "Fn::Equals": [ { "Ref": "Certificate" }, "" ] },
     "BlankDockerImageApi": { "Fn::Equals": [ { "Ref": "DockerImageApi" }, "" ] },
+    "BlankInstanceBootCommand": { "Fn::Equals": [ { "Ref": "InstanceBootCommand" }, "" ] },
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "BlankRegistryHost": { "Fn::Equals": [ { "Ref": "RegistryHost" }, "" ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
@@ -883,7 +884,10 @@
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
               "curl -s https://convox.s3.amazonaws.com/agent/0.67/convox.conf > /etc/init/convox.conf",
-              { "Ref": "InstanceBootCommand" },
+              { "Fn::If": [ "BlankInstanceBootCommand",
+                "true",
+                { "Ref": "InstanceBootCommand" }
+              ] },
               ")"
             ] ] },
             "runcmd:",

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -856,32 +856,47 @@
         "SecurityGroups": [ { "Ref": "SecurityGroup" } ],
         "UserData": { "Fn::Base64":
           { "Fn::Join": [ "\n", [
-            "#!/bin/bash",
-            "fallocate -l 5G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile",
-            "echo 'exclude=kernel*' >> /etc/yum.conf",
-            "yum -y update",
-            "yum -y install aws-cfn-bootstrap",
-            { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },
-            "echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config",
-            { "Fn::If": [ "BlankCertificate",
-              { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] },
-              { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Ref": "RegistryHost" }, { "Ref": "RegistryPort" } ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] }
-            ] },
-            { "Fn::If": [ "BlankCertificate",
-              { "Fn::Join": [ "", [ "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --insecure-registry=", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, " --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker" ] ] },
-              "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock  --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker"
-            ] },
-            "service docker restart",
-            "mkdir -p /etc/convox",
-            { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
-            { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
-            { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
-            "curl -s https://convox.s3.amazonaws.com/agent/0.67/convox.conf > /etc/init/convox.conf",
-            "start convox",
-            { "Ref": "InstanceBootCommand" },
-            { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
-            "sleep 30",
-            { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] }
+            "#cloud-config",
+            "repo_upgrade: all",
+            "packages:",
+            "- aws-cfn-bootstrap",
+            "swap:",
+            "  filename: /swapfile",
+            "  size: 5000000000",
+            "write_files:",
+            "- path: /opt/convox/runcmd.sh",
+            "  permissions: '0755'",
+            "  content: |",
+            { "Fn::Join" : [ "\n      ", [
+              "      #!/bin/bash",
+              { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },
+              "echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config",
+              { "Fn::If": [ "BlankCertificate",
+                { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] },
+                { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Ref": "RegistryHost" }, { "Ref": "RegistryPort" } ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] }
+              ] },
+              { "Fn::If": [ "BlankCertificate",
+                { "Fn::Join": [ "", [ "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --insecure-registry=", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, " --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker" ] ] },
+                "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock  --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker"
+              ] },
+              "mkdir -p /etc/convox",
+              { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
+              { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
+              { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
+              "curl -s https://convox.s3.amazonaws.com/agent/0.67/convox.conf > /etc/init/convox.conf"
+            ] ] },
+            "- path: /var/lib/cloud/scripts/per-once/convox.sh",
+            "  permissions: '0755'",
+            "  content: |",
+            { "Fn::Join" : [ "\n      ", [
+              "      #!/bin/bash",
+              { "Ref": "InstanceBootCommand" },
+              { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
+              "sleep 30",
+              { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] }
+            ] ] },
+            "runcmd:",
+            "- [ cloud-init-per, once, convox_runcmd, /opt/convox/runcmd.sh ]"
           ] ] }
         }
       }


### PR DESCRIPTION
@nzoschke I took a pass at #522 by using cloud-init as you hinted in #517.

cloud-init's `bootcmd` runs _before_ `write_files`, which made for a much gnarlier patch.  `runcmd` however, runs after `write_files` but before services start, so it seems we can get away without `bootcmd`.

I chose to keep `InstanceBootCommand` and the `cfn-{init,signal}` in a separate file that runs after services are started, which preserves the existing behavior.

I could have gone a bit more minimal on the patch by leaving the swap and yum commands as bash, but I chose to leverage cloud-init's features instead.  Happy to reconsider that.

fixes #522 

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit release record in GitHub
- [ ] Publish release
- [ ] Release CLI