### PR TITLE
Restore build:create error event

### DIFF
--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -165,6 +165,16 @@ func BuildUpdate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		return httperr.Server(err)
 	}
 
+	if b.Status == "failed" {
+		provider.EventSend(&structs.Event{
+			Action: "build:create",
+			Data: map[string]string{
+				"app": b.App,
+				"id":  b.Id,
+			},
+		}, fmt.Errorf(b.Reason))
+	}
+
 	return RenderJson(rw, b)
 }
 

--- a/api/provider/aws/event.go
+++ b/api/provider/aws/event.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"encoding/json"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
@@ -26,6 +27,7 @@ func (p *AWSProvider) EventSend(e *structs.Event, err error) error {
 	log := logger.New("ns=kernel")
 
 	e.Status = "success"
+	e.Timestamp = time.Now().UTC()
 
 	if err != nil {
 		e.Data["message"] = err.Error()


### PR DESCRIPTION
This is an RFC, since Rack events in general are up for design / re-design.

Good build:
```
web      | aws EventSend msg="{\"action\":\"build:create\",\"status\":\"success\",\"data\":{\"app\":\"httpd\",\"id\":\"BEDLSWUFPDK\"},\"timestamp\":\"2016-04-21T23:16:32.310771035Z\"}"
web      | aws EventSend msg="{\"action\":\"release:create\",\"status\":\"success\",\"data\":{\"app\":\"httpd\",\"id\":\"RZGGPJQCLHG\"},\"timestamp\":\"2016-04-21T23:16:38.334722521Z\"}"
web      | aws EventSend msg="{\"action\":\"build:finish\",\"status\":\"success\",\"data\":{\"app\":\"httpd\",\"id\":\"BEDLSWUFPDK\"},\"timestamp\":\"2016-04-21T23:16:38.648482702Z\"}"
```

Bad build (image in docker-compose.yml doesn't exist):
```
web      | aws EventSend msg="{\"action\":\"build:create\",\"status\":\"success\",\"data\":{\"app\":\"httpd\",\"id\":\"BIGQURCQITQ\"},\"timestamp\":\"2016-04-21T23:18:48.974479872Z\"}"
web      | aws EventSend msg="{\"action\":\"build:finish\",\"status\":\"error\",\"data\":{\"app\":\"httpd\",\"id\":\"BIGQURCQITQ\",\"message\":\"exit status 1\"},\"timestamp\":\"2016-04-21T23:20:59.826717043Z\"}"
```

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI
