### PR TITLE
WIP: Allow multiple apps in convox start with --link

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -915,6 +915,9 @@ func proxyPort(protocol, from, to, link string, proxy bool) {
 		args = append(args, "proxy")
 	}
 
+	// wait for main container to come up
+	time.Sleep(1 * time.Second)
+
 	cmd := Execer("docker", args...)
 	// cmd.Stdout = os.Stdout
 	// cmd.Stderr = os.Stderr

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"log"
 	"math/rand"
-	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -461,45 +460,6 @@ func (m *Manifest) MissingEnvironment(cache bool, app string) ([]string, error) 
 	sort.Strings(missing)
 
 	return missing, nil
-}
-
-func (m *Manifest) PortConflicts() ([]string, error) {
-	wanted := m.PortsWanted()
-
-	conflicts := make([]string, 0)
-
-	host := dockerHost()
-
-	for _, p := range wanted {
-		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%s", host, p), 200*time.Millisecond)
-
-		if err == nil {
-			conflicts = append(conflicts, p)
-			defer conn.Close()
-		}
-	}
-
-	return conflicts, nil
-}
-
-func (m *Manifest) PortsWanted() []string {
-	ports := make([]string, 0)
-
-	for _, entry := range *m {
-		if pp, ok := entry.Ports.([]interface{}); ok {
-			for _, port := range pp {
-				if p, ok := port.(string); ok {
-					parts := strings.SplitN(p, ":", 2)
-
-					if len(parts) == 2 {
-						ports = append(ports, parts[0])
-					}
-				}
-			}
-		}
-	}
-
-	return ports
 }
 
 func (m *Manifest) Push(app, registry, tag string, flatten string) []error {

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -916,8 +916,8 @@ func proxyPort(protocol, from, to, link string, proxy bool) {
 	}
 
 	cmd := Execer("docker", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	// cmd.Stdout = os.Stdout
+	// cmd.Stderr = os.Stderr
 	cmd.Run()
 }
 

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -522,6 +522,8 @@ func (m *Manifest) Run(app string, cache bool, links []string) []error {
 		}
 	}()
 
+	Execer("docker", "network", "create", "convox").Run()
+
 	for i, name := range m.runOrder() {
 		sch := make(chan error)
 		go (*m)[name].runAsync(m, m.prefixForEntry(name, i), app, name, cache, links, ch, sch)

--- a/api/manifest/manifest_test.go
+++ b/api/manifest/manifest_test.go
@@ -49,21 +49,6 @@ RUNNING: docker tag -f xvlbzgbaic compose/web
 	_assert(t, cases)
 }
 
-func TestPortsWanted(t *testing.T) {
-	destDir := mkBuildDir(t, "../../examples/compose")
-	defer os.RemoveAll(destDir)
-
-	Init(destDir)
-	m, _ := Read(destDir, defaultManifestFile)
-	ps := m.PortsWanted()
-
-	cases := Cases{
-		{ps, []string{"5000"}},
-	}
-
-	_assert(t, cases)
-}
-
 func TestRunOrder(t *testing.T) {
 	var m Manifest
 	data := []byte(`web:
@@ -235,7 +220,7 @@ func testBuild(m *Manifest, app string) (string, string) {
 }
 
 func testRun(m *Manifest, app string) (string, string) {
-	return testRunner(m, app, func() { m.Run(app, true) })
+	return testRunner(m, app, func() { m.Run(app, true, []string{}) })
 }
 
 func testRunner(m *Manifest, app string, fn runnerFn) (string, string) {

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -72,16 +72,6 @@ func cmdStart(c *cli.Context) {
 		}
 	}
 
-	conflicts, err := m.PortConflicts()
-	if err != nil {
-		stdcli.QOSEventSend("cli-start", distinctId, stdcli.QOSEventProperties{Error: err})
-	}
-
-	if len(conflicts) > 0 {
-		stdcli.Error(fmt.Errorf("ports in use: %s", strings.Join(conflicts, ", ")))
-		return
-	}
-
 	missing, err := m.MissingEnvironment(cache, app)
 	if err != nil {
 		stdcli.QOSEventSend("cli-start", distinctId, stdcli.QOSEventProperties{Error: err})

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -22,6 +22,14 @@ func init() {
 				Value: "docker-compose.yml",
 				Usage: "path to an alternate docker compose manifest file",
 			},
+			cli.StringSliceFlag{
+				Name:  "link",
+				Usage: "link another instance of convox start",
+			},
+			cli.StringFlag{
+				Name:  "name",
+				Usage: "set the name of this convox start instance for use with --link",
+			},
 			cli.BoolFlag{
 				Name:  "no-cache",
 				Usage: "pull fresh image dependencies",
@@ -43,6 +51,7 @@ func cmdStart(c *cli.Context) {
 	}
 
 	cache := !c.Bool("no-cache")
+	links := c.StringSlice("link")
 
 	wd := "."
 
@@ -54,6 +63,10 @@ func cmdStart(c *cli.Context) {
 	if err != nil {
 		stdcli.Error(err)
 		return
+	}
+
+	if name := c.String("name"); name != "" {
+		app = name
 	}
 
 	file := c.String("file")
@@ -90,7 +103,7 @@ func cmdStart(c *cli.Context) {
 	ch := make(chan []error)
 
 	go func() {
-		ch <- m.Run(app, cache)
+		ch <- m.Run(app, cache, links)
 	}()
 
 	if c.Bool("sync") && stdcli.ReadSetting("sync") != "false" {


### PR DESCRIPTION
This PR is rebased on top of #648

```
$ cd foo && convox start
web: starting

$ convox start --name bar --link foo
worker: starting (with $FOO_WEB_HOST)

$ convox start --link foo --link bar
monitor: starting (with $FOO_WEB_HOST and $BAR_WORKER_HOST)
```

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI
