### PR TITLE
Fix SSL chain malformed errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.6-alpine
 
-RUN apk update && apk add docker git haproxy openssh openssl python
+RUN apk update && apk add build-base docker git haproxy openssh openssl python
 
 RUN go get github.com/ddollar/init
-RUN go get github.com/ddollar/rerun
-COPY pkg/cfssl /go/bin/cfssl
+RUN go get github.com/convox/rerun
+RUN go get github.com/convox/cfssl/cmd/cfssl
 
 COPY conf/haproxy.cfg /etc/haproxy/haproxy.cfg
 


### PR DESCRIPTION
Looks like changing the base image made the pre-compiled binary not work any more. This forks cfssl to our Github account to make it a bit more stable and builds it into the image.

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [x] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit release record in GitHub
- [ ] Publish release
- [ ] Release CLI

