### PR TITLE
Capture `convox run` output in a log

### DIFF
--- a/ci/tests/example-app
+++ b/ci/tests/example-app
@@ -87,4 +87,4 @@ wait_for_app_deployment
 
 convox ps --app $APP_NAME
 
-convox run --app $APP_NAME web echo "hello world" | grep "hello world"
+convox run --app $APP_NAME web echo "hello world" | tee -a $CIRCLE_ARTIFACTS/$APP_NAME-run.log && grep -i "hello world" $CIRCLE_ARTIFACTS/$APP_NAME-run.log


### PR DESCRIPTION
The use of `tee` will allow the output to be displayed to STDOUT and logged to an artifact file.

Previous behavior, the output was being swallowed by `grep` and made it harder to debug what was going on.