### PR TITLE
Add NAT gateway friendly name during install

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -615,6 +615,8 @@ func friendlyName(t string) string {
 		return "CloudWatch Log Group"
 	case "AWS::Logs::SubscriptionFilter":
 		return ""
+	case "AWS::EC2::NatGateway":
+		return "NAT Gateway"
 	case "AWS::S3::Bucket":
 		return "S3 Bucket"
 	case "AWS::SNS::Topic":


### PR DESCRIPTION
Currently shows up during install as:

```
Created Unknown: AWS::EC2::NatGateway: nat-0e45767997c6859ed
```