### PR TITLE
Update submodules on git checkout

### DIFF
--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -126,9 +126,11 @@ func cloneGit(s string) {
 	writeAsset("/usr/local/bin/git-restore-mtime", "git-restore-mtime", 0755, nil)
 
 	run(".", "git", "clone", "--progress", repo, "src")
+	run("src", "git", "submodule", "update", "--init", "--recursive")
 
 	if commitish != "" {
 		run("src", "git", "checkout", commitish)
+		run("src", "git", "submodule", "update", "--recursive")
 	}
 
 	run("src", "/usr/local/bin/git-restore-mtime", ".")


### PR DESCRIPTION
When checking out a git repository, also pull in the submodules. The changes here call `git submodule update --init --recursive` once the repo is cloned, and then if there's a hash to checkout, to call `git submodule update --recursive` after the hash has been checked out.

Not sure what best practices are around git submodules are - both of these commands seemingly succeed on repos without submodules - but they could be alternatively conditionally run if a `.gitmodules` file was present?

/cc @nzoschke 

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

