### PR TITLE
Make stopping of local containers more graceful

### DIFF
--- a/manifest/run.go
+++ b/manifest/run.go
@@ -175,13 +175,17 @@ func (r *Run) Wait() error {
 }
 
 func (r *Run) Stop() {
-	for _, p := range r.processes {
-		Docker("kill", p.Name).Run()
-	}
+	args := []string{"stop"}
 
 	for _, p := range r.proxies {
-		Docker("kill", p.Name).Run()
+		args = append(args, p.Name)
 	}
+
+	for _, p := range r.processes {
+		args = append(args, p.Name)
+	}
+
+	Docker(args...).Run()
 }
 
 func pruneSyncs(syncs []sync.Sync) []sync.Sync {


### PR DESCRIPTION
"docker kill" doesn't allow processes to exit cleanly, which can result in data corruption
when data volumes are used. "docker stop" first sends a SIGTERM and then SIGKILL
only if process didn't exit within a timeout.

Resolves #1042.