### PR TITLE
Adding support for relative paths when parsing docker-compose.yml

### DIFF
--- a/manifest/process.go
+++ b/manifest/process.go
@@ -1,6 +1,10 @@
 package manifest
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
 
 type Process struct {
 	Name string
@@ -40,6 +44,14 @@ func NewProcess(app string, s Service) Process {
 	}
 
 	for _, volume := range s.Volumes {
+		parts := strings.Split(volume, ":")
+		if !filepath.IsAbs(parts[0]) {
+			absoluteVolumePath, err := filepath.Abs(parts[0])
+			if err != nil {
+				fmt.Errorf("There was a problem parsing the volume: %s", volume)
+			}
+			volume = filepath.Join(absoluteVolumePath, parts[1])
+		}
 		args = append(args, "-v", volume)
 	}
 

--- a/manifest/process.go
+++ b/manifest/process.go
@@ -44,13 +44,15 @@ func NewProcess(app string, s Service) Process {
 	}
 
 	for _, volume := range s.Volumes {
-		parts := strings.Split(volume, ":")
-		if !filepath.IsAbs(parts[0]) {
-			absoluteVolumePath, err := filepath.Abs(parts[0])
-			if err != nil {
-				fmt.Errorf("There was a problem parsing the volume: %s", volume)
+		if strings.Contains(volume, ":") {
+			parts := strings.Split(volume, ":")
+			if !filepath.IsAbs(parts[0]) {
+				absoluteVolumePath, err := filepath.Abs(parts[0])
+				if err != nil {
+					fmt.Errorf("There was a problem parsing the volume: %s", volume)
+				}
+				volume = strings.Join([]string{absoluteVolumePath, parts[1]}, ":")
 			}
-			volume = filepath.Join(absoluteVolumePath, parts[1])
 		}
 		args = append(args, "-v", volume)
 	}


### PR DESCRIPTION
In its current form if I have a docker-compose.yml that looks like:
```
version: "2"
services:
  postgres:
    image: postgres:9.5
    volumes:
      - ./dbdata:/var/lib/postgresql/data
```

I will get this error:
```
postgres │ running: docker run -i --rm --name lessons-postgres -v ./dbdata:/var/lib/postgresql/data convox-5ec422cf51
postgres │ docker: Error response from daemon: create ./dbdata: "./dbdata" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed.
```

Docker expects absolute paths when resolving volume paths. This patch adds support for relative paths when mounting volumes by testing if the path is absolute and if it's not, we resolve the path using `Abs` so we can proceed booting the container cleanly:

```
postgres │ running: docker run -i --rm --name lessons-postgres -v /Users/adam/dev/lessons/dbdata:/var/lib/postgresql/data convox-5ec422cf51
```

