### PR TITLE
Validate syslog url scheme

### DIFF
--- a/api/provider/aws/service.go
+++ b/api/provider/aws/service.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -315,6 +316,18 @@ func (p *AWSProvider) ServiceUnlinkSubscribe(a *structs.App, s *structs.Service)
 }
 
 func createSyslog(s *structs.Service) (*cloudformation.CreateStackInput, error) {
+	u, err := url.Parse(s.Parameters["Url"])
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case "udp", "tcp", "tcp+tls":
+		// proceed
+	default:
+		return nil, fmt.Errorf("Invalid url scheme `%s`. Allowed schemes are `udp`, `tcp`, `tcp+tls`.", u.Scheme)
+	}
+
 	formation, err := serviceFormation(s.Type, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [x] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

Example:

    convox services create syslog --url tcp+ssl://example.com:11234
    ERROR: Invalid url scheme `tcp+ssl`. Allowed schemes are `udp`, `tcp`, `tcp+tls`.

Fixes #581