### PR TITLE
Adding known racks subcommand to convox racks

### DIFF
--- a/cmd/convox/racks.go
+++ b/cmd/convox/racks.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "racks",
-		Description: "list Convox racks you've connected to",
+		Description: "list your Convox racks",
 		Usage:       "",
 		Action:      cmdRacks,
 		Subcommands: []cli.Command{

--- a/cmd/convox/racks.go
+++ b/cmd/convox/racks.go
@@ -1,39 +1,74 @@
 package main
 
 import (
-	"fmt"
+  "encoding/json"
+  "fmt"
+  "io/ioutil"
+  "path/filepath"
 
-	"github.com/convox/rack/cmd/convox/stdcli"
-	"gopkg.in/urfave/cli.v1"
+
+  "github.com/convox/rack/cmd/convox/stdcli"
+  "gopkg.in/urfave/cli.v1"
 )
 
 func init() {
-	stdcli.RegisterCommand(cli.Command{
-		Name:        "racks",
-		Description: "list your Convox racks",
-		Usage:       "",
-		Action:      cmdRacks,
-	})
+  stdcli.RegisterCommand(cli.Command{
+    Name:        "racks",
+    Description: "list your Convox racks",
+    Usage:       "",
+    Action:      cmdRacks,
+    Subcommands: []cli.Command{
+      {
+        Name:        "known",
+        Description: "list known racks to this workstation",
+        Usage:       "",
+        Action:      cmdKnownRacks,
+      },
+    },
+  })
 }
 
 func cmdRacks(c *cli.Context) error {
-	if len(c.Args()) > 0 {
-		return stdcli.ExitError(fmt.Errorf("`convox racks` does not take arguments. Perhaps you meant `convox racks`?"))
-	}
+  if len(c.Args()) > 0 {
+    return stdcli.ExitError(fmt.Errorf("`convox racks` does not take arguments. Perhaps you meant `convox racks`?"))
+  }
 
-	racks, err := rackClient(c).Racks()
-	if err != nil {
-		return stdcli.ExitError(err)
-	}
+  racks, err := rackClient(c).Racks()
+  if err != nil {
+    return stdcli.ExitError(err)
+  }
 
-	t := stdcli.NewTable("RACK", "STATUS")
-	for _, rack := range racks {
-		name := rack.Name
-		if rack.Organization != nil {
-			name = fmt.Sprintf("%s/%s", rack.Organization.Name, name)
-		}
-		t.AddRow(name, rack.Status)
-	}
-	t.Print()
-	return nil
+  t := stdcli.NewTable("RACK", "STATUS")
+  for _, rack := range racks {
+    name := rack.Name
+    if rack.Organization != nil {
+      name = fmt.Sprintf("%s/%s", rack.Organization.Name, name)
+    }
+    t.AddRow(name, rack.Status)
+  }
+  t.Print()
+  return nil
+}
+
+func cmdKnownRacks(c *cli.Context) error {
+  config := filepath.Join(ConfigRoot, "auth")
+  data, _ := ioutil.ReadFile(filepath.Join(config))
+  if data == nil {
+    data = []byte("{}")
+  }
+
+  var auth ConfigAuth
+  err := json.Unmarshal(data, &auth)
+
+  if err != nil {
+    return err
+  }
+
+  t := stdcli.NewTable("RACK")
+  for rack, _ := range auth {
+    t.AddRow(rack)
+  }
+
+  t.Print()
+  return nil
 }

--- a/cmd/convox/racks.go
+++ b/cmd/convox/racks.go
@@ -13,13 +13,13 @@ import (
 func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "racks",
-		Description: "list your Convox racks",
+		Description: "list Convox racks you've connected to",
 		Usage:       "",
 		Action:      cmdRacks,
 		Subcommands: []cli.Command{
 			{
 				Name:        "known",
-				Description: "list known racks to this workstation",
+				Description: "list racks used by this workstation",
 				Usage:       "",
 				Action:      cmdKnownRacks,
 			},

--- a/cmd/convox/racks.go
+++ b/cmd/convox/racks.go
@@ -1,74 +1,73 @@
 package main
 
 import (
-  "encoding/json"
-  "fmt"
-  "io/ioutil"
-  "path/filepath"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
 
-
-  "github.com/convox/rack/cmd/convox/stdcli"
-  "gopkg.in/urfave/cli.v1"
+	"github.com/convox/rack/cmd/convox/stdcli"
+	"gopkg.in/urfave/cli.v1"
 )
 
 func init() {
-  stdcli.RegisterCommand(cli.Command{
-    Name:        "racks",
-    Description: "list your Convox racks",
-    Usage:       "",
-    Action:      cmdRacks,
-    Subcommands: []cli.Command{
-      {
-        Name:        "known",
-        Description: "list known racks to this workstation",
-        Usage:       "",
-        Action:      cmdKnownRacks,
-      },
-    },
-  })
+	stdcli.RegisterCommand(cli.Command{
+		Name:        "racks",
+		Description: "list your Convox racks",
+		Usage:       "",
+		Action:      cmdRacks,
+		Subcommands: []cli.Command{
+			{
+				Name:        "known",
+				Description: "list known racks to this workstation",
+				Usage:       "",
+				Action:      cmdKnownRacks,
+			},
+		},
+	})
 }
 
 func cmdRacks(c *cli.Context) error {
-  if len(c.Args()) > 0 {
-    return stdcli.ExitError(fmt.Errorf("`convox racks` does not take arguments. Perhaps you meant `convox racks`?"))
-  }
+	if len(c.Args()) > 0 {
+		return stdcli.ExitError(fmt.Errorf("`convox racks` does not take arguments. Perhaps you meant `convox racks`?"))
+	}
 
-  racks, err := rackClient(c).Racks()
-  if err != nil {
-    return stdcli.ExitError(err)
-  }
+	racks, err := rackClient(c).Racks()
+	if err != nil {
+		return stdcli.ExitError(err)
+	}
 
-  t := stdcli.NewTable("RACK", "STATUS")
-  for _, rack := range racks {
-    name := rack.Name
-    if rack.Organization != nil {
-      name = fmt.Sprintf("%s/%s", rack.Organization.Name, name)
-    }
-    t.AddRow(name, rack.Status)
-  }
-  t.Print()
-  return nil
+	t := stdcli.NewTable("RACK", "STATUS")
+	for _, rack := range racks {
+		name := rack.Name
+		if rack.Organization != nil {
+			name = fmt.Sprintf("%s/%s", rack.Organization.Name, name)
+		}
+		t.AddRow(name, rack.Status)
+	}
+	t.Print()
+	return nil
 }
 
 func cmdKnownRacks(c *cli.Context) error {
-  config := filepath.Join(ConfigRoot, "auth")
-  data, _ := ioutil.ReadFile(filepath.Join(config))
-  if data == nil {
-    data = []byte("{}")
-  }
+	config := filepath.Join(ConfigRoot, "auth")
+	data, _ := ioutil.ReadFile(filepath.Join(config))
+	if data == nil {
+		data = []byte("{}")
+	}
 
-  var auth ConfigAuth
-  err := json.Unmarshal(data, &auth)
+	var auth ConfigAuth
+	err := json.Unmarshal(data, &auth)
 
-  if err != nil {
-    return err
-  }
+	if err != nil {
+		return err
+	}
 
-  t := stdcli.NewTable("RACK")
-  for rack, _ := range auth {
-    t.AddRow(rack)
-  }
+	t := stdcli.NewTable("RACK")
+	for rack, _ := range auth {
+		t.AddRow(rack)
+	}
 
-  t.Print()
-  return nil
+	t.Print()
+	return nil
 }

--- a/cmd/convox/racks.go
+++ b/cmd/convox/racks.go
@@ -64,7 +64,7 @@ func cmdKnownRacks(c *cli.Context) error {
 	}
 
 	t := stdcli.NewTable("RACK")
-	for rack, _ := range auth {
+	for rack := range auth {
 		t.AddRow(rack)
 	}
 


### PR DESCRIPTION
Currently if you're hosting your own convox racks the `convox racks` command simply returns the rack you're connected to:

```
⮀ convox racks
RACK            STATUS
reverb-staging  running
```

But by adding a known subcommand that pulls out all known racks out of `~/.convox/auth` we can give the open source user a more complete map of their potentially installed racks that they've previously connected to. Right now I find myself doing `cat ~/.convox/auth` to determine the rack endpoints of my staging/prod/internal clusters which feels like broken UX.

```
⮀ ~/go/bin/convox racks known
RACK
internal-1234.us-east-1.elb.amazonaws.com
localhost
staging-1234.us-east-1.elb.amazonaws.com
```

Now that I know what the cnames of my rackend points are this makes using `convox switch <endpoint>` a breeze.

Thoughts on this?

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI
