### PR TITLE
Improve error when app name conflicts with rack name

### DIFF
--- a/api/controllers/apps.go
+++ b/api/controllers/apps.go
@@ -50,6 +50,10 @@ func AppShow(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 func AppCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	name := r.FormValue("name")
 
+	if name == os.Getenv("RACK") {
+		return httperr.Errorf(403, "application name cannot match rack name (%s). Please choose a different name for your app.", name)
+	}
+
 	// Early check for unbound app only.
 	if app, err := models.GetAppUnbound(name); err == nil {
 		return httperr.Errorf(403, "there is already a legacy app named %s (%s). We recommend you delete this app and create it again.", name, app.Status)

--- a/api/controllers/apps_test.go
+++ b/api/controllers/apps_test.go
@@ -130,6 +130,17 @@ func TestAppCreateWithAlreadyExistsUnbound(t *testing.T) {
 	assert.Equal(t, "{\"error\":\"there is already a legacy app named application (running). We recommend you delete this app and create it again.\"}", body)
 }
 
+func TestAppCreateWithRackName(t *testing.T) {
+	aws := test.StubAws(
+		test.DescribeAppStackCycle("foobar"),
+	)
+	defer aws.Close()
+
+	val := url.Values{"name": []string{"convox-test"}}
+	body := test.AssertStatus(t, 403, "POST", "http://convox/apps", val)
+	assert.Equal(t, "{\"error\":\"application name cannot match rack name (convox-test). Please choose a different name for your app.\"}", body)
+}
+
 // TODO: test bucket cleanup. this is handled via goroutines.
 /* NOTE: the S3 stuff fucks up b.c the client ries to prepend the
 bucket name to the ephermeral host, so you get `app-XXX.127.0.0.1`


### PR DESCRIPTION
## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [x] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

Fixes #490