### PR TITLE
Mountable volumes

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -191,7 +191,7 @@ func (m Manifest) Validate() error {
 	regexValidCronLabel := regexp.MustCompile(`\A[a-zA-Z][-a-zA-Z0-9]{3,29}\z`)
 
 	for _, entry := range map[string]ManifestEntry(m) {
-		labels := entry.labelsByPrefix("convox.cron")
+		labels := entry.LabelsByPrefix("convox.cron")
 		for k := range labels {
 			parts := strings.Split(k, ".")
 			if len(parts) != 3 {
@@ -981,7 +981,7 @@ func (me ManifestEntry) Label(key string) string {
 	return ""
 }
 
-func (me ManifestEntry) labelsByPrefix(prefix string) map[string]string {
+func (me ManifestEntry) LabelsByPrefix(prefix string) map[string]string {
 	returnLabels := make(map[string]string)
 	switch labels := me.Labels.(type) {
 	case map[interface{}]interface{}:

--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -981,6 +981,8 @@ func (me ManifestEntry) Label(key string) string {
 	return ""
 }
 
+// LabelsByPrefix filters Docker Compose label names by prefixes and returns
+// a map of label names to values that match.
 func (me ManifestEntry) LabelsByPrefix(prefix string) map[string]string {
 	returnLabels := make(map[string]string)
 	switch labels := me.Labels.(type) {

--- a/api/models/manifest.go
+++ b/api/models/manifest.go
@@ -469,10 +469,19 @@ func (me ManifestEntry) EnvMap() map[string]string {
 }
 
 func (me ManifestEntry) MountableVolumes() []string {
+	volumesEnabled := false
+	labels := me.LabelsByPrefix("convox.volumes.mount")
+	for _, value := range labels {
+		if value == "true" {
+			volumesEnabled = true
+			break
+		}
+	}
+
 	volumes := []string{}
 
 	for _, volume := range me.Volumes {
-		if strings.HasPrefix(volume, "/var/run/docker.sock") {
+		if strings.HasPrefix(volume, "/var/run/docker.sock") || volumesEnabled {
 			volumes = append(volumes, volume)
 		}
 	}


### PR DESCRIPTION
If you set a label like:

```
labels:
  - convox.volumes.mount=true
```

Your volumes entries in `docker-compose.yml` will be honored and volumes will be mounted from the host.

# Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI
