### PR TITLE
Human friendly logging about why instances are replaced

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -909,7 +909,7 @@
             "  - echo \"", { "Ref": "ClientId" }, "\" > /etc/convox/client_id\n",
             "  - echo \"", { "Ref": "Kinesis" }, "\" > /etc/convox/kinesis\n",
             "  - echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group\n",
-            "  - curl -s https://convox.s3.amazonaws.com/agent/0.68/convox.conf > /etc/init/convox.conf\n",
+            "  - curl -s https://convox.s3.amazonaws.com/agent/0.69/convox.conf > /etc/init/convox.conf\n",
             "  - echo -e '/var/log/docker {\\n  rotate 7\\n  daily\\n  nocompress\\n  copytruncate\\n}' >> /etc/logrotate.d/docker\n",
             { "Fn::If": [ "BlankInstanceBootCommand",
               { "Ref": "AWS::NoValue" },

--- a/api/workers/autoscale.go
+++ b/api/workers/autoscale.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"time"
@@ -26,7 +27,6 @@ func autoscaleRack() {
 	log := logger.New("ns=workers.autoscale at=autoscaleRack")
 
 	capacity, err := provider.CapacityGet()
-
 	if err != nil {
 		log.Log("fn=models.GetSystemCapacity err=%q", err)
 		return
@@ -39,7 +39,6 @@ func autoscaleRack() {
 	}
 
 	system, err := provider.SystemGet()
-
 	if err != nil {
 		log.Log("fn=models.GetSystem err=%q", err)
 		return
@@ -69,9 +68,11 @@ func autoscaleRack() {
 	system.Count = instances
 
 	err = provider.SystemSave(*system)
-
 	if err != nil {
 		log.Log("fn=system.Save err=%q", err)
 		return
 	}
+
+	// log for humans
+	fmt.Printf("who=\"convox/monitor\" what=\"autoscaled instance count to %d\" why=\"a service wants %s processes behind a load balancer\"\n", system.Count)
 }

--- a/api/workers/cluster.go
+++ b/api/workers/cluster.go
@@ -12,10 +12,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/ddollar/logger"
-	"github.com/fsouza/go-dockerclient"
 )
 
 type Instance struct {
@@ -56,8 +54,6 @@ func StartCluster() {
 			log.Error(err)
 			continue
 		}
-
-		// TODO: Add an instances.testDocker() call to the mission critical path
 
 		// Test if ASG Instance is registered and connected in ECS cluster
 		for k, i := range instances {
@@ -197,79 +193,4 @@ func (instances Instances) log() string {
 		strings.Join(asgIds, ","),
 		strings.Join(unhealthyIds, ","),
 	)
-}
-
-func (instances Instances) testDocker() error {
-	for _, i := range instances {
-		instance := instances[i.Id]
-
-		res, err := models.EC2().DescribeInstances(&ec2.DescribeInstancesInput{
-			Filters: []*ec2.Filter{
-				&ec2.Filter{Name: aws.String("instance-id"), Values: []*string{&i.Id}},
-			},
-		})
-
-		if err != nil {
-			return err
-		}
-
-		if len(res.Reservations) != 1 || len(res.Reservations[0].Instances) != 1 {
-			return fmt.Errorf("could not describe container instance")
-		}
-
-		ip := *res.Reservations[0].Instances[0].PrivateIpAddress
-
-		if os.Getenv("DEVELOPMENT") == "true" {
-			ip = *res.Reservations[0].Instances[0].PublicIpAddress
-		}
-
-		d, err := docker.NewClient(fmt.Sprintf("http://%s:2376", ip))
-
-		if err != nil {
-			return err
-		}
-
-		err = d.PullImage(docker.PullImageOptions{
-			Repository: "busybox",
-		}, docker.AuthConfiguration{})
-
-		if err != nil {
-			return err
-		}
-
-		instance.Docker = true
-
-		dres, err := d.CreateContainer(docker.CreateContainerOptions{
-			Config: &docker.Config{
-				Cmd:   []string{"sh", "-c", `dmesg | grep "Remounting filesystem read-only"`},
-				Image: "busybox",
-			},
-		})
-
-		if err != nil {
-			return err
-		}
-
-		err = d.StartContainer(dres.ID, nil)
-
-		if err != nil {
-			return err
-		}
-
-		code, err := d.WaitContainer(dres.ID)
-
-		if err != nil {
-			return err
-		}
-
-		// grep exit status is 0 if any line was selected, 1 otherwise
-		// no "Remounting" selected is healthy
-		if code == 1 {
-			instance.Check = true
-		}
-
-		instances[i.Id] = instance
-	}
-
-	return nil
 }

--- a/api/workers/cluster.go
+++ b/api/workers/cluster.go
@@ -44,14 +44,12 @@ func StartCluster() {
 		instances := Instances{}
 
 		err := instances.describeASG()
-
 		if err != nil {
 			log.Error(err)
 			continue
 		}
 
 		err = instances.describeECS()
-
 		if err != nil {
 			log.Error(err)
 			continue
@@ -60,7 +58,7 @@ func StartCluster() {
 		// TODO: Add an instances.testDocker() call to the mission critical path
 
 		// Test if ASG Instance is registered and connected in ECS cluster
-		for _, i := range instances {
+		for k, i := range instances {
 			if !i.ASG {
 				// TODO: Rogue instance?! Terminate?
 				continue
@@ -77,11 +75,15 @@ func StartCluster() {
 				)
 
 				i.Unhealthy = true
+				instances[k] = i
 
 				if err != nil {
 					log.Error(err)
 					continue
 				}
+
+				// log for humans
+				fmt.Printf("who=\"convox/monitor\" what=\"marked instance %s unhealthy\" why=\"ECS reported agent disconnected\"\n", i.Id)
 			}
 		}
 


### PR DESCRIPTION
Addresses #718. With https://github.com/convox/agent/pull/25. Add logs for humans around instance monitoring, failure and scale events.

## Demo

```bash
$ convox logs --app=convox --filter=why --follow=false --since=2h
2016-06-13T20:23:41Z web:20160613194548-monitor/5a0c98f252bf who="EC2/ASG" what="Launching a new EC2 instance: i-a5f0bc3f" why="At 2016-06-13T20:23:03Z an instance was started in response to a difference between desired and actual capacity, increasing the capacity from 3 to 4."
2016-06-13T20:42:54Z agent:0.69/i-a5f0bc3f who="convox/agent" what="marked i-a5f0bc3f unhealthy" why="docker signal: killed"
2016-06-13T20:47:29Z web:20160613194548-monitor/a76ecf0a4d4d who="EC2/ASG" what="Launching a new EC2 instance: i-5a034cc0" why="At 2016-06-13T20:43:33Z an instance was started in response to a difference between desired and actual capacity, increasing the capacity from 2 to 3."
2016-06-13T21:11:47Z web:20160613194548-monitor/a76ecf0a4d4d who="convox/monitor" what="marked instance i-98f86904 unhealthy" why="ECS reported agent disconnected"
2016-06-13T21:12:29Z web:20160613194548-monitor/a76ecf0a4d4d who="EC2/ASG" what="Terminating EC2 instance: i-98f86904" why="At 2016-06-13T21:12:19Z an instance was taken out of service in response to a user health-check."
2016-06-13T21:17:29Z web:20160613194548-monitor/a76ecf0a4d4d who="EC2/ASG" what="Launching a new EC2 instance: i-319f0ead" why="At 2016-06-13T21:12:48Z an instance was started in response to a difference between desired and actual capacity, increasing the capacity from 2 to 3."
```

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI
