### PR TITLE
Support ap-southeast-2 region

### DIFF
--- a/api/cmd/formation/Makefile
+++ b/api/cmd/formation/Makefile
@@ -14,6 +14,6 @@ formation.zip: lambda.js formation
 	zip formation.zip lambda.js formation
 
 release: formation.zip
-	for region in us-east-1 us-west-2 eu-west-1 ap-northeast-1; do \
+	for region in us-east-1 us-west-2 eu-west-1 ap-northeast-1 ap-southeast-2; do \
 		aws s3 cp formation.zip s3://convox-$$region/release/$(VERSION)/formation.zip --acl public-read; \
 	done

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -59,7 +59,7 @@ var FormationUrl = "https://convox.s3.amazonaws.com/release/%s/formation.json"
 var isDevelopment = false
 
 // https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region
-var lambdaRegions = map[string]bool{"us-east-1": true, "us-west-2": true, "eu-west-1": true, "ap-northeast-1": true, "test": true}
+var lambdaRegions = map[string]bool{"us-east-1": true, "us-west-2": true, "eu-west-1": true, "ap-northeast-1": true, "ap-southeast-2": true, "test": true}
 
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())


### PR DESCRIPTION
@nzoschke 
https://aws.amazon.com/about-aws/whats-new/2016/06/aws-lambda-available-in-asia-pacific-sydney/

This PR:

* Adds `ap-southeast-2` to the supported regions check.
* Adds `ap-southeast-2` to the lambda custom resource release bucket list (a bucket needs to be created?)

closes https://github.com/convox-archive/kernel/pull/149 https://github.com/convox-archive/cli/pull/119 https://github.com/convox-archive/app/pull/18 https://github.com/convox-archive/cli/pull/82 https://github.com/convox-archive/cli/pull/82 https://github.com/convox-archive/app/pull/11 https://github.com/convox-archive/kernel/pull/95

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

