### PR TITLE
Adding subnet tags changes to kernel.json

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -588,6 +588,9 @@
       "DependsOn": [ "AvailabilityZones", "Vpc" ],
       "Type": "AWS::EC2::Subnet",
       "Properties": {
+        "Tags": [
+          {"Key": "Name", "Value": { "Fn::Join": [ " ", [ {"Ref": "AWS::StackName"}, "public", "0" ] ] }}
+        ],
         "AvailabilityZone": { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone0" ] },
         "CidrBlock": { "Ref": "Subnet0CIDR" },
         "VpcId": { "Ref": "Vpc" }
@@ -597,6 +600,9 @@
       "DependsOn": [ "AvailabilityZones", "Vpc" ],
       "Type": "AWS::EC2::Subnet",
       "Properties": {
+        "Tags": [
+          {"Key": "Name", "Value": { "Fn::Join": [ " ", [ {"Ref": "AWS::StackName"}, "public", "1" ] ] }}
+        ],
         "AvailabilityZone": { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone1" ] },
         "CidrBlock": { "Ref": "Subnet1CIDR" },
         "VpcId": { "Ref": "Vpc" }
@@ -606,6 +612,9 @@
       "DependsOn": [ "AvailabilityZones", "Vpc" ],
       "Type": "AWS::EC2::Subnet",
       "Properties": {
+        "Tags": [
+          {"Key": "Name", "Value": { "Fn::Join": [ " ", [ {"Ref": "AWS::StackName"}, "public", "2" ] ] }}
+        ],
         "AvailabilityZone": { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone2" ] },
         "CidrBlock": { "Ref": "Subnet2CIDR" },
         "VpcId": { "Ref": "Vpc" }
@@ -616,6 +625,9 @@
       "DependsOn": [ "AvailabilityZones", "Vpc" ],
       "Type": "AWS::EC2::Subnet",
       "Properties": {
+        "Tags": [
+          {"Key": "Name", "Value": { "Fn::Join": [ " ", [ {"Ref": "AWS::StackName"}, "private", "0" ] ] }}
+        ],
         "AvailabilityZone": { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone0" ] },
         "CidrBlock": { "Ref": "SubnetPrivate0CIDR" },
         "VpcId": { "Ref": "Vpc" }
@@ -626,6 +638,9 @@
       "DependsOn": [ "AvailabilityZones", "Vpc" ],
       "Type": "AWS::EC2::Subnet",
       "Properties": {
+        "Tags": [
+          {"Key": "Name", "Value": { "Fn::Join": [ " ", [ {"Ref": "AWS::StackName"}, "private", "1" ] ] }}
+        ],
         "AvailabilityZone": { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone1" ] },
         "CidrBlock": { "Ref": "SubnetPrivate1CIDR" },
         "VpcId": { "Ref": "Vpc" }
@@ -636,6 +651,9 @@
       "DependsOn": [ "AvailabilityZones", "Vpc" ],
       "Type": "AWS::EC2::Subnet",
       "Properties": {
+        "Tags": [
+          {"Key": "Name", "Value": { "Fn::Join": [ " ", [ {"Ref": "AWS::StackName"}, "private", "2" ] ] }}
+        ],
         "AvailabilityZone": { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone2" ] },
         "CidrBlock": { "Ref": "SubnetPrivate2CIDR" },
         "VpcId": { "Ref": "Vpc" }


### PR DESCRIPTION
![http://i.imgur.com/1Em4Nyp.png](http://i.imgur.com/1Em4Nyp.png)

Currently subnets created with convox have no tags. This pull request modifies `api/dist/kernel.json` to compute and attach a tag for the subnets. 

A. After adding tags
B and B1 are before adding tags.

Thoughts?

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

