### PR TITLE
Allow docker-compose.yml generation if Dockerfile is present

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -1457,8 +1457,7 @@ func initApplication(dir string) error {
 
 	os.Chdir(dir)
 
-	// TODO parse the Dockerfile and build a docker-compose.yml
-	if exists("Dockerfile") || exists("docker-compose.yml") {
+	if exists("docker-compose.yml") {
 		return nil
 	}
 
@@ -1466,8 +1465,11 @@ func initApplication(dir string) error {
 
 	fmt.Printf("Initializing %s\n", kind)
 
-	if err := writeAsset("Dockerfile", fmt.Sprintf("init/%s/Dockerfile", kind)); err != nil {
-		return err
+	// TODO parse the Dockerfile and build a docker-compose.yml
+	if !exists("Dockerfile") {
+		if err := writeAsset("Dockerfile", fmt.Sprintf("init/%s/Dockerfile", kind)); err != nil {
+			return err
+		}
 	}
 
 	if err := generateManifest(dir, fmt.Sprintf("init/%s/docker-compose.yml", kind)); err != nil {

--- a/api/manifest/manifest_test.go
+++ b/api/manifest/manifest_test.go
@@ -177,6 +177,37 @@ worker:
 	_assert(t, cases)
 }
 
+func TestGenerateDockerfileProcfile(t *testing.T) {
+	destDir := mkBuildDir(t, "../../examples/dockerfile-procfile")
+	defer os.RemoveAll(destDir)
+
+	Init(destDir)
+	m, _ := Read(destDir, defaultManifestFile)
+
+	Execer = func(bin string, args ...string) *exec.Cmd {
+		return exec.Command("true")
+	}
+
+	cases := Cases{
+		{readFile(t, destDir, "docker-compose.yml"), `web:
+  build: .
+  command: ruby web.rb
+  labels:
+  - convox.port.443.protocol=tls
+  - convox.port.443.proxy=true
+  ports:
+  - 80:4000
+  - 443:4001
+worker:
+  build: .
+  command: ruby worker.rb
+`},
+		{[]string{"web", "worker"}, m.runOrder()},
+	}
+
+	_assert(t, cases)
+}
+
 func mkBuildDir(t *testing.T, srcDir string) string {
 	destDir, err := ioutil.TempDir("", "")
 

--- a/cmd/convox/init.go
+++ b/cmd/convox/init.go
@@ -40,7 +40,7 @@ func cmdInit(c *cli.Context) {
 
 	// TODO parse the Dockerfile and build a docker-compose.yml
 	if exists("docker-compose.yml") {
-		stdcli.Error(fmt.Errorf("Cannot initialize a project that already contains a Dockerfile or docker-compose.yml"))
+		stdcli.Error(fmt.Errorf("Cannot initialize a project that already contains a docker-compose.yml"))
 		return
 	}
 

--- a/cmd/convox/init.go
+++ b/cmd/convox/init.go
@@ -39,8 +39,8 @@ func cmdInit(c *cli.Context) {
 	}
 
 	// TODO parse the Dockerfile and build a docker-compose.yml
-	if exists("Dockerfile") || exists("docker-compose.yml") {
-		stdcli.Error(fmt.Errorf("Can not initialize a project that already contains a Dockerfile or docker-compose.yml"))
+	if exists("docker-compose.yml") {
+		stdcli.Error(fmt.Errorf("Cannot initialize a project that already contains a Dockerfile or docker-compose.yml"))
 		return
 	}
 
@@ -71,7 +71,7 @@ func detectApplication(dir string) string {
 
 func initApplication(dir string) error {
 	// TODO parse the Dockerfile and build a docker-compose.yml
-	if exists("Dockerfile") || exists("docker-compose.yml") {
+	if exists("docker-compose.yml") {
 		return nil
 	}
 

--- a/examples/dockerfile-procfile/Dockerfile
+++ b/examples/dockerfile-procfile/Dockerfile
@@ -1,0 +1,11 @@
+FROM convox/ruby
+
+RUN gem install sinatra
+
+ENV PORT 3000
+EXPOSE 3000
+
+WORKDIR /app
+COPY . /app
+
+CMD ["ruby", "web.rb"]

--- a/examples/dockerfile-procfile/Gemfile
+++ b/examples/dockerfile-procfile/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "sinatra"

--- a/examples/dockerfile-procfile/Gemfile.lock
+++ b/examples/dockerfile-procfile/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sinatra

--- a/examples/dockerfile-procfile/Procfile
+++ b/examples/dockerfile-procfile/Procfile
@@ -1,0 +1,2 @@
+web: ruby web.rb
+worker: ruby worker.rb

--- a/examples/dockerfile-procfile/web.rb
+++ b/examples/dockerfile-procfile/web.rb
@@ -1,0 +1,7 @@
+require "sinatra"
+
+set :bind, "0.0.0.0"
+
+get "/" do
+  "Hello, World"
+end

--- a/examples/dockerfile-procfile/worker.rb
+++ b/examples/dockerfile-procfile/worker.rb
@@ -1,0 +1,6 @@
+$stdout.sync = true
+
+loop do
+  puts "working!"
+  sleep 1
+end


### PR DESCRIPTION
Continuation of https://github.com/convox/rack/pull/628

- Allows docker-compose.yml generation if Dockerfile is present
- Adds tests for Procfile-based docker-compose.yml generation

Thanks @prognostikos 

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI
