### PR TITLE
Latest version is not an error

### DIFF
--- a/vendor/github.com/convox/version/version.go
+++ b/vendor/github.com/convox/version/version.go
@@ -184,7 +184,7 @@ func (vs Versions) Next(curr string) (string, error) {
 		return published, nil
 	}
 
-	return "", fmt.Printf("current version %q is latest", curr)
+	return "", fmt.Sprintf("current version %q is latest", curr)
 }
 
 // Walk a bucket to create initial versions.json file

--- a/vendor/github.com/convox/version/version.go
+++ b/vendor/github.com/convox/version/version.go
@@ -184,7 +184,7 @@ func (vs Versions) Next(curr string) (string, error) {
 		return published, nil
 	}
 
-	return "", fmt.Errorf("current version %q is latest", curr)
+	return "", fmt.Printf("current version %q is latest", curr)
 }
 
 // Walk a bucket to create initial versions.json file


### PR DESCRIPTION
I don't think having an up-to-date rack should be considered an error:

```
$ convox rack releases
VERSION                         UPDATED       STATUS
20160810023912                  2 hours ago   active
20160809175449-subnet-behavior  23 hours ago
20160808193602                  1 day ago
ERROR: current version "20160810023912" is latest
```

Note: Not tested.