### PR TITLE
Fix #949: Add explicit `security` upgrade param

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -908,7 +908,7 @@
             "#cloud-config\n",
             "repo_upgrade_exclude:\n",
             "  - kernel*\n",
-            "repo_upgrade: security\n"
+            "repo_upgrade: bugfix\n"
             "packages:\n",
             "  - aws-cfn-bootstrap\n",
             "mounts:\n",

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -908,6 +908,7 @@
             "#cloud-config\n",
             "repo_upgrade_exclude:\n",
             "  - kernel*\n",
+            "repo_upgrade: security\n"
             "packages:\n",
             "  - aws-cfn-bootstrap\n",
             "mounts:\n",


### PR DESCRIPTION
Fix #949 

The documented default of `security` doesn't seem to be working, so set it explicitly in our cloud-config section.