### PR TITLE
Use current active release to fork from

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -500,20 +500,22 @@ func (a *App) RunAttached(process, command, releaseId string, height, width int,
 				return fmt.Errorf("unable to retrieve task definition")
 			}
 
+		ContainerCheck:
 			for _, container = range t.TaskDefinition.ContainerDefinitions {
 				releaseMatch := false
 
+			ReleaseCheck:
 				for _, kv := range container.Environment {
 					if *kv.Name == "RELEASE" {
 						if *kv.Value == releaseId {
 							releaseMatch = true
-							break
+							break ReleaseCheck
 						}
 					}
 				}
 
 				if *container.Name == process && releaseMatch {
-					break
+					break ContainerCheck
 				}
 				container = nil
 			}

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -356,6 +356,13 @@ func (a *App) ForkRelease() (*Release, error) {
 	release.Id = generateId("R", 10)
 	release.Created = time.Time{}
 
+	env, err := provider.EnvironmentGet(a.Name)
+	if err != nil {
+		fmt.Printf("fn=ForkRelease level=error msg=\"error getting environment: %s\"", err)
+	}
+
+	release.Env = env.Raw()
+
 	return &Release{
 		Id:       release.Id,
 		App:      release.App,

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -344,7 +344,7 @@ func (a *App) Formation() (string, error) {
 }
 
 func (a *App) ForkRelease() (*Release, error) {
-	release, err := provider.ReleaseLatest(a.Name)
+	release, err := provider.ReleaseGet(a.Name, a.Release)
 	if err != nil {
 		return nil, err
 	}

--- a/api/provider/aws/environment.go
+++ b/api/provider/aws/environment.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/convox/rack/api/crypt"
+	"github.com/convox/rack/api/structs"
+)
+
+func (p *AWSProvider) EnvironmentGet(app string) (structs.Environment, error) {
+	a, err := p.AppGet(app)
+	if err != nil {
+		return nil, err
+	}
+
+	if a.Status == "creating" {
+		return nil, fmt.Errorf("app is still being created: %s", app)
+	}
+
+	data, err := p.s3Get(a.Outputs["Settings"], "env")
+	if err != nil {
+		// if we get a 404 from aws just return an empty environment
+		if awsError, ok := err.(awserr.RequestFailure); ok && awsError.StatusCode() == 404 {
+			return structs.Environment{}, nil
+		}
+
+		return nil, err
+	}
+
+	if a.Parameters["Key"] != "" {
+		cr := crypt.New(os.Getenv("AWS_REGION"), os.Getenv("AWS_ACCESS"), os.Getenv("AWS_SECRET"))
+
+		if d, err := cr.Decrypt(a.Parameters["Key"], data); err == nil {
+			data = d
+		}
+	}
+
+	env := structs.Environment{}
+	env.LoadEnvironment(data)
+
+	return env, nil
+}

--- a/api/provider/aws/releases.go
+++ b/api/provider/aws/releases.go
@@ -97,6 +97,28 @@ func (p *AWSProvider) ReleaseList(app string) (structs.Releases, error) {
 	return releases, nil
 }
 
+func (p *AWSProvider) ReleaseLatest(app string) (*structs.Release, error) {
+	releases, err := p.ReleaseList(app)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(releases) == 0 {
+		return nil, nil
+	}
+
+	r := releases[0]
+
+	return &structs.Release{
+		Id:       r.Id,
+		App:      r.App,
+		Build:    r.Build,
+		Env:      r.Env,
+		Manifest: r.Manifest,
+		Created:  r.Created,
+	}, nil
+}
+
 func (p *AWSProvider) ReleasePromote(app, id string) (*structs.Release, error) {
 	_, err := p.AppGet(app)
 	if err != nil {

--- a/api/provider/aws/releases.go
+++ b/api/provider/aws/releases.go
@@ -97,28 +97,6 @@ func (p *AWSProvider) ReleaseList(app string) (structs.Releases, error) {
 	return releases, nil
 }
 
-func (p *AWSProvider) ReleaseLatest(app string) (*structs.Release, error) {
-	releases, err := p.ReleaseList(app)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(releases) == 0 {
-		return nil, nil
-	}
-
-	r := releases[0]
-
-	return &structs.Release{
-		Id:       r.Id,
-		App:      r.App,
-		Build:    r.Build,
-		Env:      r.Env,
-		Manifest: r.Manifest,
-		Created:  r.Created,
-	}, nil
-}
-
 func (p *AWSProvider) ReleasePromote(app, id string) (*structs.Release, error) {
 	_, err := p.AppGet(app)
 	if err != nil {

--- a/api/provider/aws/releases_test.go
+++ b/api/provider/aws/releases_test.go
@@ -75,6 +75,56 @@ func TestReleaseList(t *testing.T) {
 	}, r)
 }
 
+func TestReleaseLatestEmpty(t *testing.T) {
+	defer func() {
+		provider.CurrentProvider = new(provider.TestProviderRunner)
+	}()
+	p := provider.CurrentProvider.(*provider.TestProviderRunner)
+
+	p.Mock.On("ReleaseList", "myapp").Return(structs.Releases{}, nil)
+
+	rs, err := p.ReleaseList("myapp")
+	assert.Nil(t, err)
+	assert.Equal(t, (*structs.Release)(nil), rs.Latest())
+}
+
+func TestReleaseLatest(t *testing.T) {
+	defer func() {
+		provider.CurrentProvider = new(provider.TestProviderRunner)
+	}()
+	p := provider.CurrentProvider.(*provider.TestProviderRunner)
+
+	p.Mock.On("ReleaseList", "myapp").Return(structs.Releases{
+		structs.Release{
+			Id:       "RVFETUHHKKD",
+			App:      "httpd",
+			Build:    "BHINCLZYYVN",
+			Env:      "foo=bar",
+			Manifest: "web:\n  image: httpd\n  ports:\n  - 80:80\n",
+			Created:  time.Unix(1459780542, 627770380).UTC(),
+		},
+		structs.Release{
+			Id:       "RFVZFLKVTYO",
+			App:      "httpd",
+			Build:    "BNOARQMVHUO",
+			Env:      "foo=bar",
+			Manifest: "web:\n  image: httpd\n  ports:\n  - 80:80\n",
+			Created:  time.Unix(1459709199, 166694813).UTC(),
+		},
+	}, nil)
+
+	rs, err := p.ReleaseList("myapp")
+	assert.Nil(t, err)
+	assert.Equal(t, &structs.Release{
+		Id:       "RVFETUHHKKD",
+		App:      "httpd",
+		Build:    "BHINCLZYYVN",
+		Env:      "foo=bar",
+		Manifest: "web:\n  image: httpd\n  ports:\n  - 80:80\n",
+		Created:  time.Unix(1459780542, 627770380).UTC(),
+	}, rs.Latest())
+}
+
 var release1GetItemCycle = awsutil.Cycle{
 	Request: awsutil.Request{
 		RequestURI: "/",

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -44,6 +44,7 @@ type Provider interface {
 	ReleaseDelete(app, id string) (*structs.Release, error)
 	ReleaseGet(app, id string) (*structs.Release, error)
 	ReleaseList(app string) (structs.Releases, error)
+	ReleaseLatest(app string) (*structs.Release, error)
 	ReleasePromote(app, id string) (*structs.Release, error)
 	ReleaseSave(*structs.Release, string, string) error
 
@@ -170,6 +171,10 @@ func ReleaseGet(app, id string) (*structs.Release, error) {
 
 func ReleaseList(app string) (structs.Releases, error) {
 	return CurrentProvider.ReleaseList(app)
+}
+
+func ReleaseLatest(app string) (*structs.Release, error) {
+	return CurrentProvider.ReleaseLatest(app)
 }
 
 func ReleasePromote(app, id string) (*structs.Release, error) {

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -33,6 +33,8 @@ type Provider interface {
 
 	EventSend(*structs.Event, error) error
 
+	EnvironmentGet(app string) (structs.Environment, error)
+
 	IndexDiff(*structs.Index) ([]string, error)
 	IndexDownload(*structs.Index, string) error
 	IndexUpload(string, []byte) error
@@ -138,6 +140,10 @@ func CertificateList() (structs.Certificates, error) {
 
 func EventSend(e *structs.Event, err error) error {
 	return CurrentProvider.EventSend(e, err)
+}
+
+func EnvironmentGet(app string) (structs.Environment, error) {
+	return CurrentProvider.EnvironmentGet(app)
 }
 
 func IndexDiff(i *structs.Index) ([]string, error) {

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -44,7 +44,6 @@ type Provider interface {
 	ReleaseDelete(app, id string) (*structs.Release, error)
 	ReleaseGet(app, id string) (*structs.Release, error)
 	ReleaseList(app string) (structs.Releases, error)
-	ReleaseLatest(app string) (*structs.Release, error)
 	ReleasePromote(app, id string) (*structs.Release, error)
 	ReleaseSave(*structs.Release, string, string) error
 
@@ -171,10 +170,6 @@ func ReleaseGet(app, id string) (*structs.Release, error) {
 
 func ReleaseList(app string) (structs.Releases, error) {
 	return CurrentProvider.ReleaseList(app)
-}
-
-func ReleaseLatest(app string) (*structs.Release, error) {
-	return CurrentProvider.ReleaseLatest(app)
 }
 
 func ReleasePromote(app, id string) (*structs.Release, error) {

--- a/api/provider/test.go
+++ b/api/provider/test.go
@@ -140,13 +140,8 @@ func (p *TestProviderRunner) ReleaseGet(app, id string) (*structs.Release, error
 }
 
 func (p *TestProviderRunner) ReleaseList(app string) (structs.Releases, error) {
-	p.Called(app)
-	return p.Releases, nil
-}
-
-func (p *TestProviderRunner) ReleaseLatest(app string) (*structs.Release, error) {
-	p.Called(app)
-	return &p.Release, nil
+	args := p.Called(app)
+	return args.Get(0).(structs.Releases), args.Error(1)
 }
 
 func (p *TestProviderRunner) ReleasePromote(app, id string) (*structs.Release, error) {

--- a/api/provider/test.go
+++ b/api/provider/test.go
@@ -144,6 +144,11 @@ func (p *TestProviderRunner) ReleaseList(app string) (structs.Releases, error) {
 	return p.Releases, nil
 }
 
+func (p *TestProviderRunner) ReleaseLatest(app string) (*structs.Release, error) {
+	p.Called(app)
+	return &p.Release, nil
+}
+
 func (p *TestProviderRunner) ReleasePromote(app, id string) (*structs.Release, error) {
 	p.Called(app, id)
 	return &p.Release, nil

--- a/api/provider/test.go
+++ b/api/provider/test.go
@@ -104,6 +104,11 @@ func (p *TestProviderRunner) EventSend(e *structs.Event, err error) error {
 	return nil
 }
 
+func (p *TestProviderRunner) EnvironmentGet(app string) (structs.Environment, error) {
+	p.Called()
+	return nil, nil
+}
+
 func (p *TestProviderRunner) IndexDiff(i *structs.Index) ([]string, error) {
 	p.Called(i)
 	return []string{}, nil

--- a/api/structs/environment.go
+++ b/api/structs/environment.go
@@ -53,3 +53,11 @@ func (e Environment) Raw() string {
 
 	return strings.Join(lines, "\n")
 }
+
+// LoadRaw reads a raw string (key/values separated by a newline) to load environment variables
+func (e Environment) LoadRaw(raw string) {
+	for _, rawKV := range strings.Split(raw, "\n") {
+		keyValue := strings.SplitN(rawKV, "=", 2)
+		e[keyValue[0]] = keyValue[1]
+	}
+}

--- a/api/structs/environment.go
+++ b/api/structs/environment.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 )
 
+// Environment is of type map used to store environment variables.
 type Environment map[string]string
 
+// LoadEnvironment sets the environment from data.
 func (e Environment) LoadEnvironment(data []byte) Environment {
 
 	scanner := bufio.NewScanner(bytes.NewReader(data))
@@ -27,10 +29,11 @@ func (e Environment) LoadEnvironment(data []byte) Environment {
 	return e
 }
 
+// SortedNames returns a slice of environment variables sorted by name.
 func (e Environment) SortedNames() []string {
 	names := []string{}
 
-	for key, _ := range e {
+	for key := range e {
 		names = append(names, key)
 	}
 
@@ -39,6 +42,7 @@ func (e Environment) SortedNames() []string {
 	return names
 }
 
+// Raw returns the environment variables as one string separated by a newline.
 func (e Environment) Raw() string {
 	lines := make([]string, len(e))
 

--- a/api/structs/environment.go
+++ b/api/structs/environment.go
@@ -1,0 +1,51 @@
+package structs
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Environment map[string]string
+
+func (e Environment) LoadEnvironment(data []byte) Environment {
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+
+	for scanner.Scan() {
+		parts := strings.SplitN(scanner.Text(), "=", 2)
+
+		if len(parts) == 2 {
+			if key := strings.TrimSpace(parts[0]); key != "" {
+				e[key] = parts[1]
+			}
+		}
+	}
+
+	return e
+}
+
+func (e Environment) SortedNames() []string {
+	names := []string{}
+
+	for key, _ := range e {
+		names = append(names, key)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+func (e Environment) Raw() string {
+	lines := make([]string, len(e))
+
+	//TODO: might make sense to quote here
+	for i, name := range e.SortedNames() {
+		lines[i] = fmt.Sprintf("%s=%s", name, e[name])
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/api/structs/release.go
+++ b/api/structs/release.go
@@ -20,6 +20,7 @@ func NewRelease(app string) *Release {
 	}
 }
 
+// Latest returns the latest release determined by the date created.
 func (rs Releases) Latest() *Release {
 	if len(rs) == 0 {
 		return nil

--- a/api/structs/release.go
+++ b/api/structs/release.go
@@ -25,5 +25,12 @@ func (rs Releases) Latest() *Release {
 		return nil
 	}
 
-	return &rs[0]
+	latest := rs[0]
+	for _, r := range rs {
+		if latest.Created.Before(r.Created) {
+			latest = r
+		}
+	}
+
+	return &latest
 }

--- a/api/structs/release.go
+++ b/api/structs/release.go
@@ -19,3 +19,11 @@ func NewRelease(app string) *Release {
 		Id:  generateId("R", 10),
 	}
 }
+
+func (rs Releases) Latest() *Release {
+	if len(rs) == 0 {
+		return nil
+	}
+
+	return &rs[0]
+}

--- a/cmd/convox/releases.go
+++ b/cmd/convox/releases.go
@@ -74,7 +74,7 @@ func cmdReleases(c *cli.Context) error {
 		return stdcli.ExitError(err)
 	}
 
-	t := stdcli.NewTable("ID", "CREATED", "STATUS")
+	t := stdcli.NewTable("ID", "CREATED", "BUILD", "STATUS")
 
 	for _, r := range releases {
 		status := ""
@@ -83,7 +83,7 @@ func cmdReleases(c *cli.Context) error {
 			status = "active"
 		}
 
-		t.AddRow(r.Id, humanizeTime(r.Created), status)
+		t.AddRow(r.Id, humanizeTime(r.Created), r.Build, status)
 	}
 
 	t.Print()

--- a/cmd/convox/uninstall.go
+++ b/cmd/convox/uninstall.go
@@ -38,7 +38,7 @@ type Stack struct {
 func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "uninstall",
-		Description: "uninstall convox from an aws account",
+		Description: "uninstall a convox rack",
 		Usage:       "<stack-name> <region> [credentials.csv]",
 		Action:      cmdUninstall,
 		Flags: []cli.Flag{


### PR DESCRIPTION
Whenever `ForkRelease` is called it will now use the current release's build. Fixes #793

Also moved `ReleaseLatest` to the provider interface and added the Build ID to the output of `convox releases`.

Also in here, is a fix for `convox run --release`. If no releaseId is provided, `convox run` will use the last promoted release to run a process. Otherwise iterate over the previous revisions (starting with the
latest) looking for the releaseId specified. This makes sure the same environment variables are available. Closes #669

This does not resolve the issue where `convox run` can be used with a
release that hasn't been promoted yet. That will be tackled separately.

