### PR TITLE
AMI bump for docker 1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.1-alpine
+FROM golang:1.6.2-alpine
 
 RUN apk update && apk add build-base docker git haproxy openssh openssl python tar
 

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -16,13 +16,13 @@
   "Mappings": {
     "RegionConfig": {
       "us-east-1": { "Ami": "ami-8f7687e2" },
-      "us-west-1": { "Ami": "ami-b7d5a8d7" },
-      "us-west-2": { "Ami": "ami-c7a451a7" },
-      "eu-west-1": { "Ami": "ami-9c9819ef" },
-      "eu-central-1": { "Ami": "ami-9aeb0af5" },
-      "ap-northeast-1": { "Ami": "ami-7e4a5b10" },
-      "ap-southeast-1": { "Ami": "ami-be63a9dd" },
-      "ap-southeast-2": { "Ami": "ami-b8cbe8db" }
+      "us-west-1": { "Ami": "ami-bb473cdb" },
+      "us-west-2": { "Ami": "ami-84b44de4" },
+      "eu-west-1": { "Ami": "ami-4e6ffe3d" },
+      "eu-central-1": { "Ami": "ami-b0cc23df" },
+      "ap-northeast-1": { "Ami": "ami-095dbf68" },
+      "ap-southeast-1": { "Ami": "ami-cf03d2ac" },
+      "ap-southeast-2": { "Ami": "ami-697a540a" }
     }
   },
   "Outputs": {

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -15,7 +15,7 @@
   },
   "Mappings": {
     "RegionConfig": {
-      "us-east-1": { "Ami": "ami-67a3a90d" },
+      "us-east-1": { "Ami": "ami-8f7687e2" },
       "us-west-1": { "Ami": "ami-b7d5a8d7" },
       "us-west-2": { "Ami": "ami-c7a451a7" },
       "eu-west-1": { "Ami": "ami-9c9819ef" },

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -471,7 +471,6 @@ func (a *App) ExecAttached(pid, command string, height, width int, rw io.ReadWri
 
 func (a *App) RunAttached(process, command, releaseId string, height, width int, rw io.ReadWriter) error {
 	resources, err := a.Resources()
-
 	if err != nil {
 		return err
 	}
@@ -480,7 +479,6 @@ func (a *App) RunAttached(process, command, releaseId string, height, width int,
 		TaskDefinition: aws.String(resources[UpperName(process)+"ECSTaskDefinition"].Id),
 	}
 	task, err := ECS().DescribeTaskDefinition(input)
-
 	if err != nil {
 		return err
 	}
@@ -503,19 +501,16 @@ func (a *App) RunAttached(process, command, releaseId string, height, width int,
 	}
 
 	release, err := GetRelease(a.Name, releaseId)
-
 	if err != nil {
 		return err
 	}
 
 	manifest, err := LoadManifest(release.Manifest, a)
-
 	if err != nil {
 		return err
 	}
 
 	me := manifest.Entry(process)
-
 	if me == nil {
 		return fmt.Errorf("no such process: %s", process)
 	}
@@ -524,7 +519,6 @@ func (a *App) RunAttached(process, command, releaseId string, height, width int,
 	host := ""
 
 	pss, err := ListProcesses(a.Name)
-
 	if err != nil {
 		return err
 	}
@@ -579,7 +573,6 @@ func (a *App) RunAttached(process, command, releaseId string, height, width int,
 	}
 
 	d, err := Docker(host)
-
 	if err != nil {
 		return err
 	}
@@ -592,7 +585,6 @@ func (a *App) RunAttached(process, command, releaseId string, height, width int,
 		Username:      username,
 		Password:      password,
 	})
-
 	if err != nil {
 		return err
 	}
@@ -618,7 +610,6 @@ func (a *App) RunAttached(process, command, releaseId string, height, width int,
 			Binds: binds,
 		},
 	})
-
 	if err != nil {
 		return err
 	}
@@ -645,25 +636,23 @@ func (a *App) RunAttached(process, command, releaseId string, height, width int,
 	time.Sleep(100 * time.Millisecond)
 
 	err = d.StartContainer(res.ID, nil)
-
 	if err != nil {
 		return err
 	}
 
 	err = d.ResizeContainerTTY(res.ID, height, width)
-
 	if err != nil {
-		return err
+		// In some cases, a container might finish and exit by the time ResizeContainerTTY is called.
+		// Resizing the TTY shouldn't cause the call to error out for cases like that.
+		fmt.Printf("fn=RunAttached level=warning msg=\"unable to resize container: %s\"", err)
 	}
 
 	code, err := d.WaitContainer(res.ID)
-
 	if err != nil {
 		return err
 	}
 
 	_, err = rw.Write([]byte(fmt.Sprintf("%s%d\n", StatusCodePrefix, code)))
-
 	if err != nil {
 		return err
 	}
@@ -673,7 +662,6 @@ func (a *App) RunAttached(process, command, releaseId string, height, width int,
 
 func (a *App) RunDetached(process, command, releaseId string) error {
 	resources, err := a.Resources()
-
 	if err != nil {
 		return err
 	}
@@ -741,7 +729,6 @@ func (a *App) ProcessPorts(ps string) map[string]string {
 
 func (a *App) Resources() (Resources, error) {
 	resources, err := ListResources(a.Name)
-
 	if err != nil {
 		return nil, err
 	}
@@ -772,7 +759,6 @@ func cleanupBucket(bucket string) error {
 	}
 
 	res, err := S3().ListObjectVersions(req)
-
 	if err != nil {
 		return err
 	}
@@ -796,7 +782,6 @@ func cleanupBucketObject(bucket, key, version string) {
 	}
 
 	_, err := S3().DeleteObject(req)
-
 	if err != nil {
 		fmt.Printf("error: %s\n", err)
 	}


### PR DESCRIPTION
Bumped the AMI for all regions according to http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html.

```
The current Amazon ECS-optimized AMI (amzn-ami-2016.03.c-amazon-ecs-optimized) consists of:

The latest minimal version of the Amazon Linux AMI
The latest version of the Amazon ECS container agent (1.10.0)
The recommended version of Docker for the latest Amazon ECS container agent (1.11.1)
The latest version of the ecs-init package to run and monitor the Amazon ECS agent (1.10.0-1)
```

```
Region	AMI Name	AMI ID	EC2 console link
us-east-1	amzn-ami-2016.03.c-amazon-ecs-optimized	ami-8f7687e2	Launch instance
us-west-1	amzn-ami-2016.03.c-amazon-ecs-optimized	ami-bb473cdb	Launch instance
us-west-2	amzn-ami-2016.03.c-amazon-ecs-optimized	ami-84b44de4	Launch instance
eu-west-1	amzn-ami-2016.03.c-amazon-ecs-optimized	ami-4e6ffe3d	Launch instance
eu-central-1	amzn-ami-2016.03.c-amazon-ecs-optimized	ami-b0cc23df	Launch instance
ap-northeast-1	amzn-ami-2016.03.c-amazon-ecs-optimized	ami-095dbf68	Launch instance
ap-southeast-1	amzn-ami-2016.03.c-amazon-ecs-optimized	ami-cf03d2ac	Launch instance
ap-southeast-2	amzn-ami-2016.03.c-amazon-ecs-optimized	ami-697a540a	Launch instance


```