### PR TITLE
validate process name for `convox run` based on formation, not active…

### DIFF
--- a/api/models/formation.go
+++ b/api/models/formation.go
@@ -21,7 +21,6 @@ type Formation []FormationEntry
 
 func ListFormation(app string) (Formation, error) {
 	a, err := GetApp(app)
-
 	if err != nil {
 		return nil, err
 	}
@@ -31,13 +30,11 @@ func ListFormation(app string) (Formation, error) {
 	}
 
 	release, err := GetRelease(a.Name, a.Release)
-
 	if err != nil {
 		return nil, err
 	}
 
 	manifest, err := LoadManifest(release.Manifest, a)
-
 	if err != nil {
 		return nil, err
 	}

--- a/client/formation.go
+++ b/client/formation.go
@@ -19,7 +19,6 @@ func (c *Client) ListFormation(app string) (Formation, error) {
 	var formation Formation
 
 	err := c.Get(fmt.Sprintf("/apps/%s/formation", app), &formation)
-
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/convox/ps.go
+++ b/cmd/convox/ps.go
@@ -46,6 +46,11 @@ func cmdPs(c *cli.Context) error {
 		return stdcli.ExitError(err)
 	}
 
+	if c.Bool("help") {
+		stdcli.Usage(c, "")
+		return nil
+	}
+
 	ps, err := rackClient(c).GetProcesses(app, c.Bool("stats"))
 	if err != nil {
 		return stdcli.ExitError(err)

--- a/cmd/convox/run.go
+++ b/cmd/convox/run.go
@@ -129,15 +129,13 @@ func runAttached(c *cli.Context, app, ps, args, release string) (int, error) {
 	return code, nil
 }
 func validateProcessId(c *cli.Context, app, ps string) error {
-
-	processes, err := rackClient(c).GetProcesses(app, false)
-
+	formation, err := rackClient(c).ListFormation(app)
 	if err != nil {
 		return err
 	}
 
-	for _, p := range processes {
-		if ps == p.Name {
+	for _, f := range formation {
+		if ps == f.Name {
 			return nil
 		}
 	}


### PR DESCRIPTION
This retains the ability to do a `convox run` on a process type scaled to 0 or -1