### PR TITLE
change ssh port sg to use vpc cidr, not 0.0.0.0

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -780,7 +780,7 @@
       "Properties": {
         "GroupDescription": "Instances",
         "SecurityGroupIngress": [
-          { "IpProtocol": "tcp", "FromPort": "22", "ToPort": "22", "CidrIp": "0.0.0.0/0" },
+          { "IpProtocol": "tcp", "FromPort": "22", "ToPort": "22", "CidrIp": { "Ref": "VPCCIDR" } },
           { "IpProtocol": "tcp", "FromPort": "0", "ToPort": "65535", "CidrIp": { "Ref": "VPCCIDR" } },
           { "IpProtocol": "udp", "FromPort": "0", "ToPort": "65535", "CidrIp": { "Ref": "VPCCIDR" } }
         ],


### PR DESCRIPTION
Fixes #710, continuing from #715. From @beedub:

> I was hoping to test installing from scratch but currently blocked by #714. I tested manually post-install on private and public installs by manually updating the sg's. Related issue: #710

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

this should be safer