### PR TITLE
Require at least 2 instances

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -81,7 +81,7 @@ func init() {
 			cli.IntFlag{
 				Name:  "instance-count",
 				Value: 3,
-				Usage: "number of EC2 instances",
+				Usage: "number of EC2 instances (must be greater than 1)",
 			},
 			cli.StringFlag{
 				Name:  "instance-type",
@@ -313,7 +313,11 @@ func cmdInstall(c *cli.Context) {
 	versionName := version.Version
 	formationUrl := fmt.Sprintf(FormationUrl, versionName)
 
-	instanceCount := fmt.Sprintf("%d", c.Int("instance-count"))
+	numInstances := c.Int("instance-count")
+	instanceCount := fmt.Sprintf("%d", numInstances)
+        if numInstances < 2 {
+		stdcli.QOSEventSend("cli-install", distinctId, stdcli.QOSEventProperties{Error: fmt.Errorf("instance-count must be greater than 1")})
+        }
 
 	fmt.Printf("Installing Convox (%s)...\n", versionName)
 


### PR DESCRIPTION
Not sure if this is the right/useful fix or not.  Based on my conversation with @mwarkentin, there should be at least 1 more instance than the number of processes your app is scaled to.  Since by default when you create your app, it will be scaled to at least 1, it doesn't make sense to me that you can create a rack with < 2 instances.  If you do, you'll end up in a weird state where 2 containers end up launching on the same instance and you have to hand stop one of the tasks.  There's a more fundamental ecs weirdness that you don't get an error when updating a task when there is only one instance, and this same failure happens.

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

