### PR TITLE
Block environment get while creating

### DIFF
--- a/api/models/environment.go
+++ b/api/models/environment.go
@@ -40,6 +40,10 @@ func GetEnvironment(app string) (Environment, error) {
 		return nil, err
 	}
 
+	if a.Status == "creating" {
+		return nil, fmt.Errorf("app is still being created: %s", app)
+	}
+
 	data, err := s3Get(a.Outputs["Settings"], "env")
 
 	if err != nil {


### PR DESCRIPTION
Solves #335 by not getting the env settings if app status is creating.

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI