### PR TITLE
Improving `convox ps` reliability

### DIFF
--- a/api/models/process.go
+++ b/api/models/process.go
@@ -271,7 +271,7 @@ func ListProcesses(app string) ([]*Process, error) {
 }
 
 // ListPendingProcesses tries to get a list of all pending processes.
-// If unable to connect to a docker daemon, or error out for another reason, it will bypass that instance and continue to other daemons.
+// If unable to gather needed data it will continue to other processes.
 func ListPendingProcesses(app string) (Processes, error) {
 	// In AWS ECS, pending processes would present themselves during a deployment.
 	pss := Processes{}

--- a/api/models/process.go
+++ b/api/models/process.go
@@ -249,8 +249,6 @@ func ListProcesses(app string) ([]*Process, error) {
 		select {
 		case ps := <-psch:
 			pss = append(pss, &ps)
-		default:
-			// noop
 		}
 	}
 


### PR DESCRIPTION
Following changes are to make `convox ps` act a bit more reliable when encountering errors while gathering data. The goal is to log errors (if any) and fail gracefully.