### PR TITLE
Normalize DescribeInstances calls

### DIFF
--- a/api/models/process.go
+++ b/api/models/process.go
@@ -150,7 +150,10 @@ func ListProcesses(app string) ([]*Process, error) {
 	}
 
 	ires, err := EC2().DescribeInstances(&ec2.DescribeInstancesInput{
-		InstanceIds: instanceIds,
+		Filters: []*ec2.Filter{
+			&ec2.Filter{Name: aws.String("instance-id"), Values: instanceIds},
+		},
+		MaxResults: aws.Int64(1000),
 	})
 
 	if err != nil {

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -11,4 +11,4 @@ convox install | tee $CIRCLE_ARTIFACTS/convox-installer.log
 
 grep -v "Created Unknown" $CIRCLE_ARTIFACTS/convox-installer.log
 
-convox logs --app $STACK_NAME > $CIRCLE_ARTIFACTS/convox.log &
+convox instances

--- a/ci/report.sh
+++ b/ci/report.sh
@@ -6,6 +6,8 @@ export CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM:-0}
 export STACK_NAME=convox-${CIRCLE_BUILD_NUM}
 export $($(dirname $0)/region.sh ${CIRCLE_NODE_INDEX})
 
+convox logs --app $STACK_NAME --follow=false --since=24h > $CIRCLE_ARTIFACTS/convox.log
+
 # Save App ECS Artifacts
 aws ecs list-clusters | tee $CIRCLE_ARTIFACTS/list-clusters.json
 aws ecs describe-clusters --clusters $(jq -r '.clusterArns[]' $CIRCLE_ARTIFACTS/list-clusters.json) | tee $CIRCLE_ARTIFACTS/describe-clusters.json

--- a/provider/aws/instances.go
+++ b/provider/aws/instances.go
@@ -21,8 +21,10 @@ func (p *AWSProvider) InstanceList() (structs.Instances, error) {
 	}
 
 	ec2Res, err := p.ec2().DescribeInstances(&ec2.DescribeInstancesInput{
-		InstanceIds: instanceIds,
-		MaxResults:  aws.Int64(1000),
+		Filters: []*ec2.Filter{
+			&ec2.Filter{Name: aws.String("instance-id"), Values: instanceIds},
+		},
+		MaxResults: aws.Int64(1000),
 	})
 	if err != nil {
 		return nil, err

--- a/provider/aws/instances_test.go
+++ b/provider/aws/instances_test.go
@@ -92,7 +92,7 @@ func describeContainerInstancesResponse() string {
 
 func describeInstancesCycle() awsutil.Cycle {
 	return awsutil.Cycle{
-		awsutil.Request{"/", "", `Action=DescribeInstances&InstanceId.1=i-4a5513f4&InstanceId.2=i-3963798e&InstanceId.3=i-c6a72b76&MaxResults=1000&Version=2015-10-01`},
+		awsutil.Request{"/", "", `Action=DescribeInstances&Filter.1.Name=instance-id&Filter.1.Value.1=i-4a5513f4&Filter.1.Value.2=i-3963798e&Filter.1.Value.3=i-c6a72b76&MaxResults=1000&Version=2015-10-01`},
 		awsutil.Response{200, describeInstancesResponse()},
 	}
 }

--- a/test/aws_cycles.go
+++ b/test/aws_cycles.go
@@ -111,7 +111,7 @@ func DescribeConvoxStackCycle(stackName string) awsutil.Cycle {
 
 func DescribeInstancesCycle() awsutil.Cycle {
 	return awsutil.Cycle{
-		awsutil.Request{"/", "", `Action=DescribeInstances&InstanceId.1=i-4a5513f4&InstanceId.2=i-3963798e&InstanceId.3=i-c6a72b76&Version=2015-10-01`},
+		awsutil.Request{"/", "", `Action=DescribeInstances&Filter.1.Name=instance-id&Filter.1.Value.1=i-4a5513f4&Filter.1.Value.2=i-3963798e&Filter.1.Value.3=i-c6a72b76&MaxResults=1000&Version=2015-10-01`},
 		awsutil.Response{200, describeInstancesResponse()},
 	}
 }


### PR DESCRIPTION
Follow up to #1109. Use a valid EC2 DescribeInstances call that will return more than >100 instances.