### PR TITLE
Allow a rack to only operate on itself

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -71,8 +71,15 @@ func GetApp(name string) (*App, error) {
 		app, err = getAppByStackName(name)
 	}
 
-	if app != nil && app.Tags["Rack"] != "" && app.Tags["Rack"] != os.Getenv("RACK") {
-		return nil, fmt.Errorf("no such app: %s", name)
+	if app != nil {
+		if app.Tags["Rack"] != "" && app.Tags["Rack"] != os.Getenv("RACK") {
+			return nil, fmt.Errorf("no such app: %s", name)
+
+		} else if len(app.Tags) == 0 && name != os.Getenv("RACK") {
+			// This checks for a rack. An app with zero tags is a rack (this assumption should be addressed).
+			// Makes sure the name equals current rack name; otherwise error out.
+			return nil, fmt.Errorf("invalid rack: %s", name)
+		}
 	}
 
 	return app, err

--- a/api/provider/aws/apps.go
+++ b/api/provider/aws/apps.go
@@ -18,7 +18,8 @@ func (p *AWSProvider) AppGet(name string) (*structs.App, error) {
 			StackName: aws.String(name),
 		})
 	} else {
-		// try 'convox-myapp', and if not found try 'myapp'
+
+		// try '$RACK-myapp', and if not found try 'myapp'
 		res, err = p.describeStacks(&cloudformation.DescribeStacksInput{
 			StackName: aws.String(os.Getenv("RACK") + "-" + name),
 		})
@@ -42,6 +43,10 @@ func (p *AWSProvider) AppGet(name string) (*structs.App, error) {
 
 	if app.Tags["Rack"] != "" && app.Tags["Rack"] != os.Getenv("RACK") {
 		return nil, fmt.Errorf("no such app on this rack: %s", name)
+	} else if len(app.Tags) == 0 && name != os.Getenv("RACK") {
+		// This checks for a rack. An app with zero tags is a rack (this assumption should be addressed).
+		// Makes sure the name equals current rack name; otherwise error out.
+		return nil, fmt.Errorf("invalid rack: %s", name)
 	}
 
 	return &app, nil


### PR DESCRIPTION
This fix address the issue where more than one rack in the same AWS account
and region from affecting one another. Fixes issue #379.