### PR TITLE
Adding docker-compose original host name. Fixes issue #624

### DIFF
--- a/api/manifest/manifest.go
+++ b/api/manifest/manifest.go
@@ -937,7 +937,11 @@ func (me ManifestEntry) runAsync(m *Manifest, prefix, app, process string, cache
 				return
 			}
 
+			// Add the convox container name to the host list which is app + link
 			args = append(args, fmt.Sprintf(`--add-host=%s:%s`, host, strings.TrimSpace(string(ip))))
+
+			// Add traditional docker-compose host link which is simply container name, in this case it's called link
+			args = append(args, fmt.Sprintf(`--add-host=%s:%s`, link, strings.TrimSpace(string(ip))))
 		}
 	}
 


### PR DESCRIPTION
This patch addresses https://github.com/convox/rack/issues/624.

Few questions I have:

Is there a more concise way to do this?
Do we really want to add both the convox host name `app + link` and `link`?
If we only went with `link` would it break existing behavior in the app in other places?

Output of `convox start` with this patch:
```
docker run -i --name esper-nginx -e \
  --add-host=esper-adwords:172.17.0.5 \
  --add-host=adwords:172.17.0.5 \
  --add-host=esper-api:172.17.0.7 \
  --add-host=api:172.17.0.7 \ 
  esper/nginx
```

And from within the container:
```
⮀ docker exec -it esper-api cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.17.0.6	esper-adwords
172.17.0.6	adwords
172.17.0.5	esper-api
172.17.0.5	api
172.17.0.7	221c665f47c3
```

Feedback and thoughts greatly appreciated

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

