### PR TITLE
support single path volumes

### DIFF
--- a/manifest/process.go
+++ b/manifest/process.go
@@ -1,6 +1,12 @@
 package manifest
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
 
 type Process struct {
 	Name string
@@ -46,6 +52,17 @@ func NewProcess(app string, s Service, m Manifest) Process {
 	}
 
 	for _, volume := range s.Volumes {
+		if !strings.Contains(volume, ":") {
+			usr, err := user.Current()
+			if err != nil {
+				log.Fatal(err)
+			}
+			hostPath, err := filepath.Abs(fmt.Sprintf("%s/.convox/volumes/%s/%s/%s", usr.HomeDir, app, s.Name, volume))
+			if err != nil {
+				//this won't break
+			}
+			volume = fmt.Sprintf("%s:%s", hostPath, volume)
+		}
 		args = append(args, "-v", volume)
 	}
 

--- a/manifest/process_test.go
+++ b/manifest/process_test.go
@@ -1,0 +1,46 @@
+package manifest_test
+
+import (
+	"fmt"
+	"os/user"
+	"testing"
+
+	"github.com/convox/rack/manifest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewProcess(t *testing.T) {
+	s := manifest.Service{
+		Name: "foo",
+		Volumes: []string{
+			"/data/data",
+			"/foo:/data/data",
+		},
+	}
+
+	m := manifest.Manifest{
+		Services: map[string]manifest.Service{
+			"foo": s,
+		},
+	}
+
+	p := manifest.NewProcess("api", s, m)
+
+	usr, _ := user.Current()
+	dir := usr.HomeDir
+
+	expectedArgs := []string{
+		"-i",
+		"--rm",
+		"--name",
+		"api-foo",
+		"-v",
+		fmt.Sprintf("%s/.convox/volumes/api/foo/data/data:/data/data", dir),
+		"-v",
+		"/foo:/data/data",
+		"api/foo",
+	}
+
+	assert.Equal(t, p.Name, "api-foo")
+	assert.Equal(t, p.Args, expectedArgs)
+}

--- a/manifest/service_test.go
+++ b/manifest/service_test.go
@@ -17,5 +17,4 @@ func TestTag(t *testing.T) {
 		Name: "foo_bar",
 	}
 	assert.Equal(t, s.Tag("api"), "api/foo-bar")
-
 }


### PR DESCRIPTION
Single path volumes will now get created at: /Users/luke/.convox/volumes/${APP_NAME}/${SERVICE_NAME}/${CONTAINER_PATH}

@ianmalott can you check the functionality please
@MiguelMoll can you check the code pleas
