### PR TITLE
Allow for any number of whitespace characters between the COPY/ADD commands for file syncing

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -916,7 +916,7 @@ func (me ManifestEntry) syncAdds(app, process string) error {
 	}
 
 	for _, line := range strings.Split(string(data), "\n") {
-		parts := strings.Split(strings.TrimSpace(line), " ")
+		parts := strings.Fields(line)
 
 		if len(parts) < 1 {
 			continue


### PR DESCRIPTION
Was banging my head for a little bit why the file syncing wasn't working, and realized that the Dockerfile had an extra space between the local and remote files specified in the COPY command (e.g. COPY ./app  /app #Notice two spaces between them). Technically it's a valid Dockerfile, and thought this may help someone else who runs into a similar issue for some reason.

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [x] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI