### PR TITLE
only attempt terminal manipulation on tty stdin

### DIFF
--- a/cmd/convox/exec.go
+++ b/cmd/convox/exec.go
@@ -52,7 +52,6 @@ func cmdExec(c *cli.Context) error {
 	ps := c.Args()[0]
 
 	code, err := rackClient(c).ExecProcessAttached(app, ps, strings.Join(c.Args()[1:], " "), os.Stdin, os.Stdout, h, w)
-
 	if err != nil {
 		return stdcli.ExitError(err)
 	}


### PR DESCRIPTION
Allows `convox exec` to function even when stdin is not a TTY.


## Quick CLI Release Playbook
- [x] Code review
- [x] Merge into master
- [ ] Release CLI
