### PR TITLE
Switch API call for `instances terminate`

### DIFF
--- a/api/controllers/instances.go
+++ b/api/controllers/instances.go
@@ -4,7 +4,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/convox/rack/api/httperr"
 	"github.com/convox/rack/api/models"
 	"github.com/convox/rack/api/provider"

--- a/api/controllers/instances.go
+++ b/api/controllers/instances.go
@@ -70,8 +70,9 @@ func InstanceTerminate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 
 	instanceId := mux.Vars(r)["id"]
 
-	_, err = models.EC2().TerminateInstances(&ec2.TerminateInstancesInput{
-		InstanceIds: []*string{&instanceId},
+	_, err = models.AutoScaling().TerminateInstanceInAutoScalingGroup(&autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId: aws.String(instanceId),
+		ShouldDecrementDesiredCapacity: aws.Bool(false),
 	})
 
 	if err != nil {


### PR DESCRIPTION
Convox is currently using the ec2 terminate instances call - this doesn't take
autoscaling events or containers into account. Switch to `TerminateInstanceInAutoScalingGroup`
instead.

Docs:

* http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TerminateInstances.html
* http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_TerminateInstanceInAutoScalingGroup.html