### PR TITLE
amzn-ami-2016.03.a-amazon-ecs-optimized + cloud-init

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -5,6 +5,7 @@
     "BlankAmi": { "Fn::Equals": [ { "Ref": "Ami" }, "" ] },
     "BlankCertificate": { "Fn::Equals": [ { "Ref": "Certificate" }, "" ] },
     "BlankDockerImageApi": { "Fn::Equals": [ { "Ref": "DockerImageApi" }, "" ] },
+    "BlankInstanceBootCommand": { "Fn::Equals": [ { "Ref": "InstanceBootCommand" }, "" ] },
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "BlankRegistryHost": { "Fn::Equals": [ { "Ref": "RegistryHost" }, "" ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
@@ -884,7 +885,10 @@
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
               "curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf",
-              { "Ref": "InstanceBootCommand" },
+              { "Fn::If": [ "BlankInstanceBootCommand",
+                "true",
+                { "Ref": "InstanceBootCommand" }
+              ] },
               ")"
             ] ] },
             "runcmd:",

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -13,14 +13,14 @@
   },
   "Mappings": {
     "RegionConfig": {
-      "us-east-1": { "Ami": "ami-33b48a59" },
-      "us-west-1": { "Ami": "ami-26f78746" },
-      "us-west-2": { "Ami": "ami-65866a05" },
-      "eu-west-1": { "Ami": "ami-77ab1504" },
-      "eu-central-1": { "Ami": "ami-341efb5b" },
-      "ap-northeast-1": { "Ami": "ami-b3afa2dd" },
-      "ap-southeast-1": { "Ami": "ami-0cb0786f" },
-      "ap-southeast-2": { "Ami": "ami-cf6342ac" }
+      "us-east-1": { "Ami": "ami-67a3a90d" },
+      "us-west-1": { "Ami": "ami-b7d5a8d7" },
+      "us-west-2": { "Ami": "ami-c7a451a7" },
+      "eu-west-1": { "Ami": "ami-9c9819ef" },
+      "eu-central-1": { "Ami": "ami-9aeb0af5" },
+      "ap-northeast-1": { "Ami": "ami-7e4a5b10" },
+      "ap-southeast-1": { "Ami": "ami-be63a9dd" },
+      "ap-southeast-2": { "Ami": "ami-b8cbe8db" }
     }
   },
   "Outputs": {

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -858,6 +858,8 @@
           { "Fn::Join": [ "\n", [
             "#cloud-config",
             "repo_upgrade: all",
+            "repo_upgrade_exclude:",
+            "- kernel*",
             "packages:",
             "- aws-cfn-bootstrap",
             "swap:",

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -6,6 +6,7 @@
     "BlankCertificate": { "Fn::Equals": [ { "Ref": "Certificate" }, "" ] },
     "BlankDockerImageApi": { "Fn::Equals": [ { "Ref": "DockerImageApi" }, "" ] },
     "BlankInstanceBootCommand": { "Fn::Equals": [ { "Ref": "InstanceBootCommand" }, "" ] },
+    "BlankInstanceRunCommand": { "Fn::Equals": [ { "Ref": "InstanceRunCommand" }, "" ] },
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "BlankRegistryHost": { "Fn::Equals": [ { "Ref": "RegistryHost" }, "" ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
@@ -192,7 +193,12 @@
     },
     "InstanceBootCommand": {
       "Type": "String",
-      "Description": "A single line of extra shell script to run as UserData during instance boot.",
+      "Description": "A single line of shell script to run as CloudInit command early during instance boot.",
+      "Default": ""
+    },
+    "InstanceRunCommand": {
+      "Type": "String",
+      "Description": "A single line of shell script to run as CloudInit command late during instance boot.",
       "Default": ""
     },
     "InstanceCount": {
@@ -892,7 +898,12 @@
               ] ] }
             ] },
             "runcmd:\n",
-            "  - sleep 30\n",
+            { "Fn::If": [ "BlankInstanceRunCommand",
+              "  - sleep 30\n",
+              { "Fn::Join": [ "", [
+              "  - ", { "Ref": "InstanceRunCommand" }, "\n"
+              ] ] }
+            ] },
             "  - /opt/aws/bin/cfn-signal --stack ", { "Ref": "AWS::StackName" }, " --region ", {"Ref":"AWS::Region"}, " --resource Instances\n"
           ] ] }
         }

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -888,6 +888,7 @@
             "bootcmd:\n",
             "  - mkswap /dev/xvdb\n",
             "  - swapon /dev/xvdb\n",
+            "  - [ cloud-init-per, instance, docker_storage_setup, /usr/bin/docker-storage-setup ]\n",
             "  - echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config\n",
             "  - echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config\n",
             { "Fn::If": [ "BlankCertificate",

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -856,33 +856,48 @@
         "SecurityGroups": [ { "Ref": "SecurityGroup" } ],
         "UserData": { "Fn::Base64":
           { "Fn::Join": [ "\n", [
-            "#!/bin/bash",
-            "fallocate -l 5G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile",
-            "echo 'exclude=kernel*' >> /etc/yum.conf",
-            "yum -y update",
-            "yum -y install aws-cfn-bootstrap",
-            { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },
-            "echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config",
-            { "Fn::If": [ "BlankCertificate",
-              { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] },
-              { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Ref": "RegistryHost" }, { "Ref": "RegistryPort" } ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] }
-            ] },
-            { "Fn::If": [ "BlankCertificate",
-              { "Fn::Join": [ "", [ "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --insecure-registry=", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, " --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker" ] ] },
-              "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock  --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker"
-            ] },
-            "service docker restart",
-            "mkdir -p /etc/convox",
-            { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
-            { "Fn::Join": [ "", [ "echo \"", { "Ref": "ClientId" }, "\" > /etc/convox/client_id" ] ] },
-            { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
-            { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
-            "curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf",
-            "start convox",
-            { "Ref": "InstanceBootCommand" },
-            { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
-            "sleep 30",
-            { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] }
+            "#cloud-config",
+            "repo_upgrade: all",
+            "packages:",
+            "- aws-cfn-bootstrap",
+            "swap:",
+            "  filename: /swapfile",
+            "  size: 5000000000",
+            "write_files:",
+            "- path: /opt/convox/runcmd.sh",
+            "  permissions: '0755'",
+            "  content: |",
+            { "Fn::Join" : [ "\n      ", [
+              "      #!/bin/bash",
+              { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },
+              "echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config",
+              { "Fn::If": [ "BlankCertificate",
+                { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] },
+                { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Ref": "RegistryHost" }, { "Ref": "RegistryPort" } ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] }
+              ] },
+              { "Fn::If": [ "BlankCertificate",
+                { "Fn::Join": [ "", [ "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --insecure-registry=", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, " --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker" ] ] },
+                "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock  --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker"
+              ] },
+              "mkdir -p /etc/convox",
+              { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
+              { "Fn::Join": [ "", [ "echo \"", { "Ref": "ClientId" }, "\" > /etc/convox/client_id" ] ] },
+              { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
+              { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
+              "curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf"
+            ] ] },
+            "- path: /var/lib/cloud/scripts/per-once/convox.sh",
+            "  permissions: '0755'",
+            "  content: |",
+            { "Fn::Join" : [ "\n      ", [
+              "      #!/bin/bash",
+              { "Ref": "InstanceBootCommand" },
+              { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
+              "sleep 30",
+              { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] }
+            ] ] },
+            "runcmd:",
+            "- [ cloud-init-per, once, convox_runcmd, /opt/convox/runcmd.sh ]"
           ] ] }
         }
       }

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -274,6 +274,11 @@
       "Description": "Private Subnet 2 CIDR Block",
       "Type": "String"
     },
+    "SwapSize": {
+      "Type": "Number",
+      "Description": "Default swap volume size in GB",
+      "Default": "5"
+    },
     "Version": {
       "Description": "(REQUIRED) Convox release version",
       "MinLength" : "1",
@@ -847,13 +852,22 @@
       "Type": "AWS::AutoScaling::LaunchConfiguration",
       "Properties": {
         "AssociatePublicIpAddress": true,
-        "BlockDeviceMappings": [{
-          "DeviceName": "/dev/xvdcz",
-          "Ebs": {
-            "VolumeSize": { "Ref": "VolumeSize" },
-            "VolumeType":"gp2"
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/sdb",
+            "Ebs": {
+              "VolumeSize": { "Ref": "SwapSize" },
+              "VolumeType":"gp2"
+            }
+          },
+          {
+            "DeviceName": "/dev/xvdcz",
+            "Ebs": {
+              "VolumeSize": { "Ref": "VolumeSize" },
+              "VolumeType":"gp2"
+            }
           }
-        }],
+        ],
         "IamInstanceProfile": { "Ref": "InstanceProfile" },
         "ImageId": { "Fn::If": [ "BlankAmi", { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Ami" ] }, { "Ref": "Ami" } ] },
         "InstanceMonitoring": true,
@@ -869,10 +883,11 @@
             "  - kernel*\n",
             "packages:\n",
             "  - aws-cfn-bootstrap\n",
-            "swap:\n",
-            "  filename: /swapfile\n",
-            "  size: 5000000000\n",
+            "mounts:\n",
+            "  - ['/dev/xvdb', 'none', 'swap', 'sw', '0', '0']\n",
             "bootcmd:\n",
+            "  - mkswap /dev/xvdb\n",
+            "  - swapon /dev/xvdb\n",
             "  - echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config\n",
             "  - echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config\n",
             { "Fn::If": [ "BlankCertificate",

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -907,6 +907,7 @@
             "  - echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis\n",
             "  - echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group\n",
             "  - curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf\n",
+            "  - echo -e '/var/log/docker {\\n  rotate 7\\n  daily\\n  nocompress\\n  copytruncate\\n}' >> /etc/logrotate.d/docker\n",
             { "Fn::If": [ "BlankInstanceBootCommand",
               { "Ref": "AWS::NoValue" },
               { "Fn::Join": [ "", [

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -884,12 +884,12 @@
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
               "curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf",
+              { "Ref": "InstanceBootCommand" },
               ")"
             ] ] },
             "runcmd:",
             { "Fn::Join" : [ " ; ", [
               "- /usr/bin/cloud-init-per once convox_runcmd false || ( true",
-              { "Ref": "InstanceBootCommand" },
               { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
               "sleep 30",
               { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -865,12 +865,9 @@
             "swap:",
             "  filename: /swapfile",
             "  size: 5000000000",
-            "write_files:",
-            "- path: /opt/convox/runcmd.sh",
-            "  permissions: '0755'",
-            "  content: |",
-            { "Fn::Join" : [ "\n      ", [
-              "      #!/bin/bash",
+            "bootcmd:",
+            { "Fn::Join" : [ " ; ", [
+              "- /usr/bin/cloud-init-per once convox_bootcmd false || ( true",
               { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },
               "echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config",
               { "Fn::If": [ "BlankCertificate",
@@ -886,20 +883,18 @@
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "ClientId" }, "\" > /etc/convox/client_id" ] ] },
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
               { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
-              "curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf"
+              "curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf",
+              ")"
             ] ] },
-            "- path: /var/lib/cloud/scripts/per-once/convox.sh",
-            "  permissions: '0755'",
-            "  content: |",
-            { "Fn::Join" : [ "\n      ", [
-              "      #!/bin/bash",
+            "runcmd:",
+            { "Fn::Join" : [ " ; ", [
+              "- /usr/bin/cloud-init-per once convox_runcmd false || ( true",
               { "Ref": "InstanceBootCommand" },
               { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
               "sleep 30",
-              { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] }
-            ] ] },
-            "runcmd:",
-            "- [ cloud-init-per, once, convox_runcmd, /opt/convox/runcmd.sh ]"
+              { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
+              ")"
+            ] ] }
           ] ] }
         }
       }

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -856,49 +856,44 @@
         "PlacementTenancy" : { "Ref": "Tenancy" },
         "SecurityGroups": [ { "Ref": "SecurityGroup" } ],
         "UserData": { "Fn::Base64":
-          { "Fn::Join": [ "\n", [
-            "#cloud-config",
-            "repo_upgrade: all",
-            "repo_upgrade_exclude:",
-            "- kernel*",
-            "packages:",
-            "- aws-cfn-bootstrap",
-            "swap:",
-            "  filename: /swapfile",
-            "  size: 5000000000",
-            "bootcmd:",
-            { "Fn::Join" : [ " ; ", [
-              "- /usr/bin/cloud-init-per once convox_bootcmd false || ( true",
-              { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },
-              "echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config",
-              { "Fn::If": [ "BlankCertificate",
-                { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] },
-                { "Fn::Join": [ "", [ "echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Ref": "RegistryHost" }, { "Ref": "RegistryPort" } ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config" ] ] }
-              ] },
-              { "Fn::If": [ "BlankCertificate",
-                { "Fn::Join": [ "", [ "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --insecure-registry=", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, " --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker" ] ] },
-                "echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock  --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker"
-              ] },
-              "mkdir -p /etc/convox",
-              { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
-              { "Fn::Join": [ "", [ "echo \"", { "Ref": "ClientId" }, "\" > /etc/convox/client_id" ] ] },
-              { "Fn::Join": [ "", [ "echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis" ] ] },
-              { "Fn::Join": [ "", [ "echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group" ] ] },
-              "curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf",
-              { "Fn::If": [ "BlankInstanceBootCommand",
-                "true",
-                { "Ref": "InstanceBootCommand" }
-              ] },
-              ")"
-            ] ] },
-            "runcmd:",
-            { "Fn::Join" : [ " ; ", [
-              "- /usr/bin/cloud-init-per once convox_runcmd false || ( true",
-              { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-init", "-s", { "Ref": "AWS::StackName" }, "-r", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
-              "sleep 30",
-              { "Fn::Join": [ " ", [ "/opt/aws/bin/cfn-signal", "--stack", { "Ref": "AWS::StackName" }, "--resource", "Instances", "--region", {"Ref":"AWS::Region"} ] ] },
-              ")"
-            ] ] }
+          { "Fn::Join": [ "", [
+            "#cloud-config\n",
+            "repo_upgrade: all\n",
+            "repo_upgrade_exclude:\n",
+            "  - kernel*\n",
+            "packages:\n",
+            "  - aws-cfn-bootstrap\n",
+            "swap:\n",
+            "  filename: /swapfile\n",
+            "  size: 5000000000\n",
+            "bootcmd:\n",
+            "  - echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config\n",
+            "  - echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config\n",
+            { "Fn::If": [ "BlankCertificate",
+              { "Fn::Join": [ "", [
+                "  - echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config\n",
+                "  - echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --insecure-registry=", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, " --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker\n"
+              ] ] },
+              { "Fn::Join": [ "", [
+                "  - echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"},\"", { "Fn::Join": [ ":", [ { "Ref": "RegistryHost" }, { "Ref": "RegistryPort" } ] ] }, "\":{\"username\":\"convox\",\"password\":\"", { "Ref": "Password" }, "\",\"email\":\"user@convox.io\"}}' >> /etc/ecs/ecs.config\n",
+                "  - echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock  --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker\n"
+              ] ] }
+            ] },
+            "  - mkdir -p /etc/convox\n",
+            "  - echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region\n",
+            "  - echo \"", { "Ref": "ClientId" }, "\" > /etc/convox/client_id\n",
+            "  - echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis\n",
+            "  - echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group\n",
+            "  - curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf\n",
+            { "Fn::If": [ "BlankInstanceBootCommand",
+              { "Ref": "AWS::NoValue" },
+              { "Fn::Join": [ "", [
+              "  - ", { "Ref": "InstanceBootCommand" }, "\n"
+              ] ] }
+            ] },
+            "runcmd:\n",
+            "  - sleep 30\n",
+            "  - /opt/aws/bin/cfn-signal --stack ", { "Ref": "AWS::StackName" }, " --region ", {"Ref":"AWS::Region"}, " --resource Instances\n"
           ] ] }
         }
       }

--- a/api/provider/aws/certificates.go
+++ b/api/provider/aws/certificates.go
@@ -147,6 +147,28 @@ func (p *AWSProvider) CertificateList() (structs.Certificates, error) {
 		})
 	}
 
+	// only fetch ACM certificates in regions that support it
+	switch os.Getenv("AWS_REGION") {
+	case "us-east-1":
+		c, err := p.certificateListACM()
+
+		if err != nil {
+			return nil, err
+		}
+
+		certs = append(certs, c...)
+	}
+
+	return certs, nil
+}
+
+type CfsslCertificateBundle struct {
+	Bundle string `json:"bundle"`
+}
+
+func (p *AWSProvider) certificateListACM() (structs.Certificates, error) {
+	certs := structs.Certificates{}
+
 	ares, err := p.acm().ListCertificates(nil)
 
 	if err != nil {
@@ -178,10 +200,6 @@ func (p *AWSProvider) CertificateList() (structs.Certificates, error) {
 	}
 
 	return certs, nil
-}
-
-type CfsslCertificateBundle struct {
-	Bundle string `json:"bundle"`
 }
 
 // use cfssl bundle to generate the certificate chain

--- a/cmd/convox/proxy.go
+++ b/cmd/convox/proxy.go
@@ -69,17 +69,17 @@ func cmdProxy(c *cli.Context) {
 			return
 		}
 
-		go proxy(port, host, hostport, rackClient(c))
+		go proxy("127.0.0.1", port, host, hostport, rackClient(c))
 	}
 
 	// block forever
 	select {}
 }
 
-func proxy(port int, host string, hostport int, client *client.Client) {
-	fmt.Printf("proxying localhost:%d to %s:%d\n", port, host, hostport)
+func proxy(localhost string, localport int, remotehost string, remoteport int, client *client.Client) {
+	fmt.Printf("proxying %s:%d to %s:%d\n", localhost, localport, remotehost, remoteport)
 
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	listener, err := net.Listen("tcp4", fmt.Sprintf("%s:%d", localhost, localport))
 
 	if err != nil {
 		fmt.Printf("error: %s\n", err)
@@ -98,10 +98,10 @@ func proxy(port int, host string, hostport int, client *client.Client) {
 
 		defer conn.Close()
 
-		fmt.Printf("connect: %d\n", port)
+		fmt.Printf("connect: %d\n", localport)
 
 		go func() {
-			err := client.Proxy(host, hostport, conn)
+			err := client.Proxy(remotehost, remoteport, conn)
 
 			if err != nil {
 				fmt.Printf("error: %s\n", err)


### PR DESCRIPTION
Taking over for #550. Phew!

As a recap, the goal was to get the latest AMIs.

Changes on the new Amazon Linux broke the old userdata around doing a `docker restart` to pick up some different settings. Going forward we want to write docker settings to the disk earlier in the boot process so they are there when the AMI does the first `docker start`.

CloudInit and its bootcmd hook run earlier in the boot process, but it took us a while to learn how to use this without causing other side effects. Namely it seems impossible for our UserData supplied bootcmd to not prevent the ECS bootcmd that's baked into the AMI from executing. Thats a very important command for initializing Docker storage settings.

The workaround for now is to copy the ECS bootcmd into our userdata. We will have to be careful in case future AMIs have further bootcmd changes.

* New AMIs
* cloudinit style UserData with old userdata ported into bootcmd section
* copy /etc/cloud/cloud.cfg.d/90_ecs.cfg docker-storage-setup into bootcmd
* add and initialize dedicated swap volume at /dev/sdb
* configure log rotation for /var/log/docker
* add a SwapSize Parameter
* add InstanceRunCommand parameter to runcmd section

## Demo

```bash
[ec2-user@ip-10-0-3-71 ~]$ sudo curl http://169.254.169.254/latest/user-data
#cloud-config
repo_upgrade: all
repo_upgrade_exclude:
  - kernel*
packages:
  - aws-cfn-bootstrap
mounts:
  - ['/dev/xvdb', 'none', 'swap', 'sw', '0', '0']
bootcmd:
  - mkswap /dev/xvdb
  - swapon /dev/xvdb
  - [ cloud-init-per, instance, docker_storage_setup, /usr/bin/docker-storage-setup ]
  - echo ECS_CLUSTER=convox-Cluster-1E4XJ0PQWNAYS >> /etc/ecs/ecs.config
  - echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config
  - echo 'ECS_ENGINE_AUTH_DATA={"index.docker.io":{"username":"","password":"","email":""},"convox-826133048.us-east-1.elb.amazonaws.com:5000":{"username":"convox","password":"SECRET","email":"user@convox.io"}}' >> /etc/ecs/ecs.config
  - echo 'OPTIONS="${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --insecure-registry=convox-826133048.us-east-1.elb.amazonaws.com:5000 --host=unix:///var/run/docker.sock --host=0.0.0.0:2376"' >> /etc/sysconfig/docker
  - mkdir -p /etc/convox
  - echo "us-east-1" > /etc/convox/region
  - echo "noah@convox.com" > /etc/convox/client_id
  - echo "convox-Kinesis-8WL8ZDHOGV5F" > /etc/convox/kinesis
  - echo "convox-LogGroup-V21KNCGSV61R" > /etc/convox/log_group
  - curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf
  - echo -e '/var/log/docker {\n  rotate 7\n  daily\n  nocompress\n  copytruncate\n}' >> /etc/logrotate.d/docker
runcmd:
  - sleep 30
  - /opt/aws/bin/cfn-signal --stack convox --region us-east-1 --resource Instances

[ec2-user@ip-10-0-3-71 ~]$ lsblk
NAME                                                                                         MAJ:MIN   RM  SIZE RO TYPE MOUNTPOINT
xvda                                                                                         202:0      0    8G  0 disk 
└─xvda1                                                                                      202:1      0    8G  0 part /
xvdb                                                                                         202:16     0    5G  0 disk [SWAP]
xvdcz                                                                                        202:26368  0   30G  0 disk 
└─xvdcz1                                                                                     202:26369  0   30G  0 part 
  ├─docker-docker--pool_tmeta                                                                253:0      0   32M  0 lvm  
  │ └─docker-docker--pool                                                                    253:2      0 29.7G  0 lvm  
  │   ├─docker-202:1-263305-6d937b80ddb7303c4c081641ca8ee24122059b482fbd264f51d680b04e38876d 253:3      0  100G  0 dm   
  │   ├─docker-202:1-263305-0708cb1397c92f5341297610e68e67654e21b5a2b6b0cf69568ff9182d7d8f45 253:4      0  100G  0 dm   
  │   ├─docker-202:1-263305-21e8fc3e2dc27929516cedda5e895815ded003fd5abe4e0797c7938f188e0466 253:5      0  100G  0 dm   
  │   ├─docker-202:1-263305-43feff25e69fe82154069a35184fd47ae705e61b7ff1c31f9d6be4e727497c52 253:6      0  100G  0 dm   
  │   ├─docker-202:1-263305-ec31c0d71270b62ed41f9df6edee857294eba16dbba565cfa1c2c6a1095f6881 253:7      0  100G  0 dm   
  │   └─docker-202:1-263305-dc23f9536356ef4102469698d6f6bf495e1c31cc64628634af11db80dd033400 253:8      0  100G  0 dm   
  └─docker-docker--pool_tdata                                                                253:1      0 29.7G  0 lvm  
    └─docker-docker--pool                                                                    253:2      0 29.7G  0 lvm  
      ├─docker-202:1-263305-6d937b80ddb7303c4c081641ca8ee24122059b482fbd264f51d680b04e38876d 253:3      0  100G  0 dm   
      ├─docker-202:1-263305-0708cb1397c92f5341297610e68e67654e21b5a2b6b0cf69568ff9182d7d8f45 253:4      0  100G  0 dm   
      ├─docker-202:1-263305-21e8fc3e2dc27929516cedda5e895815ded003fd5abe4e0797c7938f188e0466 253:5      0  100G  0 dm   
      ├─docker-202:1-263305-43feff25e69fe82154069a35184fd47ae705e61b7ff1c31f9d6be4e727497c52 253:6      0  100G  0 dm   
      ├─docker-202:1-263305-ec31c0d71270b62ed41f9df6edee857294eba16dbba565cfa1c2c6a1095f6881 253:7      0  100G  0 dm   
      └─docker-202:1-263305-dc23f9536356ef4102469698d6f6bf495e1c31cc64628634af11db80dd033400 253:8      0  100G  0 dm   

[ec2-user@ip-10-0-3-71 ~]$ swapon -s
Filename				Type		Size	Used	Priority
/dev/xvdb                              	partition	5242876	0	-1

[ec2-user@ip-10-0-3-71 ~]$ cat /etc/fstab 
#
LABEL=/     /           ext4    defaults,noatime  1   1
tmpfs       /dev/shm    tmpfs   defaults        0   0
devpts      /dev/pts    devpts  gid=5,mode=620  0   0
sysfs       /sys        sysfs   defaults        0   0
proc        /proc       proc    defaults        0   0
/dev/xvdb	none	swap	sw,comment=cloudconfig	0	0

[ec2-user@ip-10-0-3-71 ~]$ cat /etc/logrotate.d/docker 
/var/log/docker {
  rotate 7
  daily
  nocompress
  copytruncate
}
```

Set:
*  `InstanceBootCommand` to `echo hi > /tmp/boot`
*  `InstanceRunCommand` to `echo hi > /tmp/run`

```
[ec2-user@ip-10-0-3-168 ~]$ ls -la --time-style=full-iso /tmp/
-rw-r--r--  1 root root    3 2016-04-29 00:06:55.255347787 +0000 boot
-rw-r--r--  1 root root    3 2016-04-29 00:07:22.590946005 +0000 run
```

## Release Playbook
- [x] Rebase against master
- [x] Release branch (20160502160743-cloud-init)
- [x] Pass CI (https://circleci.com/gh/convox/rack/754)
- [x] Code review
- [x] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI
