### PR TITLE
Bug fixes for `convox run`

### DIFF
--- a/api/structs/environment.go
+++ b/api/structs/environment.go
@@ -56,6 +56,10 @@ func (e Environment) Raw() string {
 
 // LoadRaw reads a raw string (key/values separated by a newline) to load environment variables
 func (e Environment) LoadRaw(raw string) {
+	if raw == "" {
+		return
+	}
+
 	for _, rawKV := range strings.Split(raw, "\n") {
 		keyValue := strings.SplitN(rawKV, "=", 2)
 		e[keyValue[0]] = keyValue[1]

--- a/cmd/convox/run.go
+++ b/cmd/convox/run.go
@@ -81,7 +81,7 @@ func cmdRunDetached(c *cli.Context) error {
 	ps := c.Args()[0]
 	err = validateProcessId(c, app, ps)
 	if err != nil {
-		return err
+		return stdcli.ExitError(err)
 	}
 
 	command := ""


### PR DESCRIPTION
Two `convox run` issues are fixed here:

- The CLI returns a proper error message when an app is not found with `--detach`.
- Fixed a silent error when specifying a release that doesn't have any environment settings. (Thanks to @beedub for the debug help!)