### PR TITLE
Parameterize autoscale instance batch size

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -221,6 +221,12 @@
       "Description": "The type of the instances in the runtime cluster",
       "Type": "String"
     },
+    "InstanceUpdateBatchSize": {
+      "Default": "1",
+      "Description": "The number of instances to update in a batch",
+      "MinValue": "1",
+      "Type": "Number"
+    },
     "Key": {
       "Default": "",
       "Description": "SSH key name for access to cluster instances",
@@ -1006,7 +1012,7 @@
       },
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
-          "MaxBatchSize": "1",
+          "MaxBatchSize": { "Ref": "InstanceUpdateBatchSize" },
           "MinInstancesInService": { "Ref": "InstanceCount" },
           "PauseTime" : "PT15M",
           "SuspendProcesses": [


### PR DESCRIPTION
## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

I had a fleet of 20 servers, but a rolling deploy 1-at-a-time took 30+ minutes. I would have been ok with batches of 5 servers being taken out of rotation.

Could there be weird behavior if a large batch size takes too many ECS instances out-of-rotation? Will ECS prevent the autoscale from succeeding? Despite these questions, it would be user-configurable with the safest option (1) as the default