### PR TITLE
Add some clarity to what the login password can accept

### DIFF
--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -29,7 +29,7 @@ func init() {
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "password, p",
-				Usage: "Password to use for authentication. If not specified, prompt for password. Also accepts a Convox Console API key.",
+				Usage: "Console API key or Rack password. If not specified, prompt.",
 			},
 		},
 	})

--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -29,7 +29,7 @@ func init() {
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "password, p",
-				Usage: "Password to use for authentication. If not specified, prompt for password.",
+				Usage: "Password to use for authentication. If not specified, prompt for password. Also accepts a Convox Console API key.",
 			},
 		},
 	})


### PR DESCRIPTION
Small tweak that should fix #709. The usage prompt states that a Console API key is also accepted.

## Quick CLI Release Playbook
- [x] Code review
- [ ] Merge into master
- [ ] Release CLI


