### PR TITLE
cleanup old builds after build creation

### DIFF
--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync"
 
 	"github.com/convox/rack/api/manifest"
 	"github.com/convox/rack/client"
@@ -67,23 +66,6 @@ func main() {
 
 	_, err = rackClient.UpdateBuild(os.Getenv("APP"), os.Getenv("BUILD"), string(data), "complete", "")
 	handleError(err)
-
-	bs, err := rackClient.GetBuildsWithLimit(os.Getenv("APP"), 150)
-	handleError(err)
-
-	if len(bs) >= 100 {
-		wg := new(sync.WaitGroup)
-		outDated := bs[100:]
-		for _, b := range outDated {
-			wg.Add(1)
-			go func(buildId string, wg *sync.WaitGroup) {
-				defer wg.Done()
-				_, err := rackClient.DeleteBuild(os.Getenv("APP"), buildId)
-				handleError(err)
-			}(b.Id, wg)
-		}
-		wg.Wait()
-	}
 }
 
 func handleError(err error) {

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -68,12 +68,12 @@ func main() {
 	_, err = rackClient.UpdateBuild(os.Getenv("APP"), os.Getenv("BUILD"), string(data), "complete", "")
 	handleError(err)
 
-	bs, err := rackClient.GetBuildsWithLimit(os.Getenv("APP"), 250)
+	bs, err := rackClient.GetBuildsWithLimit(os.Getenv("APP"), 150)
 	handleError(err)
 
-	if len(bs) >= 200 {
+	if len(bs) >= 100 {
 		wg := new(sync.WaitGroup)
-		outDated := bs[200:]
+		outDated := bs[100:]
 		for _, b := range outDated {
 			wg.Add(1)
 			go func(buildId string, wg *sync.WaitGroup) {

--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -193,9 +193,9 @@ func BuildUpdate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		if err != nil {
 			fmt.Println("Error listing builds for cleanup")
 		} else {
-			if len(bs) >= 4 {
+			if len(bs) >= 50 {
 				wg := new(sync.WaitGroup)
-				outDated := bs[4:]
+				outDated := bs[50:]
 				for _, b := range outDated {
 					wg.Add(1)
 					go func(buildId string, wg *sync.WaitGroup) {

--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,7 +22,21 @@ import (
 func BuildList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	app := mux.Vars(r)["app"]
 
-	builds, err := provider.BuildList(app)
+	l := r.URL.Query().Get("limit")
+
+	var err error
+	var limit int
+
+	if l == "" {
+		limit = 20
+	} else {
+		limit, err = strconv.Atoi(l)
+		if err != nil {
+			return httperr.Errorf(400, err.Error())
+		}
+	}
+
+	builds, err := provider.BuildList(app, int64(limit))
 	if awsError(err) == "ValidationError" {
 		return httperr.Errorf(404, "no such app: %s", app)
 	}

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -212,9 +212,7 @@ func (a *App) Cleanup() error {
 		return err
 	}
 
-	// FIXME: BuildList and ReleaseList only lists and cleans up the last 20 builds/releases
-	// FIXME: Should the delete calls happen in a goroutine?
-	builds, err := provider.BuildList(a.Name)
+	builds, err := provider.BuildList(a.Name, 200)
 	if err != nil {
 		return err
 	}
@@ -223,6 +221,8 @@ func (a *App) Cleanup() error {
 		provider.BuildDelete(a.Name, build.Id)
 	}
 
+	// FIXME: ReleaseList only lists and cleans up the last 20 builds/releases
+	// FIXME: Should the delete calls happen in a goroutine?
 	releases, err := provider.ReleaseList(a.Name)
 	if err != nil {
 		return err

--- a/api/provider/aws/builds.go
+++ b/api/provider/aws/builds.go
@@ -291,7 +291,7 @@ func (p *AWSProvider) BuildGet(app, id string) (*structs.Build, error) {
 	return build, nil
 }
 
-func (p *AWSProvider) BuildList(app string) (structs.Builds, error) {
+func (p *AWSProvider) BuildList(app string, limit int64) (structs.Builds, error) {
 	a, err := p.AppGet(app)
 	if err != nil {
 		return nil, err
@@ -305,7 +305,7 @@ func (p *AWSProvider) BuildList(app string) (structs.Builds, error) {
 			},
 		},
 		IndexName:        aws.String("app.created"),
-		Limit:            aws.Int64(20),
+		Limit:            aws.Int64(limit),
 		ScanIndexForward: aws.Bool(false),
 		TableName:        aws.String(buildsTable(a.Name)),
 	}

--- a/api/provider/aws/builds_test.go
+++ b/api/provider/aws/builds_test.go
@@ -125,7 +125,7 @@ func TestBuildList(t *testing.T) {
 		provider.CurrentProvider = new(provider.TestProviderRunner)
 	}()
 
-	b, err := provider.BuildList("httpd")
+	b, err := provider.BuildList("httpd", 20)
 
 	assert.Nil(t, err)
 	assert.EqualValues(t, structs.Builds{

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -20,7 +20,7 @@ type Provider interface {
 	BuildCreateTar(app string, src io.Reader, manifest, description string, cache bool) (*structs.Build, error)
 	BuildDelete(app, id string) (*structs.Build, error)
 	BuildGet(app, id string) (*structs.Build, error)
-	BuildList(app string) (structs.Builds, error)
+	BuildList(app string, limit int64) (structs.Builds, error)
 	BuildRelease(*structs.Build) (*structs.Release, error)
 	BuildSave(*structs.Build) error
 
@@ -104,8 +104,8 @@ func BuildGet(app, id string) (*structs.Build, error) {
 	return CurrentProvider.BuildGet(app, id)
 }
 
-func BuildList(app string) (structs.Builds, error) {
-	return CurrentProvider.BuildList(app)
+func BuildList(app string, limit int64) (structs.Builds, error) {
+	return CurrentProvider.BuildList(app, limit)
 }
 
 func BuildRelease(b *structs.Build) (*structs.Release, error) {

--- a/api/provider/test.go
+++ b/api/provider/test.go
@@ -58,8 +58,8 @@ func (p *TestProviderRunner) BuildGet(app, id string) (*structs.Build, error) {
 	return &p.Build, nil
 }
 
-func (p *TestProviderRunner) BuildList(app string) (structs.Builds, error) {
-	p.Called(app)
+func (p *TestProviderRunner) BuildList(app string, limit int64) (structs.Builds, error) {
+	p.Called(app, limit)
 	return p.Builds, nil
 }
 

--- a/client/builds.go
+++ b/client/builds.go
@@ -35,6 +35,18 @@ func (c *Client) GetBuilds(app string) (Builds, error) {
 	return builds, nil
 }
 
+func (c *Client) GetBuildsWithLimit(app string, limit int) (Builds, error) {
+	var builds Builds
+
+	err := c.Get(fmt.Sprintf("/apps/%s/builds?limit=%d", app, limit), &builds)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return builds, nil
+}
+
 func (c *Client) CreateBuildIndex(app string, index Index, cache bool, manifest string, description string) (*Build, error) {
 	var build Build
 

--- a/client/builds.go
+++ b/client/builds.go
@@ -27,7 +27,6 @@ func (c *Client) GetBuilds(app string) (Builds, error) {
 	var builds Builds
 
 	err := c.Get(fmt.Sprintf("/apps/%s/builds", app), &builds)
-
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +38,6 @@ func (c *Client) GetBuildsWithLimit(app string, limit int) (Builds, error) {
 	var builds Builds
 
 	err := c.Get(fmt.Sprintf("/apps/%s/builds?limit=%d", app, limit), &builds)
-
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +49,6 @@ func (c *Client) CreateBuildIndex(app string, index Index, cache bool, manifest 
 	var build Build
 
 	data, err := json.Marshal(index)
-
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +61,6 @@ func (c *Client) CreateBuildIndex(app string, index Index, cache bool, manifest 
 	}
 
 	err = c.Post(fmt.Sprintf("/apps/%s/builds", app), params, &build)
-
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +113,6 @@ func (c *Client) GetBuild(app, id string) (*Build, error) {
 	var build Build
 
 	err := c.Get(fmt.Sprintf("/apps/%s/builds/%s", app, id), &build)
-
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +158,6 @@ func (c *Client) UpdateBuild(app, id, manifest, status, reason string) (*Build, 
 	var build Build
 
 	err := c.Put(fmt.Sprintf("/apps/%s/builds/%s", app, id), params, &build)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes #361 

Currently ECR has a 500 image limit.

This causes builds and deployments to fail.

This approach may be too brute force, however we expect Amazon to remove this limit over time so want to avoid putting lots of engineering time into this hopefully temporary fix.

The idea here is to simply delete older builds, this will be done in batches on each build to remove old builds for existing users and will generally only delete the 51st oldest build from there.

Currently you can only access the 20 most recent bulids anyway so this should not break anyone's existing workflows.

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

