### PR TITLE
Gather build logs in separate goroutine.

### DIFF
--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -295,7 +295,7 @@ func BuildLogs(ws *websocket.Conn) *httperr.Error {
 	go keepAlive(ws, quit)
 	go func() {
 		fmt.Println("############################ BEFORE client.Logs")
-		err := client.Logs(docker.LogsOptions{
+		e := client.Logs(docker.LogsOptions{
 			Container:    fmt.Sprintf("build-%s", build),
 			Follow:       true,
 			Stdout:       true,
@@ -307,7 +307,7 @@ func BuildLogs(ws *websocket.Conn) *httperr.Error {
 		})
 
 		fmt.Println("############################ AFTER client.Logs")
-		logErr <- err
+		logErr <- e
 	}()
 
 ForLoop:
@@ -321,9 +321,8 @@ ForLoop:
 
 		default:
 			fmt.Println("############################ IN default case")
-			b, e := provider.BuildGet(app, build)
-			if e != nil {
-				err = e
+			b, err := provider.BuildGet(app, build)
+			if err != nil {
 				break ForLoop
 			}
 

--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -294,7 +294,6 @@ func BuildLogs(ws *websocket.Conn) *httperr.Error {
 
 	go keepAlive(ws, quit)
 	go func() {
-		fmt.Println("############################ BEFORE client.Logs")
 		e := client.Logs(docker.LogsOptions{
 			Container:    fmt.Sprintf("build-%s", build),
 			Follow:       true,
@@ -306,21 +305,17 @@ func BuildLogs(ws *websocket.Conn) *httperr.Error {
 			ErrorStream:  ws,
 		})
 
-		fmt.Println("############################ AFTER client.Logs")
 		logErr <- e
 	}()
 
 ForLoop:
 	for {
-		fmt.Println("############################ FOR LOOP")
 		select {
 
 		case err = <-logErr:
-			fmt.Println("############################ IN client.Logs err case")
 			break ForLoop
 
 		default:
-			fmt.Println("############################ IN default case")
 			b, err := provider.BuildGet(app, build)
 			if err != nil {
 				break ForLoop

--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -647,7 +647,6 @@ func finishBuild(c *cli.Context, app string, build *client.Build) (string, error
 func waitForBuild(c *cli.Context, app, id string) (string, error) {
 	for {
 		build, err := rackClient(c).GetBuild(app, id)
-
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Sometimes, `client.Logs()` would block. That has to be looked into. But in the mean time, this alternate approach won't lock up the CLI during a build/deploy.

This PR is more like a RFC on the approach taken. Definitely still a WIP. For example, if the Logs() call does block in the goroutine, that goroutine will stay alive in the background until it's cleaned up (docker timeout perhaps?).