### PR TITLE
Add --shift argument to convox start

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -915,6 +915,9 @@ func proxyPort(protocol, from, to, link string, proxy bool) {
 		args = append(args, "proxy")
 	}
 
+	// wait for main container to come up
+	time.Sleep(1 * time.Second)
+
 	cmd := Execer("docker", args...)
 	// cmd.Stdout = os.Stdout
 	// cmd.Stderr = os.Stderr

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -916,8 +916,8 @@ func proxyPort(protocol, from, to, link string, proxy bool) {
 	}
 
 	cmd := Execer("docker", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	// cmd.Stdout = os.Stdout
+	// cmd.Stderr = os.Stderr
 	cmd.Run()
 }
 

--- a/api/manifest/manifest_test.go
+++ b/api/manifest/manifest_test.go
@@ -55,7 +55,7 @@ func TestPortsWanted(t *testing.T) {
 
 	Init(destDir)
 	m, _ := Read(destDir, defaultManifestFile)
-	ps := m.PortsWanted()
+	ps := m.PortsWanted(0)
 
 	cases := Cases{
 		{ps, []string{"5000"}},
@@ -235,7 +235,7 @@ func testBuild(m *Manifest, app string) (string, string) {
 }
 
 func testRun(m *Manifest, app string) (string, string) {
-	return testRunner(m, app, func() { m.Run(app, true) })
+	return testRunner(m, app, func() { m.Run(app, true, 0) })
 }
 
 func testRunner(m *Manifest, app string, fn runnerFn) (string, string) {


### PR DESCRIPTION
Adds a `--shift` argument to `convox start` that allows the requested ports to be shifted. This allows multiple applications to run on one host without conflicts.

Another potential solution to #484
Rebased on top of #648 

```shell
$ convox start
$ curl https://localhost:443/

$ convox start --shift 10000
$ curl https://localhost:10443/

$ echo 20000 > .convox/shift
$ convox start
$ curl https://localhost:20443/
```

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI
