### PR TITLE
restore convox.start.shift label for per-service shift

### DIFF
--- a/manifest/fixtures/shift.yml
+++ b/manifest/fixtures/shift.yml
@@ -2,3 +2,9 @@ web:
   ports:
     - 5000
     - 6000:7000
+other:
+  labels:
+    - convox.start.shift=1000
+  ports:
+    - 8000
+    - 9000:9001

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -45,6 +45,16 @@ func Load(data []byte) (*Manifest, error) {
 	for name, service := range m.Services {
 		service.Name = name
 		service.Networks = m.Networks
+
+		if ss, ok := service.Labels["convox.start.shift"]; ok {
+			shift, err := strconv.Atoi(ss)
+			if err != nil {
+				return nil, fmt.Errorf("invalid shift: %s", ss)
+			}
+
+			service.Ports.Shift(shift)
+		}
+
 		m.Services[name] = service
 	}
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -333,6 +333,15 @@ func TestShift(t *testing.T) {
 			assert.Equal(t, web.Ports[1].Balancer, 11000)
 			assert.Equal(t, web.Ports[1].Container, 7000)
 		}
+
+		other := m.Services["other"]
+
+		if assert.NotNil(t, other) && assert.Equal(t, len(other.Ports), 2) {
+			assert.Equal(t, other.Ports[0].Balancer, 8000)
+			assert.Equal(t, other.Ports[0].Container, 8000)
+			assert.Equal(t, other.Ports[1].Balancer, 15000)
+			assert.Equal(t, other.Ports[1].Container, 9001)
+		}
 	}
 }
 


### PR DESCRIPTION
per-service shift is additive with --shift

closes #746