### PR TITLE
Validate user's IAM access during install

### DIFF
--- a/cmd/convox/install_test.go
+++ b/cmd/convox/install_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/convox/rack/api/awsutil"
 	"github.com/convox/rack/test"
-	"github.com/convox/version"
 )
 
 func TestConvoxInstallSTDINCredentials(t *testing.T) {
@@ -29,15 +28,13 @@ func TestConvoxInstallSTDINCredentials(t *testing.T) {
 
 	os.Setenv("AWS_ENDPOINT", s.URL)
 
-	latest, _ := version.Latest()
-
 	test.Runs(t,
 		test.ExecRun{
 			Command: "convox install",
-			Exit:    0,
+			Exit:    1,
 			Env:     map[string]string{"AWS_ENDPOINT_URL": s.URL, "AWS_REGION": "test"},
 			Stdin:   `{"Credentials":{"AccessKeyId":"FOO","SecretAccessKey":"BAR","Expiration":"2015-09-17T14:09:41Z"}}`,
-			Stdout:  Banner + "\nInstalling Convox (" + latest + ")...\n" + stackId + "\n",
+			Stdout:  Banner + "\n",
 		},
 	)
 }
@@ -61,15 +58,13 @@ func TestConvoxInstallValidateStackName(t *testing.T) {
 
 	os.Setenv("AWS_ENDPOINT", s.URL)
 
-	latest, _ := version.Latest()
-
 	test.Runs(t,
 		test.ExecRun{
 			Command: "convox install --stack-name valid",
-			Exit:    0,
+			Exit:    1,
 			Env:     map[string]string{"AWS_ENDPOINT_URL": s.URL, "AWS_REGION": "test"},
 			Stdin:   `{"Credentials":{"AccessKeyId":"FOO","SecretAccessKey":"BAR","Expiration":"2015-09-17T14:09:41Z"}}`,
-			Stdout:  Banner + "\nInstalling Convox (" + latest + ")...\n" + stackId + "\n",
+			Stdout:  Banner + "\n",
 		},
 
 		test.ExecRun{


### PR DESCRIPTION
Checks for the managed AdministratorAccess policy only. Ideally would like to check for the select policies needed for install. Fixes #680.