### PR TITLE
Api cpu should be capitalized

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -1576,7 +1576,7 @@
         "Tasks": [
           {
             "Command": "api/bin/web",
-            "CPU": { "Ref": "ApiCpu" },
+            "Cpu": { "Ref": "ApiCpu" },
             "Environment": {
               "AWS_REGION": { "Ref": "AWS::Region" },
               "AWS_ACCESS": { "Ref": "KernelAccess" },


### PR DESCRIPTION
The custom task definition supports `Cpu`, not `CPU`. (Tested this change my dev rack)