### PR TITLE
Changing uninstall help text to not confuse users

### DIFF
--- a/cmd/convox/uninstall.go
+++ b/cmd/convox/uninstall.go
@@ -38,7 +38,7 @@ type Stack struct {
 func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "uninstall",
-		Description: "uninstall convox from an aws account",
+		Description: "uninstall a convox rack",
 		Usage:       "<stack-name> <region> [credentials.csv]",
 		Action:      cmdUninstall,
 		Flags: []cli.Flag{


### PR DESCRIPTION
I think that the current help text for `convox uninstall` is a little confusing. While this command will definitely uninstall convox, I think the language around it should state that you can uninstall a single rack and not all convox racks entirely.

Thoughts?


## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

