### PR TITLE
use Go 1.6.3 for all the things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 language: go
 
 go:
-  - 1.6.1
+  - 1.6.3
 
 before_install:
   - go get -u github.com/convox/version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.2-alpine
+FROM golang:1.6.3-alpine
 
 RUN apk update && apk add build-base docker git haproxy openssh openssl python tar
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,8 @@ machine:
     INSTALL_DIR: /home/ubuntu/.go_workspace/src/github.com/convox/rack
   post:
     - sudo rm -rf /usr/local/go
-    - curl https://storage.googleapis.com/golang/go1.6.1.linux-amd64.tar.gz -O
-    - sudo tar -C /usr/local -xzf go1.6.1.linux-amd64.tar.gz
+    - curl https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz -O
+    - sudo tar -C /usr/local -xzf go1.6.3.linux-amd64.tar.gz
 
 dependencies:
   pre:


### PR DESCRIPTION
syncs up with what's being used for the CLI release: https://github.com/convox/release/pull/23