### PR TITLE
Critical Fix: Older clients can accidentally delete a process / ELB

### DIFF
--- a/api/controllers/formation.go
+++ b/api/controllers/formation.go
@@ -47,7 +47,13 @@ func FormationSet(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		if c, err := strconv.ParseInt(cc, 10, 64); err != nil {
 			return httperr.Errorf(403, "count must be numeric")
 		} else {
-			count = c
+			// critical fix: old clients default to count=-1 for "no change"
+			// assert a minimum client version before setting count=-1 which now deletes a service / ELB
+			if c == -1 && r.Header.Get("Version") < "20160602213113" {
+				count = -2
+			} else {
+				count = c
+			}
 		}
 	}
 


### PR DESCRIPTION
In https://github.com/convox/rack/commit/10605762873a69239b0184e9093d6cc08a3a6a66 an API change was introduced where sending `count=-1` to the `convox scale` API is valid and indicates to delete the process type and ELB.

This was released in [rack 20160602143119](https://github.com/convox/rack/releases/tag/20160602143119) and [CLI 20160602213113](https://dl.equinox.io/convox/convox/stable/archive).

There have been reports of an serious side effect. Doing a `convox scale --memory=512` on older clients sends a `count=-1` value as a default, triggering the new deletion behavior.

This API update asserts a minimum client version before accepting `count=-1`.

## Release Playbook
- [x] Rebase against master
- [x] Release branch ()
- [ ] Pass CI ()
- [x] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

