### PR TITLE
dont upgrade all packages; fixes a surprise update to docker 1.11

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -879,7 +879,6 @@
         "UserData": { "Fn::Base64":
           { "Fn::Join": [ "", [
             "#cloud-config\n",
-            "repo_upgrade: all\n",
             "repo_upgrade_exclude:\n",
             "  - kernel*\n",
             "packages:\n",


### PR DESCRIPTION
@MiguelMoll and I have been tracking down an error in CI with `convox run`:

```bash
$ convox run --app httpd-807 web echo "hello world”
> hello world
> ERROR: API error (500): Container c5ef6ea6901a616ec68f57712b2eb41104b654949ef30d72b625e473f80f1a23 is not running
```

The root cause was that Docker 1.11 was getting onto newly installed Racks from a `yum update`. This patch prevents automatically updating all packages like Docker, favoring getting Docker updates from new AMIs.