### PR TITLE
Handle manifests with repeated images

### DIFF
--- a/manifest/build_test.go
+++ b/manifest/build_test.go
@@ -1,7 +1,7 @@
 package manifest_test
 
 import (
-	"math"
+	"fmt"
 	"os/exec"
 	"testing"
 
@@ -28,8 +28,10 @@ func NewTestExecer() *TestExecer {
 }
 
 func (p *TestExecer) CombinedOutput(cmd *exec.Cmd) ([]byte, error) {
-	i := int(math.Mod(float64(p.Index), float64(len(p.CannedResponses))))
-	resp := p.CannedResponses[i]
+	if p.Index > len(p.CannedResponses)-1 {
+		return nil, fmt.Errorf("CannedResponse index out of range")
+	}
+	resp := p.CannedResponses[p.Index]
 	p.Index++
 	return resp.Output, resp.Error
 }

--- a/manifest/build_test.go
+++ b/manifest/build_test.go
@@ -165,6 +165,38 @@ func TestBuildRepeatSimple(t *testing.T) {
 	assert.Equal(t, te.Commands[2].Args, cmd3)
 }
 
+func TestBuildRepeatImage(t *testing.T) {
+	output := manifest.NewOutput()
+	str := output.Stream("build")
+	dr := manifest.DefaultRunner
+	te := NewTestExecer()
+	te.CannedResponses = []ExecResponse{
+		ExecResponse{
+			Output: []byte(""),
+			Error:  nil,
+		},
+	}
+	manifest.DefaultRunner = te
+	defer func() { manifest.DefaultRunner = dr }()
+
+	m, err := manifestFixture("repeat-image")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = m.Build(".", "web", str, false)
+
+	cmd1 := []string{"docker", "pull", "convox/rails"}
+	cmd2 := []string{"docker", "tag", "convox/rails", "web/web1"}
+	cmd3 := []string{"docker", "tag", "convox/rails", "web/web2"}
+
+	if assert.Equal(t, len(te.Commands), 3) {
+		assert.Equal(t, te.Commands[0].Args, cmd1)
+		assert.Equal(t, te.Commands[1].Args, cmd2)
+		assert.Equal(t, te.Commands[2].Args, cmd3)
+	}
+}
+
 func TestBuildRepeatComplex(t *testing.T) {
 	output := manifest.NewOutput()
 	str := output.Stream("build")

--- a/manifest/fixtures/repeat-image.yml
+++ b/manifest/fixtures/repeat-image.yml
@@ -1,0 +1,8 @@
+web1:
+  image: convox/rails
+  ports:
+    - 80:8080
+web2:
+  image: convox/rails
+  ports:
+    - 80:8080


### PR DESCRIPTION
When a manifest used the same image for multiple processes we were only creating one image tag, which led to errors when we tried to later tag and push into ECR (image would not be found). 

This PR maps images to a slice of tags instead of a single tag, then loops over those when running the actual `docker tag` commands.