### PR TITLE
Pad the uploading progress message to clear some text

### DIFF
--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -523,7 +523,8 @@ func executeBuildDir(c *cli.Context, dir, app, manifest, description string) (st
 	cache := !c.Bool("no-cache")
 
 	build, err := rackClient(c).CreateBuildSourceProgress(app, tar, cache, manifest, description, func(s string) {
-		fmt.Printf("\rUploading... %s", strings.TrimSpace(s))
+		// Pad string with spaces at the end to clear any text left over from a longer string.
+		fmt.Printf("\rUploading... %s       ", strings.TrimSpace(s))
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This approach seems the most pragmatic. Other option is to mess around with ASCII/Unicode escape characters to clear the end of the line:

```
fmt.Printf("\r\033[KUploading... %s       ", strings.TrimSpace(s))
```
It works but could run into issues with a different  character encoding.