### PR TITLE
Display the upload progress of the artifcat during a build

### DIFF
--- a/client/builds.go
+++ b/client/builds.go
@@ -69,13 +69,13 @@ func (c *Client) CreateBuildIndex(app string, index Index, cache bool, manifest 
 	return &build, nil
 }
 
-// CreateBuildSource will create a new build from source. If progress of the uploaded is needed, see CreateBuildSourceP
+// CreateBuildSource will create a new build from source. If progress of the uploaded is needed, see CreateBuildSourceProgress
 func (c *Client) CreateBuildSource(app string, source []byte, cache bool, manifest string, description string) (*Build, error) {
-	return c.CreateBuildSourceP(app, source, cache, manifest, description, nil)
+	return c.CreateBuildSourceProgress(app, source, cache, manifest, description, nil)
 }
 
-// CreateBuildSourceP will create a new build from source with an optional callback to provide progress of the source being uploaded.
-func (c *Client) CreateBuildSourceP(app string, source []byte, cache bool, manifest string, description string, progressCallback func(s string)) (*Build, error) {
+// CreateBuildSourceProgress will create a new build from source with an optional callback to provide progress of the source being uploaded.
+func (c *Client) CreateBuildSourceProgress(app string, source []byte, cache bool, manifest string, description string, progressCallback func(s string)) (*Build, error) {
 	var build Build
 
 	files := map[string][]byte{

--- a/client/builds.go
+++ b/client/builds.go
@@ -70,6 +70,10 @@ func (c *Client) CreateBuildIndex(app string, index Index, cache bool, manifest 
 }
 
 func (c *Client) CreateBuildSource(app string, source []byte, cache bool, manifest string, description string) (*Build, error) {
+	return c.CreateBuildSourceP(app, source, cache, manifest, description, nil)
+}
+
+func (c *Client) CreateBuildSourceP(app string, source []byte, cache bool, manifest string, description string, progressCallback func(s string)) (*Build, error) {
 	var build Build
 
 	files := map[string][]byte{
@@ -82,8 +86,7 @@ func (c *Client) CreateBuildSource(app string, source []byte, cache bool, manife
 		"manifest":    manifest,
 	}
 
-	err := c.PostMultipart(fmt.Sprintf("/apps/%s/builds", app), files, params, &build)
-
+	err := c.PostMultipartP(fmt.Sprintf("/apps/%s/builds", app), files, params, &build, progressCallback)
 	if err != nil {
 		return nil, err
 	}

--- a/client/builds.go
+++ b/client/builds.go
@@ -69,10 +69,12 @@ func (c *Client) CreateBuildIndex(app string, index Index, cache bool, manifest 
 	return &build, nil
 }
 
+// CreateBuildSource will create a new build from source. If progress of the uploaded is needed, see CreateBuildSourceP
 func (c *Client) CreateBuildSource(app string, source []byte, cache bool, manifest string, description string) (*Build, error) {
 	return c.CreateBuildSourceP(app, source, cache, manifest, description, nil)
 }
 
+// CreateBuildSourceP will create a new build from source with an optional callback to provide progress of the source being uploaded.
 func (c *Client) CreateBuildSourceP(app string, source []byte, cache bool, manifest string, description string, progressCallback func(s string)) (*Build, error) {
 	var build Build
 

--- a/client/client.go
+++ b/client/client.go
@@ -136,7 +136,7 @@ func (c *Client) PostMultipart(path string, files map[string][]byte, params Para
 	return c.PostMultipartP(path, files, params, out, nil)
 }
 
-// PostMultipartP posts a multipart message in the MIME internet format with a callback function to to report upload Progress.
+// PostMultipartP posts a multipart message in the MIME internet format with a callback function with a string stating the upload Progress.
 func (c *Client) PostMultipartP(path string, files map[string][]byte, params Params, out interface{}, callback func(s string)) error {
 	body := &bytes.Buffer{}
 

--- a/client/client.go
+++ b/client/client.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cheggaaa/pb"
+
 	"golang.org/x/net/websocket"
 )
 
@@ -129,20 +131,24 @@ func (c *Client) PostBodyResponse(path string, body io.Reader, out interface{}) 
 	return res, nil
 }
 
+// PostMultipart posts a multipart message in the MIME internet format.
 func (c *Client) PostMultipart(path string, files map[string][]byte, params Params, out interface{}) error {
+	return c.PostMultipartP(path, files, params, out, nil)
+}
+
+// PostMultipartP posts a multipart message in the MIME internet format with a callback function to to report upload Progress.
+func (c *Client) PostMultipartP(path string, files map[string][]byte, params Params, out interface{}, callback func(s string)) error {
 	body := &bytes.Buffer{}
 
 	writer := multipart.NewWriter(body)
 
 	for name, source := range files {
 		part, err := writer.CreateFormFile(name, "source.tgz")
-
 		if err != nil {
 			return err
 		}
 
 		_, err = io.Copy(part, bytes.NewReader(source))
-
 		if err != nil {
 			return err
 		}
@@ -153,12 +159,24 @@ func (c *Client) PostMultipart(path string, files map[string][]byte, params Para
 	}
 
 	err := writer.Close()
-
 	if err != nil {
 		return err
 	}
 
-	req, err := c.request("POST", path, body)
+	var bodyReader io.Reader
+	bodyReader = body
+
+	if callback != nil {
+		bar := pb.New(body.Len()).SetUnits(pb.U_BYTES)
+		bar.NotPrint = true
+		bar.ShowBar = false
+		bar.Callback = callback
+
+		bar.Start()
+		bodyReader = bar.NewProxyReader(body)
+	}
+
+	req, err := c.request("POST", path, bodyReader)
 
 	if err != nil {
 		return err

--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -522,7 +522,7 @@ func executeBuildDir(c *cli.Context, dir, app, manifest, description string) (st
 
 	cache := !c.Bool("no-cache")
 
-	build, err := rackClient(c).CreateBuildSourceP(app, tar, cache, manifest, description, func(s string) {
+	build, err := rackClient(c).CreateBuildSourceProgress(app, tar, cache, manifest, description, func(s string) {
 		fmt.Printf("\rUploading... %s", strings.TrimSpace(s))
 	})
 	if err != nil {

--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gopkg.in/urfave/cli.v1"
@@ -528,15 +529,14 @@ func executeBuildDir(c *cli.Context, dir, app, manifest, description string) (st
 
 	cache := !c.Bool("no-cache")
 
-	fmt.Print("Uploading... ")
-
-	build, err := rackClient(c).CreateBuildSource(app, tar, cache, manifest, description)
-
+	build, err := rackClient(c).CreateBuildSourceP(app, tar, cache, manifest, description, func(s string) {
+		fmt.Printf("\rUploading... %s", strings.TrimSpace(s))
+	})
 	if err != nil {
 		return "", err
 	}
 
-	fmt.Println("OK")
+	fmt.Println()
 
 	return finishBuild(c, app, build)
 }
@@ -623,6 +623,7 @@ func createTarball(base string) ([]byte, error) {
 }
 
 func finishBuild(c *cli.Context, app string, build *client.Build) (string, error) {
+	fmt.Println("Getting build logs...")
 	if build.Id == "" {
 		return "", fmt.Errorf("unable to fetch build id")
 	}

--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -616,7 +616,6 @@ func createTarball(base string) ([]byte, error) {
 }
 
 func finishBuild(c *cli.Context, app string, build *client.Build) (string, error) {
-	fmt.Println("Streaming build logs...")
 	if build.Id == "" {
 		return "", fmt.Errorf("unable to fetch build id")
 	}

--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -616,7 +616,7 @@ func createTarball(base string) ([]byte, error) {
 }
 
 func finishBuild(c *cli.Context, app string, build *client.Build) (string, error) {
-	fmt.Println("Getting build logs...")
+	fmt.Println("Streaming build logs...")
 	if build.Id == "" {
 		return "", fmt.Errorf("unable to fetch build id")
 	}

--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -427,7 +427,6 @@ func uploadIndex(c *cli.Context, index client.Index) error {
 
 func uploadItem(c *cli.Context, hash string, item client.IndexItem, bar *pb.ProgressBar, ch chan error) {
 	data, err := ioutil.ReadFile(item.Name)
-
 	if err != nil {
 		ch <- err
 		return
@@ -435,7 +434,6 @@ func uploadItem(c *cli.Context, hash string, item client.IndexItem, bar *pb.Prog
 
 	for i := 0; i < 3; i++ {
 		err = rackClient(c).IndexUpload(hash, data)
-
 		if err != nil {
 			continue
 		}
@@ -458,7 +456,6 @@ func uploadItems(c *cli.Context, index client.Index, bar *pb.ProgressBar, inch c
 
 func executeBuildDirIncremental(c *cli.Context, dir, app, manifest, description string) (string, error) {
 	system, err := rackClient(c).GetSystem()
-
 	if err != nil {
 		return "", err
 	}
@@ -471,7 +468,6 @@ func executeBuildDirIncremental(c *cli.Context, dir, app, manifest, description 
 	cache := !c.Bool("no-cache")
 
 	dir, err = filepath.Abs(dir)
-
 	if err != nil {
 		return "", err
 	}
@@ -479,7 +475,6 @@ func executeBuildDirIncremental(c *cli.Context, dir, app, manifest, description 
 	fmt.Printf("Analyzing source... ")
 
 	index, err := createIndex(dir)
-
 	if err != nil {
 		return "", err
 	}
@@ -489,7 +484,6 @@ func executeBuildDirIncremental(c *cli.Context, dir, app, manifest, description 
 	fmt.Printf("Uploading changes... ")
 
 	err = uploadIndex(c, index)
-
 	if err != nil {
 		return "", err
 	}
@@ -497,7 +491,6 @@ func executeBuildDirIncremental(c *cli.Context, dir, app, manifest, description 
 	fmt.Printf("Starting build... ")
 
 	build, err := rackClient(c).CreateBuildIndex(app, index, cache, manifest, description)
-
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
`convox build` needs better feedback during an upload. The goal here is to show the user an upload is making progress.

The feedback will include how much data has been uploaded and the total size of the file being uploaded.

Example output:
```
> convox build
Creating tarball... OK
Uploading... 58.85 KB / 58.85 KB  100.00 % 0
Getting build logs...
RUNNING: tar xz
RUNNING: docker pull httpd
Using default tag: latest
```


Fixes #543