### PR TITLE
Cleanup after app deletion

### DIFF
--- a/api/controllers/apps.go
+++ b/api/controllers/apps.go
@@ -92,7 +92,6 @@ func AppDelete(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	if awsError(err) == "ValidationError" {
 		return httperr.Errorf(404, "no such app: %s", name)
 	}
-
 	if err != nil {
 		return httperr.Server(err)
 	}

--- a/api/controllers/apps_test.go
+++ b/api/controllers/apps_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/convox/rack/api/controllers"
 	"github.com/convox/rack/api/models"
+	"github.com/convox/rack/api/provider"
 	"github.com/convox/rack/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -146,11 +147,24 @@ func TestAppCreateWithRackName(t *testing.T) {
 bucket name to the ephermeral host, so you get `app-XXX.127.0.0.1`
 */
 func TestAppDelete(t *testing.T) {
+
+	// set current provider
+	testProvider := &provider.TestProviderRunner{}
+	provider.CurrentProvider = testProvider
+	defer func() {
+		//TODO: remove: as we arent updating all tests we need to set current provider back to a
+		//clean default one
+		provider.CurrentProvider = new(provider.TestProviderRunner)
+	}()
+
 	aws := test.StubAws(
 		test.DescribeAppStackCycle("convox-test-bar"),
 		test.DeleteStackCycle("convox-test-bar"),
 	)
 	defer aws.Close()
+
+	// setup expectations on current provider
+	testProvider.On("AppDelete", "bar").Return(nil)
 
 	body := test.HTTPBody("DELETE", "http://convox/apps/bar", nil)
 

--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -127,6 +127,7 @@ func BuildCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	return RenderJson(rw, b)
 }
 
+// BuildDelete deletes a build. Makes sure not to delete a build that is contained in the active release
 func BuildDelete(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	vars := mux.Vars(r)
 	appName := vars["app"]

--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -141,7 +141,7 @@ func BuildDelete(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		return httperr.Errorf(400, "cannot delete build contained in active release")
 	}
 
-	err = provider.ReleaseBatchDelete(appName, buildID)
+	err = provider.ReleaseDelete(appName, buildID)
 	if err != nil {
 		return httperr.Server(err)
 	}
@@ -215,7 +215,7 @@ func BuildUpdate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 							continue
 						}
 
-						err = provider.ReleaseBatchDelete(app, b.Id)
+						err = provider.ReleaseDelete(app, b.Id)
 						if err != nil {
 							fmt.Printf("Error cleaning up releases for %s: %s", b.Id, err.Error())
 							continue

--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -206,6 +206,7 @@ func BuildUpdate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 			fmt.Println("Error listing builds for cleanup")
 		} else {
 			if len(bs) >= 50 {
+
 				go func() {
 					for _, b := range bs[50:] {
 						active, err := isBuildActive(app, b.Id)
@@ -406,6 +407,10 @@ func isBuildActive(appName, buildID string) (bool, error) {
 	_, err = provider.BuildGet(app.Name, buildID)
 	if err != nil {
 		return true, err
+	}
+
+	if app.Release == "" { // no release means no active build
+		return false, nil
 	}
 
 	release, err := provider.ReleaseGet(app.Name, app.Release)

--- a/api/controllers/builds_test.go
+++ b/api/controllers/builds_test.go
@@ -13,19 +13,31 @@ import (
 func TestBuildDelete(t *testing.T) {
 	// set current provider
 	testProvider := &provider.TestProviderRunner{
+		App: structs.App{
+			Name:    "app-name",
+			Release: "release-id",
+		},
 		Build: structs.Build{
 			Id: "build-id",
+		},
+		Release: structs.Release{
+			Id:    "release-id",
+			Build: "not-build-id",
 		},
 	}
 	provider.CurrentProvider = testProvider
 	defer func() {
-		//TODO: remove: as we arent updating all tests we need tos et current provider back to a
+		//TODO: remove: as we arent updating all tests we need to set current provider back to a
 		//clean default one (I miss rspec before)
 		provider.CurrentProvider = new(provider.TestProviderRunner)
 	}()
 
 	// setup expectations on current provider
+	testProvider.On("AppGet", "app-name").Return(&testProvider.App, nil)
+	testProvider.On("BuildGet", "app-name", "build-id").Return(&testProvider.Build, nil)
+	testProvider.On("ReleaseGet", "app-name", "release-id").Return(&testProvider.Release, nil)
 	testProvider.On("BuildDelete", "app-name", "build-id").Return(&testProvider.Build, nil)
+	testProvider.On("ReleaseBatchDelete", "app-name", "build-id").Return(nil)
 
 	// make request
 	body := test.HTTPBody("DELETE", "http://convox/apps/app-name/builds/build-id", nil)

--- a/api/controllers/builds_test.go
+++ b/api/controllers/builds_test.go
@@ -37,7 +37,7 @@ func TestBuildDelete(t *testing.T) {
 	testProvider.On("BuildGet", "app-name", "build-id").Return(&testProvider.Build, nil)
 	testProvider.On("ReleaseGet", "app-name", "release-id").Return(&testProvider.Release, nil)
 	testProvider.On("BuildDelete", "app-name", "build-id").Return(&testProvider.Build, nil)
-	testProvider.On("ReleaseBatchDelete", "app-name", "build-id").Return(nil)
+	testProvider.On("ReleaseDelete", "app-name", "build-id").Return(nil)
 
 	// make request
 	body := test.HTTPBody("DELETE", "http://convox/apps/app-name/builds/build-id", nil)

--- a/api/controllers/releases.go
+++ b/api/controllers/releases.go
@@ -14,7 +14,7 @@ import (
 func ReleaseList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	app := mux.Vars(r)["app"]
 
-	releases, err := provider.ReleaseList(app)
+	releases, err := provider.ReleaseList(app, 20)
 	if awsError(err) == "ValidationError" {
 		return httperr.Errorf(404, "no such app: %s", app)
 	}

--- a/api/controllers/system.go
+++ b/api/controllers/system.go
@@ -18,7 +18,7 @@ func SystemReleaseList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		return httperr.Server(err)
 	}
 
-	releases, err := provider.ReleaseList(rack.Name)
+	releases, err := provider.ReleaseList(rack.Name, 20)
 	if err != nil {
 		return httperr.Server(err)
 	}

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -122,12 +122,13 @@ func (a *App) IsBound() bool {
 	return false
 }
 
+// StackName returns the app's stack if the app is bound. Otherwise returns the short name.
 func (a *App) StackName() string {
 	if a.IsBound() {
 		return shortNameToStackName(a.Name)
-	} else {
-		return a.Name
 	}
+
+	return a.Name
 }
 
 func (a *App) Create() error {

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/convox/rack/api/helpers"
@@ -18,11 +17,9 @@ import (
 	"github.com/convox/rack/manifest"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -213,87 +210,13 @@ func (a *App) Create() error {
 	return nil
 }
 
-func (a *App) Cleanup() error {
-	err := cleanupBucket(a.Outputs["Settings"])
-	if err != nil {
-		return err
-	}
-
-	builds, err := provider.BuildList(a.Name, 200)
-	if err != nil {
-		return err
-	}
-
-	for _, build := range builds {
-		provider.BuildDelete(a.Name, build.Id)
-	}
-
-	// FIXME: ReleaseList only lists and cleans up the last 20 builds/releases
-	// FIXME: Should the delete calls happen in a goroutine?
-	releases, err := provider.ReleaseList(a.Name)
-	if err != nil {
-		return err
-	}
-
-	for _, release := range releases {
-		provider.ReleaseDelete(a.Name, release.Id)
-	}
-
-	// monitor and stack deletion state for up to 10 minutes
-	// retry once if DELETE_FAILED to automate around transient errors
-	// send delete success event only when stack is gone
-	shouldRetry := true
-
-	for i := 0; i < 60; i++ {
-		res, err := CloudFormation().DescribeStacks(&cloudformation.DescribeStacksInput{
-			StackName: aws.String(a.StackName()),
-		})
-
-		// return when stack is not found indicating successful delete
-		if ae, ok := err.(awserr.Error); ok {
-			if ae.Code() == "ValidationError" {
-				helpers.TrackEvent("kernel-app-delete-success", nil)
-				// Last ditch effort to remove the empty bucket CF leaves behind.
-				_, err := S3().DeleteBucket(&s3.DeleteBucketInput{Bucket: aws.String(a.Outputs["Settings"])})
-				if err != nil {
-					fmt.Printf("error: %s\n", err)
-				}
-				return nil
-			}
-		}
-
-		if err == nil && len(res.Stacks) == 1 && shouldRetry {
-			// if delete failed, issue one more delete stack and return
-			s := res.Stacks[0]
-			if *s.StackStatus == "DELETE_FAILED" {
-				helpers.TrackEvent("kernel-app-delete-retry", nil)
-
-				_, err := CloudFormation().DeleteStack(&cloudformation.DeleteStackInput{StackName: aws.String(a.StackName())})
-
-				if err != nil {
-					helpers.TrackEvent("kernel-app-delete-retry-error", nil)
-				} else {
-					shouldRetry = false
-				}
-			}
-		}
-
-		time.Sleep(10 * time.Second)
-	}
-
-	return nil
-}
-
 func (a *App) Delete() error {
 	helpers.TrackEvent("kernel-app-delete-start", nil)
 
-	_, err := CloudFormation().DeleteStack(&cloudformation.DeleteStackInput{StackName: aws.String(a.StackName())})
+	err := provider.AppDelete(a.Name)
 	if err != nil {
-		helpers.TrackEvent("kernel-app-delete-error", nil)
 		return err
 	}
-
-	go a.Cleanup()
 
 	NotifySuccess("app:delete", map[string]string{"name": a.Name})
 
@@ -859,60 +782,6 @@ func appFromStack(stack *cloudformation.Stack) *App {
 		Outputs:    stackOutputs(stack),
 		Parameters: stackParameters(stack),
 		Tags:       tags,
-	}
-}
-
-func cleanupBucket(bucket string) error {
-	req := &s3.ListObjectVersionsInput{
-		Bucket: aws.String(bucket),
-	}
-
-	res, err := S3().ListObjectVersions(req)
-	if err != nil {
-		return err
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		for _, d := range res.DeleteMarkers {
-			cleanupBucketObject(bucket, *d.Key, *d.VersionId)
-			time.Sleep(1 * time.Second)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		for _, v := range res.Versions {
-			cleanupBucketObject(bucket, *v.Key, *v.VersionId)
-			time.Sleep(1 * time.Second)
-		}
-	}()
-
-	wg.Wait()
-
-	_, err = S3().DeleteBucket(&s3.DeleteBucketInput{
-		Bucket: aws.String(bucket),
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func cleanupBucketObject(bucket, key, version string) {
-	req := &s3.DeleteObjectInput{
-		Bucket:    aws.String(bucket),
-		Key:       aws.String(key),
-		VersionId: aws.String(version),
-	}
-
-	_, err := S3().DeleteObject(req)
-	if err != nil {
-		fmt.Printf("error: %s\n", err)
 	}
 }
 

--- a/api/provider/aws/apps.go
+++ b/api/provider/aws/apps.go
@@ -58,6 +58,7 @@ func (p *AWSProvider) AppGet(name string) (*structs.App, error) {
 	return &app, nil
 }
 
+// AppDelete deletes an app
 func (p *AWSProvider) AppDelete(name string) error {
 
 	app, err := p.AppGet(name)

--- a/api/provider/aws/apps.go
+++ b/api/provider/aws/apps.go
@@ -3,9 +3,14 @@ package aws
 import (
 	"fmt"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/convox/rack/api/helpers"
 	"github.com/convox/rack/api/structs"
 )
 
@@ -50,6 +55,145 @@ func (p *AWSProvider) AppGet(name string) (*structs.App, error) {
 	}
 
 	return &app, nil
+}
+
+func (p *AWSProvider) AppDelete(name string) error {
+
+	app, err := p.AppGet(name)
+	if err != nil {
+		return err
+	}
+
+	_, err = p.cloudformation().DeleteStack(&cloudformation.DeleteStackInput{StackName: aws.String(app.StackName())})
+	if err != nil {
+		helpers.TrackEvent("kernel-app-delete-error", nil)
+		return err
+	}
+
+	go p.cleanup(app)
+
+	return nil
+}
+
+// cleanup deletes AWS resources that aren't handled by the CloudFormation during stack deletion.
+func (p *AWSProvider) cleanup(app *structs.App) error {
+	err := p.deleteBucket(app.Outputs["Settings"])
+	if err != nil {
+		return err
+	}
+
+	builds, err := p.BuildList(app.Name, 200)
+	if err != nil {
+		return err
+	}
+
+	for _, build := range builds {
+		p.BuildDelete(app.Name, build.Id)
+	}
+
+	err = p.releaseDeleteAll(app.Name)
+	if err != nil {
+		return err
+	}
+
+	// monitor and stack deletion state for up to 10 minutes
+	// retry once if DELETE_FAILED to automate around transient errors
+	// send delete success event only when stack is gone
+	shouldRetry := true
+
+	for i := 0; i < 60; i++ {
+		res, err := p.cloudformation().DescribeStacks(&cloudformation.DescribeStacksInput{
+			StackName: aws.String(app.StackName()),
+		})
+
+		// return when stack is not found indicating successful delete
+		if ae, ok := err.(awserr.Error); ok {
+			if ae.Code() == "ValidationError" { // Error indicates stack wasn't found, hence deleted.
+				helpers.TrackEvent("kernel-app-delete-success", nil)
+				// Last ditch effort to remove the empty bucket CF leaves behind.
+				_, err := p.s3().DeleteBucket(&s3.DeleteBucketInput{Bucket: aws.String(app.Outputs["Settings"])})
+				if err != nil {
+					fmt.Printf("last ditch effort bucket error: %s\n", err)
+				}
+				return nil
+			}
+		}
+
+		if err == nil && len(res.Stacks) == 1 && shouldRetry {
+			// if delete failed, issue one more delete stack and return
+			s := res.Stacks[0]
+			if *s.StackStatus == "DELETE_FAILED" {
+				helpers.TrackEvent("kernel-app-delete-retry", nil)
+
+				_, err := p.cloudformation().DeleteStack(&cloudformation.DeleteStackInput{StackName: aws.String(app.StackName())})
+
+				if err != nil {
+					helpers.TrackEvent("kernel-app-delete-retry-error", nil)
+				} else {
+					shouldRetry = false
+				}
+			}
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+
+	return nil
+}
+
+// deleteBucket deletes all object versions and delete markers then deletes the bucket.
+func (p *AWSProvider) deleteBucket(bucket string) error {
+	req := &s3.ListObjectVersionsInput{
+		Bucket: aws.String(bucket),
+	}
+
+	res, err := p.s3().ListObjectVersions(req)
+	if err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for _, d := range res.DeleteMarkers {
+			p.cleanupBucketObject(bucket, *d.Key, *d.VersionId)
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for _, v := range res.Versions {
+			p.cleanupBucketObject(bucket, *v.Key, *v.VersionId)
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
+	wg.Wait()
+
+	_, err = p.s3().DeleteBucket(&s3.DeleteBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *AWSProvider) cleanupBucketObject(bucket, key, version string) {
+	req := &s3.DeleteObjectInput{
+		Bucket:    aws.String(bucket),
+		Key:       aws.String(key),
+		VersionId: aws.String(version),
+	}
+
+	_, err := p.s3().DeleteObject(req)
+	if err != nil {
+		fmt.Printf("error: %s\n", err)
+	}
 }
 
 func appFromStack(stack *cloudformation.Stack) structs.App {

--- a/api/provider/aws/releases.go
+++ b/api/provider/aws/releases.go
@@ -17,6 +17,7 @@ func releasesTable(app string) string {
 	return os.Getenv("DYNAMO_RELEASES")
 }
 
+// ReleaseGet returns a release
 func (p *AWSProvider) ReleaseGet(app, id string) (*structs.Release, error) {
 
 	if id == "" {

--- a/api/provider/aws/releases.go
+++ b/api/provider/aws/releases.go
@@ -172,9 +172,9 @@ func releaseFromItem(item map[string]*dynamodb.AttributeValue) *structs.Release 
 	return release
 }
 
-// ReleaseBatchDelete will delete all releases that belong to app and buildID
+// ReleaseDelete will delete all releases that belong to app and buildID
 // This could includes the active release which implies this should be called with caution.
-func (p *AWSProvider) ReleaseBatchDelete(app, buildID string) error {
+func (p *AWSProvider) ReleaseDelete(app, buildID string) error {
 
 	// query dynamo for all releases for this build
 	qi := &dynamodb.QueryInput{

--- a/api/provider/aws/releases.go
+++ b/api/provider/aws/releases.go
@@ -233,18 +233,5 @@ func (p *AWSProvider) deleteReleaseItems(qi *dynamodb.QueryInput, tableName stri
 		wrs = append(wrs, wr)
 	}
 
-	if len(wrs) > 0 {
-		_, err = p.dynamodb().BatchWriteItem(&dynamodb.BatchWriteItemInput{
-			RequestItems: map[string][]*dynamodb.WriteRequest{
-				tableName: wrs,
-			},
-		})
-		if err != nil {
-			return err
-		}
-	} else {
-		fmt.Println("ns=api fn=deleteReleaseItems level=info  msg=\"no releases to delete\"")
-	}
-
-	return nil
+	return p.dynamoBatchDeleteItems(wrs, tableName)
 }

--- a/api/provider/aws/releases_test.go
+++ b/api/provider/aws/releases_test.go
@@ -51,7 +51,7 @@ func TestReleaseList(t *testing.T) {
 		provider.CurrentProvider = new(provider.TestProviderRunner)
 	}()
 
-	r, err := provider.ReleaseList("httpd")
+	r, err := provider.ReleaseList("httpd", 20)
 
 	assert.Nil(t, err)
 
@@ -81,9 +81,9 @@ func TestReleaseLatestEmpty(t *testing.T) {
 	}()
 	p := provider.CurrentProvider.(*provider.TestProviderRunner)
 
-	p.Mock.On("ReleaseList", "myapp").Return(structs.Releases{}, nil)
+	p.Mock.On("ReleaseList", "myapp", int64(20)).Return(structs.Releases{}, nil)
 
-	rs, err := p.ReleaseList("myapp")
+	rs, err := p.ReleaseList("myapp", 20)
 	assert.Nil(t, err)
 	assert.Equal(t, (*structs.Release)(nil), rs.Latest())
 }
@@ -94,7 +94,7 @@ func TestReleaseLatest(t *testing.T) {
 	}()
 	p := provider.CurrentProvider.(*provider.TestProviderRunner)
 
-	p.Mock.On("ReleaseList", "myapp").Return(structs.Releases{
+	p.Mock.On("ReleaseList", "myapp", int64(20)).Return(structs.Releases{
 		structs.Release{
 			Id:       "RVFETUHHKKD",
 			App:      "httpd",
@@ -113,7 +113,7 @@ func TestReleaseLatest(t *testing.T) {
 		},
 	}, nil)
 
-	rs, err := p.ReleaseList("myapp")
+	rs, err := p.ReleaseList("myapp", 20)
 	assert.Nil(t, err)
 	assert.Equal(t, &structs.Release{
 		Id:       "RVFETUHHKKD",

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -44,7 +44,7 @@ type Provider interface {
 
 	LogStream(app string, w io.Writer, opts structs.LogStreamOptions) error
 
-	ReleaseBatchDelete(app, buildID string) error
+	ReleaseDelete(app, buildID string) error
 	ReleaseGet(app, id string) (*structs.Release, error)
 	ReleaseList(app string, limit int64) (structs.Releases, error)
 	ReleasePromote(app, id string) (*structs.Release, error)
@@ -172,9 +172,9 @@ func LogStream(app string, w io.Writer, opts structs.LogStreamOptions) error {
 	return CurrentProvider.LogStream(app, w, opts)
 }
 
-// ReleaseBatchDelete deletes releases associated with app and buildID in batches
-func ReleaseBatchDelete(app, buildID string) error {
-	return CurrentProvider.ReleaseBatchDelete(app, buildID)
+// ReleaseDelete deletes releases associated with app and buildID in batches
+func ReleaseDelete(app, buildID string) error {
+	return CurrentProvider.ReleaseDelete(app, buildID)
 }
 
 func ReleaseGet(app, id string) (*structs.Release, error) {

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -13,6 +13,7 @@ var CurrentProvider Provider
 
 type Provider interface {
 	AppGet(name string) (*structs.App, error)
+	AppDelete(name string) error
 
 	BuildCopy(srcApp, id, destApp string) (*structs.Build, error)
 	BuildCreateIndex(app string, index structs.Index, manifest, description string, cache bool) (*structs.Build, error)
@@ -43,9 +44,9 @@ type Provider interface {
 
 	LogStream(app string, w io.Writer, opts structs.LogStreamOptions) error
 
-	ReleaseDelete(app, id string) (*structs.Release, error)
+	ReleaseBatchDelete(app, buildID string) error
 	ReleaseGet(app, id string) (*structs.Release, error)
-	ReleaseList(app string) (structs.Releases, error)
+	ReleaseList(app string, limit int64) (structs.Releases, error)
 	ReleasePromote(app, id string) (*structs.Release, error)
 	ReleaseSave(*structs.Release, string, string) error
 
@@ -80,6 +81,10 @@ func init() {
 
 func AppGet(name string) (*structs.App, error) {
 	return CurrentProvider.AppGet(name)
+}
+
+func AppDelete(name string) error {
+	return CurrentProvider.AppDelete(name)
 }
 
 func BuildCopy(srcApp, id, destApp string) (*structs.Build, error) {
@@ -166,16 +171,16 @@ func LogStream(app string, w io.Writer, opts structs.LogStreamOptions) error {
 	return CurrentProvider.LogStream(app, w, opts)
 }
 
-func ReleaseDelete(app, id string) (*structs.Release, error) {
-	return CurrentProvider.ReleaseDelete(app, id)
+func ReleaseBatchDelete(app, buildID string) error {
+	return CurrentProvider.ReleaseBatchDelete(app, buildID)
 }
 
 func ReleaseGet(app, id string) (*structs.Release, error) {
 	return CurrentProvider.ReleaseGet(app, id)
 }
 
-func ReleaseList(app string) (structs.Releases, error) {
-	return CurrentProvider.ReleaseList(app)
+func ReleaseList(app string, limit int64) (structs.Releases, error) {
+	return CurrentProvider.ReleaseList(app, limit)
 }
 
 func ReleasePromote(app, id string) (*structs.Release, error) {

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -83,6 +83,7 @@ func AppGet(name string) (*structs.App, error) {
 	return CurrentProvider.AppGet(name)
 }
 
+// AppDelete deletes an app
 func AppDelete(name string) error {
 	return CurrentProvider.AppDelete(name)
 }
@@ -171,6 +172,7 @@ func LogStream(app string, w io.Writer, opts structs.LogStreamOptions) error {
 	return CurrentProvider.LogStream(app, w, opts)
 }
 
+// ReleaseBatchDelete deletes releases associated with app and buildID in batches
 func ReleaseBatchDelete(app, buildID string) error {
 	return CurrentProvider.ReleaseBatchDelete(app, buildID)
 }
@@ -179,6 +181,7 @@ func ReleaseGet(app, id string) (*structs.Release, error) {
 	return CurrentProvider.ReleaseGet(app, id)
 }
 
+// ReleaseList returns a list of releases
 func ReleaseList(app string, limit int64) (structs.Releases, error) {
 	return CurrentProvider.ReleaseList(app, limit)
 }

--- a/api/provider/test.go
+++ b/api/provider/test.go
@@ -28,6 +28,11 @@ func (p *TestProviderRunner) AppGet(name string) (*structs.App, error) {
 	return &p.App, nil
 }
 
+func (p *TestProviderRunner) AppDelete(name string) error {
+	p.Called(name)
+	return nil
+}
+
 func (p *TestProviderRunner) BuildCopy(srcApp, id, destApp string) (*structs.Build, error) {
 	p.Called(srcApp, id, destApp)
 	return &p.Build, nil
@@ -134,9 +139,9 @@ func (p *TestProviderRunner) LogStream(app string, w io.Writer, opts structs.Log
 	return nil
 }
 
-func (p *TestProviderRunner) ReleaseDelete(app, id string) (*structs.Release, error) {
-	p.Called(app, id)
-	return &p.Release, nil
+func (p *TestProviderRunner) ReleaseBatchDelete(app, buildID string) error {
+	p.Called(app, buildID)
+	return nil
 }
 
 func (p *TestProviderRunner) ReleaseGet(app, id string) (*structs.Release, error) {
@@ -144,8 +149,8 @@ func (p *TestProviderRunner) ReleaseGet(app, id string) (*structs.Release, error
 	return &p.Release, nil
 }
 
-func (p *TestProviderRunner) ReleaseList(app string) (structs.Releases, error) {
-	args := p.Called(app)
+func (p *TestProviderRunner) ReleaseList(app string, limit int64) (structs.Releases, error) {
+	args := p.Called(app, limit)
 	return args.Get(0).(structs.Releases), args.Error(1)
 }
 

--- a/api/provider/test.go
+++ b/api/provider/test.go
@@ -28,6 +28,7 @@ func (p *TestProviderRunner) AppGet(name string) (*structs.App, error) {
 	return &p.App, nil
 }
 
+// AppDelete deletes an app
 func (p *TestProviderRunner) AppDelete(name string) error {
 	p.Called(name)
 	return nil
@@ -139,6 +140,7 @@ func (p *TestProviderRunner) LogStream(app string, w io.Writer, opts structs.Log
 	return nil
 }
 
+// ReleaseBatchDelete deletes releases associated with app and buildID in batches
 func (p *TestProviderRunner) ReleaseBatchDelete(app, buildID string) error {
 	p.Called(app, buildID)
 	return nil
@@ -149,6 +151,7 @@ func (p *TestProviderRunner) ReleaseGet(app, id string) (*structs.Release, error
 	return &p.Release, nil
 }
 
+// ReleaseList returns a list of releases
 func (p *TestProviderRunner) ReleaseList(app string, limit int64) (structs.Releases, error) {
 	args := p.Called(app, limit)
 	return args.Get(0).(structs.Releases), args.Error(1)

--- a/api/provider/test.go
+++ b/api/provider/test.go
@@ -140,8 +140,8 @@ func (p *TestProviderRunner) LogStream(app string, w io.Writer, opts structs.Log
 	return nil
 }
 
-// ReleaseBatchDelete deletes releases associated with app and buildID in batches
-func (p *TestProviderRunner) ReleaseBatchDelete(app, buildID string) error {
+// ReleaseDelete deletes releases associated with app and buildID in batches
+func (p *TestProviderRunner) ReleaseDelete(app, buildID string) error {
 	p.Called(app, buildID)
 	return nil
 }

--- a/api/structs/app.go
+++ b/api/structs/app.go
@@ -1,5 +1,7 @@
 package structs
 
+import "os"
+
 type App struct {
 	Name    string `json:"name"`
 	Release string `json:"release"`
@@ -27,4 +29,23 @@ func (a *App) IsBound() bool {
 
 	// Tags are present but "Name" tag is not, so we have an unbound app.
 	return false
+}
+
+func (a *App) StackName() string {
+	if a.IsBound() {
+		return shortNameToStackName(a.Name)
+	} else {
+		return a.Name
+	}
+}
+
+func shortNameToStackName(appName string) string {
+	rack := os.Getenv("RACK")
+
+	if rack == appName {
+		// Do no prefix the rack itself.
+		return appName
+	}
+
+	return rack + "-" + appName
 }

--- a/api/structs/app.go
+++ b/api/structs/app.go
@@ -31,12 +31,13 @@ func (a *App) IsBound() bool {
 	return false
 }
 
+// StackName returns the app's stack if the app is bound. Otherwise returns the short name.
 func (a *App) StackName() string {
 	if a.IsBound() {
 		return shortNameToStackName(a.Name)
-	} else {
-		return a.Name
 	}
+
+	return a.Name
 }
 
 func shortNameToStackName(appName string) string {


### PR DESCRIPTION
Fixes here include for when an app is deleted:

- Delete an app's bucket in batches of 1000 objects to play nice with AWS limits
- Delete builds and releases in batches of 25
- Force delete the app's ECR repo as it might be not be deleted by CloudFormation since there could be images yet to be deleted.