### PR TITLE
Adding services url command to return only the url of a given service

### DIFF
--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -326,9 +326,9 @@ func cmdServiceURL(c *cli.Context) error {
 	if service.URL == "" {
 		nonexistentURLError := fmt.Errorf("URL does not exist for %s", service.Name)
 		return stdcli.ExitError(nonexistentURLError)
-	} else {
-		fmt.Printf("%s\n", service.URL)
 	}
+
+	fmt.Printf("%s\n", service.URL)
 
 	return nil
 }

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -319,11 +320,13 @@ func cmdServiceURL(c *cli.Context) error {
 	}
 
 	if service.Status == "failed" {
-		fmt.Printf("Reason  %s\n", service.StatusReason)
+		service_failure_error := errors.New(fmt.Sprintf("Service failure for %s", service.StatusReason))
+		return stdcli.ExitError(service_failure_error)
 	}
 
 	if service.URL == "" {
-		fmt.Printf("URL does not exist for %s\n", service.Name)
+		nonexistent_url_error := errors.New(fmt.Sprintf("URL does not exist for %s", service.Name))
+		return stdcli.ExitError(nonexistent_url_error)
 	} else {
 		fmt.Printf("%s\n", service.URL)
 	}

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -320,12 +319,12 @@ func cmdServiceURL(c *cli.Context) error {
 	}
 
 	if service.Status == "failed" {
-		serviceFailureError := errors.New(fmt.Sprintf("Service failure for %s", service.StatusReason))
+		serviceFailureError := fmt.Errorf("Service failure for %s", service.StatusReason)
 		return stdcli.ExitError(serviceFailureError)
 	}
 
 	if service.URL == "" {
-		nonexistentURLError := errors.New(fmt.Sprintf("URL does not exist for %s", service.Name))
+		nonexistentURLError := fmt.Errorf("URL does not exist for %s", service.Name)
 		return stdcli.ExitError(nonexistentURLError)
 	} else {
 		fmt.Printf("%s\n", service.URL)

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -109,6 +109,13 @@ func init() {
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
+				Name:        "url",
+				Description: "return url for the given service",
+				Usage:       "<name>",
+				Action:      cmdServiceUrl,
+				Flags:       []cli.Flag{appFlag, rackFlag},
+			},
+			{
 				Name:        "proxy",
 				Description: "proxy ports from localhost to connect to a service",
 				Usage:       "<name>",
@@ -294,6 +301,32 @@ func cmdServiceInfo(c *cli.Context) error {
 		// NOTE: this branch is deprecated
 		fmt.Printf("URL     %s\n", service.URL)
 	}
+
+	return nil
+}
+
+func cmdServiceUrl(c *cli.Context) error {
+	if len(c.Args()) != 1 {
+		stdcli.Usage(c, "url")
+		return nil
+	}
+
+	name := c.Args()[0]
+
+	service, err := rackClient(c).GetService(name)
+	if err != nil {
+		return stdcli.ExitError(err)
+	}
+
+	if service.Status == "failed" {
+		fmt.Printf("Reason  %s\n", service.StatusReason)
+	}
+
+	if service.URL == "" {
+		fmt.Printf("URL does not exist for %s\n", service.Name)
+	} else {
+    fmt.Printf("%s\n", service.URL)
+  }
 
 	return nil
 }

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -320,13 +320,13 @@ func cmdServiceURL(c *cli.Context) error {
 	}
 
 	if service.Status == "failed" {
-		service_failure_error := errors.New(fmt.Sprintf("Service failure for %s", service.StatusReason))
-		return stdcli.ExitError(service_failure_error)
+		serviceFailureError := errors.New(fmt.Sprintf("Service failure for %s", service.StatusReason))
+		return stdcli.ExitError(serviceFailureError)
 	}
 
 	if service.URL == "" {
-		nonexistent_url_error := errors.New(fmt.Sprintf("URL does not exist for %s", service.Name))
-		return stdcli.ExitError(nonexistent_url_error)
+		nonexistentURLError := errors.New(fmt.Sprintf("URL does not exist for %s", service.Name))
+		return stdcli.ExitError(nonexistentURLError)
 	} else {
 		fmt.Printf("%s\n", service.URL)
 	}

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -112,7 +112,7 @@ func init() {
 				Name:        "url",
 				Description: "return url for the given service",
 				Usage:       "<name>",
-				Action:      cmdServiceUrl,
+				Action:      cmdServiceURL,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
@@ -305,7 +305,7 @@ func cmdServiceInfo(c *cli.Context) error {
 	return nil
 }
 
-func cmdServiceUrl(c *cli.Context) error {
+func cmdServiceURL(c *cli.Context) error {
 	if len(c.Args()) != 1 {
 		stdcli.Usage(c, "url")
 		return nil

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -319,13 +319,11 @@ func cmdServiceURL(c *cli.Context) error {
 	}
 
 	if service.Status == "failed" {
-		serviceFailureError := fmt.Errorf("Service failure for %s", service.StatusReason)
-		return stdcli.ExitError(serviceFailureError)
+		return stdcli.ExitError(fmt.Errorf("Service failure for %s", service.StatusReason))
 	}
 
 	if service.URL == "" {
-		nonexistentURLError := fmt.Errorf("URL does not exist for %s", service.Name)
-		return stdcli.ExitError(nonexistentURLError)
+		return stdcli.ExitError(fmt.Errorf("URL does not exist for %s", service.Name))
 	}
 
 	fmt.Printf("%s\n", service.URL)

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -325,8 +325,8 @@ func cmdServiceURL(c *cli.Context) error {
 	if service.URL == "" {
 		fmt.Printf("URL does not exist for %s\n", service.Name)
 	} else {
-    fmt.Printf("%s\n", service.URL)
-  }
+		fmt.Printf("%s\n", service.URL)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR adds `convox services url <name>` and returns only the service.URL for the given service.

For example if I have two services:

```
⮀ convox services
NAME             TYPE    STATUS
fluentd-staging  syslog  running
s3-8346          s3      running
```

The first doesn't have a url and returns:
```
⮀ ~/go/bin/convox services url fluentd-staging
URL does not exist for fluentd-staging
```

The second does have a url and returns:
```
⮀ ~/go/bin/convox services url s3-8346
s3://asdf:asdf@reverb-staging-s3-8346
```

Fixes https://github.com/convox/rack/issues/532

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

