### PR TITLE
More helpful build error msg

### DIFF
--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -158,12 +158,8 @@ func cmdBuildsCreate(c *cli.Context) error {
 		return stdcli.ExitError(err)
 	}
 
-	switch a.Status {
-	case "creating":
-		return stdcli.ExitError(fmt.Errorf("app is still creating: %s", app))
-	case "running", "updating":
-	default:
-		return stdcli.ExitError(fmt.Errorf("unable to build app: %s", app))
+	if a.Status != "running" {
+		return stdcli.ExitError(fmt.Errorf("app %s cannot be built; status %s", app, a.Status))
 	}
 
 	if len(c.Args()) > 0 {


### PR DESCRIPTION
When the stack rolls back, a build cannot be created until the rollback completes. The previous err msg was generic: `ERROR: unable to build app: my-app`. Now the build err msg will include the status.

(This has become an issue because of https://github.com/convox/rack/issues/1111)