### PR TITLE
Remove KINESIS from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ web:
     - SUBNETS_PRIVATE
     - VPC
     - VPCCIDR
-    - KINESIS
     - LOG_GROUP
     - PROCESS=web
   ports:
@@ -70,7 +69,6 @@ monitor:
     - SUBNETS
     - SUBNETS_PRIVATE
     - VPC
-    - KINESIS
     - LOG_GROUP
     - PROCESS=monitor
   volumes:
@@ -79,7 +77,6 @@ registry:
   environment:
     - SETTINGS_FLAVOR=local
     - PASSWORD
-    - KINESIS
     - LOG_GROUP
     - PROCESS=registry
   image: convox/registry


### PR DESCRIPTION
KINESIS is no longer a parameter, so it should be removed from the environment.

```
❯ convox start
ERROR: env expected: KINESIS
```

## Release Playbook
- [ ] Rebase against master
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update staging rack
- [ ] Edit [Rack release record](https://github.com/convox/rack/releases) and/or update [docs](https://github.com/convox/convox.github.io)
- [ ] Publish release
- [ ] Release CLI

