### PR TITLE
Sub underscores for hyphens

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -430,6 +430,7 @@ func (me *ManifestEntry) ResolvedLinkVars(m *Manifest, cache bool) (map[string]s
 		}
 
 		prefix := strings.ToUpper(link) + "_"
+		prefix = strings.Replace(prefix, "-", "_", -1)
 		linkVars[prefix+"URL"] = linkUrl.String()
 		linkVars[prefix+"HOST"] = host
 		linkVars[prefix+"SCHEME"] = scheme

--- a/api/models/release.go
+++ b/api/models/release.go
@@ -443,7 +443,7 @@ func (r *Release) resolveLinks(app App, manifest *Manifest) (Manifest, error) {
 				scheme, userInfo, host, port, path)
 
 			prefix := strings.ToUpper(link) + "_"
-
+			prefix = strings.Replace(prefix, "-", "_", -1)
 			entry.LinkVars[prefix+"HOST"] = template.HTML(host)
 			entry.LinkVars[prefix+"SCHEME"] = template.HTML(fmt.Sprintf("%q", scheme))
 			entry.LinkVars[prefix+"PORT"] = template.HTML(fmt.Sprintf("%q", port))


### PR DESCRIPTION
Currently, if you have a process name like `my-db` and use linking, you'll get env vars like `MY-DB_HOST`.

This change substitutes underscores for the hyphen(s) in the name so that you'll get `MY_DB_HOST` instead.

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

