### PR TITLE
[RELEASE] 20160811

### DIFF
--- a/api/controllers/instances.go
+++ b/api/controllers/instances.go
@@ -18,7 +18,6 @@ func init() {
 
 func InstancesKeyroll(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	err := models.InstanceKeyroll()
-
 	if err != nil {
 		return httperr.Server(err)
 	}

--- a/api/controllers/processes.go
+++ b/api/controllers/processes.go
@@ -24,7 +24,6 @@ func ProcessList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	}
 
 	processes, err := models.ListProcesses(app)
-
 	if err != nil {
 		return httperr.Server(err)
 	}

--- a/api/dist/kernel.json
+++ b/api/dist/kernel.json
@@ -416,7 +416,7 @@
             }
           ]
         },
-        "Path": "/",
+        "Path": "/convox/",
         "Policies": [
           {
             "PolicyName": "LogSubscriptionFilterRole",
@@ -458,7 +458,7 @@
             }
           ]
         },
-        "Path": "/",
+        "Path": "/convox/",
         "Policies": [
           {
             "PolicyName": "Administrator",
@@ -859,7 +859,7 @@
             }
           ]
         },
-        "Path": "/",
+        "Path": "/convox/",
         "Policies": [
           {
             "PolicyName": "ClusterInstanceRole",
@@ -1076,7 +1076,7 @@
             }
           ]
         },
-        "Path": "/",
+        "Path": "/convox/",
         "Policies": [
           {
             "PolicyName": "InstancesLifecycleRole",
@@ -1180,7 +1180,7 @@
             }
           ]
         },
-        "Path": "/",
+        "Path": "/convox/",
         "Policies": [
           {
             "PolicyName": "InstancesLifecycleHandlerRole",
@@ -1386,7 +1386,7 @@
           { "Fn::Join": [ ":", [ { "Ref": "Balancer" }, "registry", "443" ] ] }
         ],
         "Name": { "Fn::Join": [ "-", [ { "Ref": "AWS::StackName" }, "api-web" ] ] },
-        "Role": { "Ref": "ServiceRole" },
+        "Role": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
         "TaskDefinition": { "Ref": "ApiWebTasks" }
       }
     },
@@ -1402,7 +1402,7 @@
         "DesiredCount": "1",
         "LoadBalancers": [],
         "Name": { "Fn::Join": [ "-", [ { "Ref": "AWS::StackName" }, "api-monitor" ] ] },
-        "Role": { "Ref": "ServiceRole" },
+        "Role": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
         "TaskDefinition": { "Ref": "ApiMonitorTasks" }
       }
     },
@@ -1424,7 +1424,7 @@
           ],
           "Version": "2012-10-17"
         },
-        "Path": "/",
+        "Path": "/convox/",
         "Policies": [
           {
             "PolicyDocument": {
@@ -1639,7 +1639,7 @@
             ]
           },
           { "Fn::If": [ "RegionHasECR",
-            { "Ref": "AWS::NoValue" }, 
+            { "Ref": "AWS::NoValue" },
             {
               "CPU": "128",
               "Environment": {

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -428,7 +428,7 @@ func (a *App) RunAttached(process, command, releaseID string, height, width int,
 
 		_, releaseContainer, err := findAppDefinitions(process, releaseID, *task.TaskDefinition.Family, 20)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		// If container is nil, the release most likely hasn't been promoted and thus no TaskDefinition for it.

--- a/api/models/instances.go
+++ b/api/models/instances.go
@@ -16,20 +16,17 @@ func InstanceKeyroll() error {
 	keypair, err := EC2().CreateKeyPair(&ec2.CreateKeyPairInput{
 		KeyName: &keyname,
 	})
-
 	if err != nil {
 		return err
 	}
 
 	env, err := GetRackSettings()
-
 	if err != nil {
 		return err
 	}
 
 	env["InstancePEM"] = *keypair.KeyMaterial
 	err = PutRackSettings(env)
-
 	if err != nil {
 		return err
 	}

--- a/cmd/convox/logs.go
+++ b/cmd/convox/logs.go
@@ -20,15 +20,15 @@ func init() {
 			rackFlag,
 			cli.StringFlag{
 				Name:  "filter",
-				Usage: "Only return logs that match a filter pattern. If not specified, return all logs.",
+				Usage: "filter the logs by a given token",
 			},
 			cli.BoolTFlag{
 				Name:  "follow",
-				Usage: "Follow log output (default).",
+				Usage: "keep streaming new log output (default)",
 			},
 			cli.DurationFlag{
 				Name:  "since",
-				Usage: "Show logs since a duration, e.g. 10m or 1h2m10s.",
+				Usage: "show logs since a duration (e.g. 10m or 1h2m10s)",
 				Value: 2 * time.Minute,
 			},
 		},

--- a/cmd/convox/ps.go
+++ b/cmd/convox/ps.go
@@ -47,11 +47,6 @@ func cmdPs(c *cli.Context) error {
 		return stdcli.ExitError(err)
 	}
 
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
-	}
-
 	ps, err := rackClient(c).GetProcesses(app, c.Bool("stats"))
 	if err != nil {
 		return stdcli.ExitError(err)
@@ -63,29 +58,38 @@ func cmdPs(c *cli.Context) error {
 			return stdcli.ExitError(err)
 		}
 
-		t := stdcli.NewTable("ID", "NAME", "RELEASE", "CPU %", "MEM", "MEM %", "STARTED", "COMMAND")
-
-		for _, p := range ps {
-			for _, f := range fm {
-				if f.Name != p.Name {
-					continue
-				}
-				t.AddRow(prettyId(p), p.Name, p.Release, fmt.Sprintf("%0.2f%%", p.Cpu), fmt.Sprintf("%0.1fMB/%dMB", p.Memory*float64(f.Memory), f.Memory), fmt.Sprintf("%0.2f%%", p.Memory*100), humanizeTime(p.Started), p.Command)
-			}
-		}
-
-		t.Print()
-	} else {
-		t := stdcli.NewTable("ID", "NAME", "RELEASE", "STARTED", "COMMAND")
-
-		for _, p := range ps {
-			t.AddRow(prettyId(p), p.Name, p.Release, humanizeTime(p.Started), p.Command)
-		}
-
-		t.Print()
+		displayProcessesStats(ps, fm)
+		return nil
 	}
 
+	displayProcesses(ps)
+
 	return nil
+}
+
+func displayProcesses(ps []client.Process) {
+	t := stdcli.NewTable("ID", "NAME", "RELEASE", "STARTED", "COMMAND")
+
+	for _, p := range ps {
+		t.AddRow(prettyId(p), p.Name, p.Release, humanizeTime(p.Started), p.Command)
+	}
+
+	t.Print()
+}
+
+func displayProcessesStats(ps []client.Process, fm client.Formation) {
+	t := stdcli.NewTable("ID", "NAME", "RELEASE", "CPU %", "MEM", "MEM %", "STARTED", "COMMAND")
+
+	for _, p := range ps {
+		for _, f := range fm {
+			if f.Name != p.Name {
+				continue
+			}
+			t.AddRow(prettyId(p), p.Name, p.Release, fmt.Sprintf("%0.2f%%", p.Cpu), fmt.Sprintf("%0.1fMB/%dMB", p.Memory*float64(f.Memory), f.Memory), fmt.Sprintf("%0.2f%%", p.Memory*100), humanizeTime(p.Started), p.Command)
+		}
+	}
+
+	t.Print()
 }
 
 func cmdPsInfo(c *cli.Context) error {

--- a/cmd/convox/rack.go
+++ b/cmd/convox/rack.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/convox/rack/cmd/convox/stdcli"
 	"github.com/convox/version"
@@ -19,6 +21,28 @@ func init() {
 		Flags:       []cli.Flag{rackFlag},
 		Subcommands: []cli.Command{
 			{
+				Name:        "logs",
+				Description: "stream the rack logs",
+				Usage:       "",
+				Action:      cmdRackLogs,
+				Flags: []cli.Flag{
+					rackFlag,
+					cli.StringFlag{
+						Name:  "filter",
+						Usage: "filter the logs by a given token",
+					},
+					cli.BoolTFlag{
+						Name:  "follow",
+						Usage: "keep streaming new log output (default)",
+					},
+					cli.DurationFlag{
+						Name:  "since",
+						Usage: "show logs since a duration (e.g. 10m or 1h2m10s)",
+						Value: 2 * time.Minute,
+					},
+				},
+			},
+			{
 				Name:        "params",
 				Description: "list advanced rack parameters",
 				Usage:       "",
@@ -31,6 +55,19 @@ func init() {
 						Usage:       "NAME=VALUE [NAME=VALUE]",
 						Action:      cmdRackParamsSet,
 						Flags:       []cli.Flag{rackFlag},
+					},
+				},
+			},
+			{
+				Name:        "ps",
+				Description: "list rack processes",
+				Usage:       "",
+				Action:      cmdRackPs,
+				Flags: []cli.Flag{
+					rackFlag,
+					cli.BoolFlag{
+						Name:  "stats",
+						Usage: "display process cpu/memory stats",
 					},
 				},
 			},
@@ -99,6 +136,20 @@ func cmdRack(c *cli.Context) error {
 	return nil
 }
 
+func cmdRackLogs(c *cli.Context) error {
+	system, err := rackClient(c).GetSystem()
+	if err != nil {
+		return stdcli.ExitError(err)
+	}
+
+	err = rackClient(c).StreamAppLogs(system.Name, c.String("filter"), c.BoolT("follow"), c.Duration("since"), os.Stdout)
+	if err != nil {
+		return stdcli.ExitError(err)
+	}
+
+	return nil
+}
+
 func cmdRackParams(c *cli.Context) error {
 	system, err := rackClient(c).GetSystem()
 	if err != nil {
@@ -154,6 +205,32 @@ func cmdRackParamsSet(c *cli.Context) error {
 	}
 
 	fmt.Println("OK")
+	return nil
+}
+
+func cmdRackPs(c *cli.Context) error {
+	system, err := rackClient(c).GetSystem()
+	if err != nil {
+		return stdcli.ExitError(err)
+	}
+
+	ps, err := rackClient(c).GetProcesses(system.Name, c.Bool("stats"))
+	if err != nil {
+		return stdcli.ExitError(err)
+	}
+
+	if c.Bool("stats") {
+		fm, err := rackClient(c).ListFormation(system.Name)
+		if err != nil {
+			return stdcli.ExitError(err)
+		}
+
+		displayProcessesStats(ps, fm)
+		return nil
+	}
+
+	displayProcesses(ps)
+
 	return nil
 }
 

--- a/manifest/fixtures/interpolate-env-var.yml
+++ b/manifest/fixtures/interpolate-env-var.yml
@@ -1,0 +1,6 @@
+version: "2"
+services:
+  web:
+    image: ${KNOWN_VAR1}
+    entrypoint: ${KNOWN_VAR2}/$KNOWN_VAR2/${KNOWN_VAR3}
+    dockerfile: $$REMAIN

--- a/manifest/fixtures/repeat-image.yml
+++ b/manifest/fixtures/repeat-image.yml
@@ -1,0 +1,8 @@
+web1:
+  image: convox/rails
+  ports:
+    - 80:8080
+web2:
+  image: convox/rails
+  ports:
+    - 80:8080

--- a/manifest/fixtures/shift.yml
+++ b/manifest/fixtures/shift.yml
@@ -2,3 +2,9 @@ web:
   ports:
     - 5000
     - 6000:7000
+other:
+  labels:
+    - convox.start.shift=1000
+  ports:
+    - 8000
+    - 9000:9001

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -1,9 +1,13 @@
 package manifest
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -13,6 +17,9 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var interpolationBracketRegex = regexp.MustCompile("\\$\\{([0-9A-Za-z_]*)\\}")
+var interpolationDollarRegex = regexp.MustCompile("\\$([0-9A-Za-z_]+)")
+
 type Manifest struct {
 	Version  string             `yaml:"version"`
 	Networks Networks           `yaml:"networks"`
@@ -21,8 +28,12 @@ type Manifest struct {
 
 // Load a Manifest from raw data
 func Load(data []byte) (*Manifest, error) {
-	v, err := manifestVersion(data)
+	data, err := parseEnvVars(data)
+	if err != nil {
+		return nil, err
+	}
 
+	v, err := manifestVersion(data)
 	if err != nil {
 		return nil, err
 	}
@@ -217,6 +228,44 @@ func manifestVersion(data []byte) (string, error) {
 	}
 
 	return "1", nil
+}
+
+func parseEnvVars(data []byte) ([]byte, error) {
+	r := bytes.NewReader(data)
+	result := []byte{}
+	reader := bufio.NewReader(r)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return result, err
+		}
+		result = append(result, []byte(parseLine(line))...)
+		if err == io.EOF {
+			break
+		}
+	}
+	return result, nil
+}
+
+func parseLine(line string) string {
+	matches := interpolationDollarRegex.FindAllIndex([]byte(line), -1)
+	for _, pair := range matches {
+		if line[pair[0]-1] != '$' {
+			fmt.Println(line[pair[0]:pair[1]])
+			head := line[0:pair[0]]
+			tail := line[pair[1]:]
+			line = fmt.Sprintf("%s%s%s", head, os.Getenv(line[(pair[0]+1):pair[1]]), tail)
+		} else {
+			head := line[0:(pair[0] - 1)]
+			tail := line[pair[0]:]
+			line = fmt.Sprintf("%s%s", head, tail)
+		}
+	}
+	result := interpolationBracketRegex.FindAllStringSubmatch(line, -1)
+	for _, v := range result {
+		line = strings.Replace(line, v[0], os.Getenv(v[1]), -1)
+	}
+	return line
 }
 
 func (m *Manifest) Raw() ([]byte, error) {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -56,6 +56,16 @@ func Load(data []byte) (*Manifest, error) {
 	for name, service := range m.Services {
 		service.Name = name
 		service.Networks = m.Networks
+
+		if ss, ok := service.Labels["convox.start.shift"]; ok {
+			shift, err := strconv.Atoi(ss)
+			if err != nil {
+				return nil, fmt.Errorf("invalid shift: %s", ss)
+			}
+
+			service.Ports.Shift(shift)
+		}
+
 		m.Services[name] = service
 	}
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -367,6 +367,15 @@ func TestShift(t *testing.T) {
 			assert.Equal(t, web.Ports[1].Balancer, 11000)
 			assert.Equal(t, web.Ports[1].Container, 7000)
 		}
+
+		other := m.Services["other"]
+
+		if assert.NotNil(t, other) && assert.Equal(t, len(other.Ports), 2) {
+			assert.Equal(t, other.Ports[0].Balancer, 8000)
+			assert.Equal(t, other.Ports[0].Container, 8000)
+			assert.Equal(t, other.Ports[1].Balancer, 15000)
+			assert.Equal(t, other.Ports[1].Container, 9001)
+		}
 	}
 }
 

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -111,9 +111,9 @@ func (s *Service) Proxies(app string) []Proxy {
 
 			s.Ports[i].Balancer = 0
 
-			proxy.Protocol = coalesce(s.Labels[fmt.Sprintf("convox.port.%s.protocol", p.Name)], "tcp")
-			proxy.Proxy = s.Labels[fmt.Sprintf("convox.port.%s.proxy", p.Name)] == "true"
-			proxy.Secure = s.Labels[fmt.Sprintf("convox.port.%s.secure", p.Name)] == "true"
+			proxy.Protocol = coalesce(s.Labels[fmt.Sprintf("convox.port.%d.protocol", p.Balancer)], "tcp")
+			proxy.Proxy = s.Labels[fmt.Sprintf("convox.port.%d.proxy", p.Balancer)] == "true"
+			proxy.Secure = s.Labels[fmt.Sprintf("convox.port.%d.secure", p.Balancer)] == "true"
 
 			proxies = append(proxies, proxy)
 		}


### PR DESCRIPTION
## Pull Requests
  - closes #1009 docker-compose variable substitution [@awsmsrc]
  - closes #1023 restore convox.start.shift label for per-service shift [@ddollar]
  - closes #1026 Kernel changes to lockdown rack install permissions [@MiguelMoll]
  - closes #1028 adds `convox rack ps` and `convox rack logs` [@ddollar]
  - closes #1031 Fix proxy parameters [@bladealslayer]
  - closes #1032 Add a timeout for retrieving process stats [@MiguelMoll]
  - closes #1041 Handle manifests with repeated images [@mattmanning]

## Milestone Release
- [x] Release branch
- [x] Pass CI
- [x] Code review
- [x] Merge into master
- [ ] Close milestone
- [ ] Release master
- [ ] Pass CI
- [ ] Update staging Racks
- [ ] Deploy canaries
- [ ] Update [release notes](https://github.com/convox/rack/releases)
- [ ] Update documentation
- [ ] Publish release
- [ ] Release CLI
