### PR TITLE
WIP: Use `UsePreviousValue` in UpdateParams

### DIFF
--- a/test/aws_cycles.go
+++ b/test/aws_cycles.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"strings"
@@ -191,8 +192,22 @@ func GetItemAppReleaseCycle(appName string) awsutil.Cycle {
 }
 
 func UpdateAppStackCycle(stackName, count, memory string) awsutil.Cycle {
+	const countPreviousValue string = "1"
+	const memoryPreviousValue string = "256"
+
+	countParameterValue := "UsePreviousValue=true"
+	memoryParameterValue := "UsePreviousValue=true"
+
+	if count != countPreviousValue {
+		countParameterValue = fmt.Sprintf("ParameterValue=%s", count)
+	}
+
+	if memory != memoryPreviousValue {
+		memoryParameterValue = fmt.Sprintf("ParameterValue=%s", memory)
+	}
+
 	return awsutil.Cycle{
-		awsutil.Request{"/", "", `Action=UpdateStack&Capabilities.member.1=CAPABILITY_IAM&Parameters.member.1.ParameterKey=Cluster&Parameters.member.1.ParameterValue=convo-Clust-GEFJGLHH7O0V&Parameters.member.10.ParameterKey=MainPort80Host&Parameters.member.10.ParameterValue=33787&Parameters.member.11.ParameterKey=MainService&Parameters.member.11.ParameterValue=&Parameters.member.12.ParameterKey=Release&Parameters.member.12.ParameterValue=RCSUVJNDLDK&Parameters.member.13.ParameterKey=Repository&Parameters.member.13.ParameterValue=&Parameters.member.14.ParameterKey=Subnets&Parameters.member.14.ParameterValue=subnet-2f5e0804%2Csubnet-74a4aa03%2Csubnet-f0c3e3a9&Parameters.member.15.ParameterKey=VPC&Parameters.member.15.ParameterValue=vpc-e853928c&Parameters.member.16.ParameterKey=Version&Parameters.member.16.ParameterValue=latest&Parameters.member.2.ParameterKey=Cpu&Parameters.member.2.ParameterValue=200&Parameters.member.3.ParameterKey=Environment&Parameters.member.3.ParameterValue=https%3A%2F%2Fapache-app2-settings-1vudpykaywx8o.s3.amazonaws.com%2Freleases%2FRCSUVJNDLDK%2Fenv&Parameters.member.4.ParameterKey=Key&Parameters.member.4.ParameterValue=arn%3Aaws%3Akms%3Aus-east-1%3A901416387788%3Akey%2Fe4c9e19c-7410-4e0f-88bf-ac7ac085625d&Parameters.member.5.ParameterKey=MainCommand&Parameters.member.5.ParameterValue=&Parameters.member.6.ParameterKey=MainDesiredCount&Parameters.member.6.ParameterValue=` + count + `&Parameters.member.7.ParameterKey=MainImage&Parameters.member.7.ParameterValue=convox-720091589.us-east-1.elb.amazonaws.com%3A5000%2Fapache-app2-main%3ABDDTZLECEZN&Parameters.member.8.ParameterKey=MainMemory&Parameters.member.8.ParameterValue=` + memory + `&Parameters.member.9.ParameterKey=MainPort80Balancer&Parameters.member.9.ParameterValue=80&StackName=convox-test-application&UsePreviousTemplate=true&Version=2010-05-15`},
+		awsutil.Request{"/", "", `Action=UpdateStack&Capabilities.member.1=CAPABILITY_IAM&Parameters.member.1.ParameterKey=Cluster&Parameters.member.1.UsePreviousValue=true&Parameters.member.10.ParameterKey=MainPort80Host&Parameters.member.10.UsePreviousValue=true&Parameters.member.11.ParameterKey=MainService&Parameters.member.11.UsePreviousValue=true&Parameters.member.12.ParameterKey=Release&Parameters.member.12.UsePreviousValue=true&Parameters.member.13.ParameterKey=Repository&Parameters.member.13.UsePreviousValue=true&Parameters.member.14.ParameterKey=Subnets&Parameters.member.14.UsePreviousValue=true&Parameters.member.15.ParameterKey=VPC&Parameters.member.15.UsePreviousValue=true&Parameters.member.16.ParameterKey=Version&Parameters.member.16.UsePreviousValue=true&Parameters.member.2.ParameterKey=Cpu&Parameters.member.2.UsePreviousValue=true&Parameters.member.3.ParameterKey=Environment&Parameters.member.3.UsePreviousValue=true&Parameters.member.4.ParameterKey=Key&Parameters.member.4.UsePreviousValue=true&Parameters.member.5.ParameterKey=MainCommand&Parameters.member.5.UsePreviousValue=true&Parameters.member.6.ParameterKey=MainDesiredCount&Parameters.member.6.` + countParameterValue + `&Parameters.member.7.ParameterKey=MainImage&Parameters.member.7.UsePreviousValue=true&Parameters.member.8.ParameterKey=MainMemory&Parameters.member.8.` + memoryParameterValue + `&Parameters.member.9.ParameterKey=MainPort80Balancer&Parameters.member.9.UsePreviousValue=true&StackName=convox-test-application&UsePreviousTemplate=true&Version=2010-05-15`},
 		awsutil.Response{200,
 			`
 <UpdateStackResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">


### PR DESCRIPTION
When NoEcho was turned on for the CF Password param, we updated one relevant code path (`convox rack update`), but didn't update the second (`convox rack params set`). This updates the second code path so that all stack update paths should now use `UsePreviousValue` to play nicely with NoEcho params.