### PR TITLE
Fix issue preventing a new release from being forked

### DIFF
--- a/api/controllers/environment.go
+++ b/api/controllers/environment.go
@@ -27,23 +27,19 @@ func EnvironmentList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 
 func EnvironmentSet(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	vars := mux.Vars(r)
-
 	app := vars["app"]
 
 	_, err := models.GetEnvironment(app)
-
 	if awsError(err) == "ValidationError" {
 		return httperr.Errorf(404, "no such app: %s", app)
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
-
 	if err != nil {
 		return httperr.Server(err)
 	}
 
 	releaseId, err := models.PutEnvironment(app, models.LoadEnvironment(body))
-
 	if err != nil {
 		return httperr.Server(err)
 	}
@@ -51,7 +47,6 @@ func EnvironmentSet(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	rw.Header().Set("Release-Id", releaseId)
 
 	env, err := models.GetEnvironment(app)
-
 	if err != nil {
 		return httperr.Server(err)
 	}

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -344,9 +344,15 @@ func (a *App) Formation() (string, error) {
 }
 
 func (a *App) ForkRelease() (*Release, error) {
-	release, err := provider.ReleaseGet(a.Name, a.Release)
-	if err != nil {
-		return nil, err
+	var release *structs.Release
+	var err error
+
+	// If app doesn't have a release, move on to create a new one.
+	if a.Release != "" {
+		release, err = provider.ReleaseGet(a.Name, a.Release)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if release == nil {

--- a/api/models/environment.go
+++ b/api/models/environment.go
@@ -35,7 +35,6 @@ func LoadEnvironment(data []byte) Environment {
 
 func GetEnvironment(app string) (Environment, error) {
 	a, err := GetApp(app)
-
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +44,6 @@ func GetEnvironment(app string) (Environment, error) {
 	}
 
 	data, err := s3Get(a.Outputs["Settings"], "env")
-
 	if err != nil {
 
 		// if we get a 404 from aws just return an empty environment
@@ -69,7 +67,6 @@ func GetEnvironment(app string) (Environment, error) {
 
 func PutEnvironment(app string, env Environment) (string, error) {
 	a, err := GetApp(app)
-
 	if err != nil {
 		return "", err
 	}
@@ -83,7 +80,6 @@ func PutEnvironment(app string, env Environment) (string, error) {
 	}
 
 	release, err := a.ForkRelease()
-
 	if err != nil {
 		return "", err
 	}
@@ -91,7 +87,6 @@ func PutEnvironment(app string, env Environment) (string, error) {
 	release.Env = env.Raw()
 
 	err = release.Save()
-
 	if err != nil {
 		return "", err
 	}
@@ -109,7 +104,6 @@ func PutEnvironment(app string, env Environment) (string, error) {
 	}
 
 	err = S3Put(a.Outputs["Settings"], "env", []byte(e), true)
-
 	if err != nil {
 		return "", err
 	}

--- a/api/provider/aws/releases.go
+++ b/api/provider/aws/releases.go
@@ -48,7 +48,6 @@ func (p *AWSProvider) ReleaseGet(app, id string) (*structs.Release, error) {
 	}
 
 	res, err := p.dynamodb().GetItem(req)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If app doesn't have a release, it should create a new one. Bug was preventing that from happening.