### PR TITLE
Add setting for max cluster size

### DIFF
--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -1020,7 +1020,7 @@
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : "1",
-        "MaxSize" : "100",
+        "MaxSize" : "1000",
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "Tags": [
           {


### PR DESCRIPTION
I tried to regenerate the templates as well, but got:

```
$ make -C api templates ; make fixtures
go-bindata -nometadata -pkg=models -prefix=models -o=models/templates.go models/templates/...
go-bindata -nometadata -pkg=aws -prefix=provider/aws -o=provider/aws/templates.go provider/aws/templates/...
go install github.com/convox/rack/api/cmd/fixture
rm api/models/fixtures/*.json
make -C api/models/fixtures
env AWS_REGION=us-test-2 PROVIDER=test RACK=convox-test fixture balancer_labels.yml > balancer_labels.json
env AWS_REGION=us-test-2 PROVIDER=test RACK=convox-test fixture command_exec_form.yml > command_exec_form.json
env AWS_REGION=us-test-2 PROVIDER=test RACK=convox-test fixture command_string_form.yml > command_string_form.json
env AWS_REGION=us-test-2 PROVIDER=test RACK=convox-test fixture complex_environment.yml > complex_environment.json
env AWS_REGION=us-test-2 PROVIDER=test RACK=convox-test fixture custom_health.yml > custom_health.json
env AWS_REGION=us-test-2 PROVIDER=test RACK=convox-test fixture environment_map.yml > environment_map.json
env AWS_REGION=us-test-2 PROVIDER=test RACK=convox-test fixture multi_balancer.yml > multi_balancer.json
env AWS_REGION=us-test-2 PROVIDER=test RACK=convox-test fixture web_external_internal.yml > web_external_internal.json
env AWS_REGION=us-test-2 PROVIDER=test RACK=convox-test fixture web_postgis.yml > web_postgis.json
ERROR: web links to service: postgres which does not expose any ports
make[1]: *** [web_postgis.json] Error 1
make: *** [fixtures] Error 2
```