### PR TITLE
Fix cron jobs getting associated with the wrong process type

### DIFF
--- a/api/models/cronjob.go
+++ b/api/models/cronjob.go
@@ -9,7 +9,7 @@ type CronJob struct {
 	Name          string `yaml:"name"`
 	Schedule      string `yaml:"schedule"`
 	Command       string `yaml:"command"`
-	ManifestEntry *ManifestEntry
+	ManifestEntry ManifestEntry
 }
 
 func NewCronJobFromLabel(key, value string) CronJob {

--- a/api/models/manifest.go
+++ b/api/models/manifest.go
@@ -152,7 +152,7 @@ func (m Manifest) CronJobs() []CronJob {
 		labels := entry.LabelsByPrefix("convox.cron")
 		for key, value := range labels {
 			cronjob := NewCronJobFromLabel(key, value)
-			cronjob.ManifestEntry = &entry
+			cronjob.ManifestEntry = entry
 			cronjobs = append(cronjobs, cronjob)
 		}
 	}


### PR DESCRIPTION
There was a pointer bug in the creation of CronJobs that caused jobs to be created on the last process defined in `docker-compose.yml`. This removes the pointer so that the CronJob gets associated with the correct ManifestEntry

## Release Playbook
- [x] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

