### PR TITLE
Wait until we can get the IP address for a container by its name

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -576,6 +576,7 @@ func (m *Manifest) Run(app string, cache bool, shift int) []error {
 			if (err == nil) && (net.ParseIP(strings.TrimSpace(string(ip))) != nil) {
 				break
 			}
+			time.Sleep(100 * time.Millisecond)
 		}
 	}
 

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -571,7 +571,7 @@ func (m *Manifest) Run(app string, cache bool, shift int) []error {
 		// block until we can get the container IP
 		for {
 			host := containerName(app, name)
-			ip, err := Execer("docker", "inspect", "-f", "{{ .NetworkSettings.IPAddress }}", host).CombinedOutput()
+			ip, err := Execer("docker", "inspect", "-f", "{{ .NetworkSettings.IPAddress }}", host).Output()
 
 			if (err == nil) && (net.ParseIP(strings.TrimSpace(string(ip))) != nil) {
 				break


### PR DESCRIPTION
This fixes a timing bug where `docker inspect` returns a blank IP address if we try to fetch it too quickly before the container hostname is propagated.

Fixes https://github.com/convox/rack/issues/679

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

