### PR TITLE
use O_WRONLY mode, print copy errors

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -1611,16 +1611,21 @@ func (m *Manifest) downloadRemoteAdds(container string, adds map[string]string) 
 				blockLocalAdds[local] += 1
 				blockLocalAddsLock.Unlock()
 
-				fd, err := os.OpenFile(local, os.O_CREATE, os.FileMode(header.Mode))
+				fd, err := os.OpenFile(local, os.O_CREATE|os.O_WRONLY, os.FileMode(header.Mode))
 
 				if err != nil {
 					fmt.Printf("err = %+v\n", err)
 					continue
 				}
 
-				io.Copy(fd, tr)
+				defer fd.Close()
 
-				fd.Close()
+				_, err = io.Copy(fd, tr)
+
+				if err != nil {
+					fmt.Printf("err = %+v\n", err)
+					continue
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Log `io.Copy` errors.

Set `O_WRONLY` mode when we open the file to write a download. Without this we get a "bad file descriptor" error and the written file is empty.

## Quick CLI Release Playbook
- [ ] Code review
- [x] Merge into master
- [ ] Release CLI