### PR TITLE
Prevent unbound apps from being promoted

### DIFF
--- a/api/models/release.go
+++ b/api/models/release.go
@@ -133,6 +133,10 @@ func (r *Release) Promote() error {
 		return err
 	}
 
+	if !app.IsBound() {
+		return fmt.Errorf("unbound apps are no longer supported for promotion")
+	}
+
 	formation, err := r.Formation()
 	if err != nil {
 		return err

--- a/api/provider/aws/releases.go
+++ b/api/provider/aws/releases.go
@@ -97,9 +97,13 @@ func (p *AWSProvider) ReleaseList(app string) (structs.Releases, error) {
 }
 
 func (p *AWSProvider) ReleasePromote(app, id string) (*structs.Release, error) {
-	_, err := p.AppGet(app)
+	a, err := p.AppGet(app)
 	if err != nil {
 		return nil, err
+	}
+
+	if !a.IsBound() {
+		return nil, fmt.Errorf("unbound apps are no longer supported for promotion")
 	}
 
 	return &structs.Release{}, fmt.Errorf("promote not yet implemented for AWS provider")

--- a/api/structs/app.go
+++ b/api/structs/app.go
@@ -12,6 +12,8 @@ type App struct {
 
 type Apps []App
 
+// IsBound checks if the app is bound returns true if it is, false otherwise
+// If an app has a "Name" tag, it's considered bound
 func (a *App) IsBound() bool {
 	if a.Tags == nil {
 		// Default to bound.

--- a/api/structs/app.go
+++ b/api/structs/app.go
@@ -11,3 +11,18 @@ type App struct {
 }
 
 type Apps []App
+
+func (a *App) IsBound() bool {
+	if a.Tags == nil {
+		// Default to bound.
+		return true
+	}
+
+	if _, ok := a.Tags["Name"]; ok {
+		// Bound apps MUST have a "Name" tag.
+		return true
+	}
+
+	// Tags are present but "Name" tag is not, so we have an unbound app.
+	return false
+}


### PR DESCRIPTION
Logic here checks if an app is not bound (that is, it doesn't have a "Name" tag), it's not allowed to be promoted.