### PR TITLE
changed provisioned throughput for DynamoDB indexes

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -1387,9 +1387,9 @@
           "IndexName": "app.created",
           "KeySchema": [ { "AttributeName": "app", "KeyType": "HASH" }, { "AttributeName": "created", "KeyType": "RANGE" } ],
           "Projection": { "ProjectionType": "ALL" },
-          "ProvisionedThroughput": { "ReadCapacityUnits": "20", "WriteCapacityUnits": "20" }
+          "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "5" }
         }],
-        "ProvisionedThroughput": { "ReadCapacityUnits": "20", "WriteCapacityUnits": "20" }
+        "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "5" }
       }
     },
     "DynamoReleases": {
@@ -1406,9 +1406,9 @@
           "IndexName": "app.created",
           "KeySchema": [ { "AttributeName": "app", "KeyType": "HASH" }, { "AttributeName": "created", "KeyType": "RANGE" } ],
           "Projection": { "ProjectionType": "ALL" },
-          "ProvisionedThroughput": { "ReadCapacityUnits": "20", "WriteCapacityUnits": "20" }
+          "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "5" }
         }],
-        "ProvisionedThroughput": { "ReadCapacityUnits": "20", "WriteCapacityUnits": "20" }
+        "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "5" }
       }
     },
     "Settings": {


### PR DESCRIPTION
## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

A default throughput of 5 read / 5 writes for each index should be really more than enough for most users.

Objects saved in DDB are really not so big, and most users will not make many builds and releases per second. It shouldn't need to be 80 for the total (about $50/month), 5 units each max (it's in operations / second, depending on the size of the objects retrieved) should largely suffice, and those who are consistantly using more than that will probably be able to figure out that they are really doing so many builds and releases.

FYI, I have set my company's at 3 units each, and it is so low I can barely see that data in the cloudwatch alarms that will usually show "insufficient data" most of the time at about 50 builds/day, even when I tried hard to build and release a bunch of apps at about the same time.