### PR TITLE
Fix to use credentials instead of user info

### DIFF
--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -128,12 +128,12 @@ func cloneGit(s string) {
 		os.Setenv("GIT_SSH_COMMAND", "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no")
 	}
 
-	fmt.Println("---u and credentials", u, credentials)
-	fmt.Println("--- u.Host", u.Host)
-	fmt.Println("--- credentials.Username", credentials.Username())
-	err = ioutil.WriteFile("/root/.netrc", []byte(fmt.Sprintf("machine %s login %s", u.Host, credentials.Username())), 0700)
-	if err != nil {
-		fmt.Println("WARNING: Failed to write to .netrc; git might fail: ", err)
+	// Public repos might not have credentials so there's nothing to save
+	if credentials != nil {
+		err = ioutil.WriteFile("/root/.netrc", []byte(fmt.Sprintf("machine %s login %s", u.Host, credentials.Username())), 0700)
+		if err != nil {
+			fmt.Println("WARNING: Failed to write to .netrc; git might fail: ", err)
+		}
 	}
 
 	writeAsset("/usr/local/bin/git-restore-mtime", "git-restore-mtime", 0755, nil)

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"runtime/debug"
 	"strings"
 
 	"github.com/convox/rack/api/manifest"
@@ -127,6 +128,9 @@ func cloneGit(s string) {
 		os.Setenv("GIT_SSH_COMMAND", "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no")
 	}
 
+	fmt.Println("---u and credentials", u, credentials)
+	fmt.Println("--- u.Host", u.Host)
+	fmt.Println("--- credentials.Username", credentials.Username())
 	err = ioutil.WriteFile("/root/.netrc", []byte(fmt.Sprintf("machine %s login %s", u.Host, credentials.Username())), 0700)
 	if err != nil {
 		fmt.Println("WARNING: Failed to write to .netrc; git might fail: ", err)
@@ -208,8 +212,6 @@ func writeDockerAuth() {
 
 func handlePanic() {
 	if r := recover(); r != nil {
-		handleError(fmt.Errorf("%v", r))
+		handleError(fmt.Errorf("%v\n%s", r, debug.Stack()))
 	}
-
-	handleError(fmt.Errorf("Unable to handle panic"))
 }

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -44,6 +44,7 @@ func main() {
 		fmt.Println("usage: build <src>")
 		os.Exit(1)
 	}
+	defer handlePanic()
 
 	src := os.Args[1]
 
@@ -203,4 +204,12 @@ func writeDockerAuth() {
 		handleError(os.MkdirAll("/root/.docker", 0700))
 		handleError(ioutil.WriteFile("/root/.docker/config.json", []byte(auth), 0400))
 	}
+}
+
+func handlePanic() {
+	if r := recover(); r != nil {
+		handleError(fmt.Errorf("%v", r))
+	}
+
+	handleError(fmt.Errorf("Unable to handle panic"))
 }

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -114,7 +114,7 @@ func cloneGit(s string) {
 	if u.Scheme == "ssh" {
 		repo = fmt.Sprintf("%s@%s%s", credentials.Username(), u.Host, u.Path)
 
-		if pass, ok := u.User.Password(); ok {
+		if pass, ok := credentials.Password(); ok {
 			key, err := base64.StdEncoding.DecodeString(pass)
 			handleError(err)
 


### PR DESCRIPTION
## Release Playbook
- [x] Rebase against master
- [x] Release branch ()
- [x] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

