### PR TITLE
Remove ap-northeast-1 from list of supported regions

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -59,7 +59,7 @@ var FormationUrl = "https://convox.s3.amazonaws.com/release/%s/formation.json"
 var isDevelopment = false
 
 // https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region
-var lambdaRegions = map[string]bool{"us-east-1": true, "us-west-2": true, "eu-west-1": true, "ap-northeast-1": true, "ap-southeast-2": true, "test": true}
+var lambdaRegions = map[string]bool{"us-east-1": true, "us-west-2": true, "eu-west-1": true, "ap-northeast-1": false, "ap-southeast-2": true, "test": true}
 
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())


### PR DESCRIPTION
Currently getting an error when creating a rack in the Tokyo region.

> Failed AWS::EC2::Subnet: CustomResource attribute error: Vendor response doesn't contain AvailabilityZone2 key in object arn:aws:cloudformation:ap-northeast-1:990037048036:stack/dev2/7bc5d800-3e2e-11e6-82fd-50d5ca9ff4c6|AvailabilityZones|1d8dabf9-6f02-476c-a5fa-a06e2b5dd053 in S3 bucket cloudformation-custom-resource-storage-apnortheast1

http://aws.amazon.com/about-aws/global-infrastructure/ states that Tokyo has 3 AZs but:
> *New customers can access two EC2 Availability Zones in Asia Pacific (Tokyo).

Hence the error above about the availability zone.

Related: #117 