### PR TITLE
Pin to use golang:1.6.1-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6-alpine
+FROM golang:1.6.1-alpine
 
 RUN apk update && apk add build-base docker git haproxy openssh openssl python
 


### PR DESCRIPTION
Version `golang:1.6-alpine` will pull the latest release of 1.6.x along with an updated version of alpine. This in turn updates docker to 1.11.1 which can break compatibility with ECS.