### PR TITLE
WIP - 827: Parse `tty` param

### DIFF
--- a/manifest/process.go
+++ b/manifest/process.go
@@ -19,6 +19,10 @@ func NewProcess(app string, s Service) Process {
 	args = append(args, "--rm")
 	args = append(args, "--name", name)
 
+	if s.Tty {
+		args = append(args, "--tty")
+	}
+
 	if s.Entrypoint != "" {
 		args = append(args, "--entrypoint", s.Entrypoint)
 	}

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -26,6 +26,7 @@ type Service struct {
 	Networks    []string    `yaml:"networks,omitempty"`
 	Ports       Ports       `yaml:"ports,omitempty"`
 	Privileged  bool        `yaml:"privileged,omitempty"`
+	Tty         bool        `yaml:"tty,omitempty"`
 	Volumes     []string    `yaml:"volumes,omitempty"`
 }
 


### PR DESCRIPTION
Fixes #827 

Not working yet..

```
$ convox start

...

build  │ Successfully built 5793a497a8f7
web    │ running: docker run -i --rm --name pronetwork-web --tty -e DEBUG=1 -e GEOIP_PATH=/usr/local/share/GeoIP -e UWSGI_PY_AUTORELOAD=1 -e COMPRESS_OFFLINE=0 -e CONVOX=1 -e CHUNNEL_URI_IDENTITY=33.33.33.100:3500 -p 80 convox-a088a6d827 sh -c /app/bin/web
web    │ the input device is not a TTY
```