### PR TITLE
Explicit build call for `monitor` added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /go/src/github.com/convox/rack
 COPY . /go/src/github.com/convox/rack
 
 RUN go install ./api
+RUN go install ./api/cmd/monitor
 RUN go install ./cmd/build
 
 ENTRYPOINT ["/go/bin/init"]


### PR DESCRIPTION
Previous method wasn't building `monitor`