### PR TITLE
Cron Job Rule name validation fix

### DIFF
--- a/api/models/cronjob.go
+++ b/api/models/cronjob.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"crypto/sha256"
+	"encoding/base32"
 	"fmt"
 	"strings"
 
@@ -47,5 +49,13 @@ func (cr *CronJob) ShortName() string {
 }
 
 func (cr *CronJob) LongName() string {
-	return fmt.Sprintf("%s-%s-%s", cr.App.StackName(), cr.Process(), cr.Name)
+	prefix := fmt.Sprintf("%s-%s-%s", cr.App.StackName(), cr.Process(), cr.Name)
+	hash := sha256.Sum256([]byte(prefix))
+	suffix := "-" + base32.StdEncoding.EncodeToString(hash[:])[:7]
+
+	// $prefix-$suffix-schedule" needs to be <= 64 characters
+	if len(prefix) > 55-len(suffix) {
+		prefix = prefix[:55-len(suffix)]
+	}
+	return prefix + suffix
 }

--- a/api/models/fixtures/Makefile
+++ b/api/models/fixtures/Makefile
@@ -9,4 +9,4 @@ fixture:
 	go build -o ./fixture fixture.go
 
 %.json: %.yml
-	env AWS_REGION=test PROVIDER=test RACK=convox-test ./fixture $< > $@
+	env AWS_REGION=test PROVIDER=test CLUSTER=convox-test RACK=convox-test ./fixture $< > $@

--- a/api/models/fixtures/cron_labels.json
+++ b/api/models/fixtures/cron_labels.json
@@ -463,7 +463,7 @@
                 "'use strict';",
                 "var aws = require('aws-sdk');",
                 "var ecs = new aws.ECS();",
-                "var cluster = '';",
+                "var cluster = 'convox-test';",
                 "var taskDefinitions = {",
                 {
                   "Fn::Join": [
@@ -562,7 +562,7 @@
                               "Ref": "AWS::AccountId"
                             },
                             ":cluster/",
-                            ""
+                            "convox-test"
                           ]
                         ]
                       }

--- a/api/models/fixtures/cron_labels.json
+++ b/api/models/fixtures/cron_labels.json
@@ -1,0 +1,1078 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "BlankBalancerMainPort443Certificate": {
+      "Fn::Equals": [
+        {
+          "Ref": "MainPort443Certificate"
+        },
+        ""
+      ]
+    },
+    "BlankSecurityGroup": {
+      "Fn::Equals": [
+        {
+          "Ref": "SecurityGroup"
+        },
+        ""
+      ]
+    },
+    "EnabledMain": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                0,
+                {
+                  "Ref": "MainFormation"
+                }
+              ]
+            },
+            "-1"
+          ]
+        }
+      ]
+    },
+    "EnabledReallyLongProcessTypeName": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                0,
+                {
+                  "Ref": "ReallyLongProcessTypeNameFormation"
+                }
+              ]
+            },
+            "-1"
+          ]
+        }
+      ]
+    },
+    "Internal": {
+      "Fn::Equals": [
+        {
+          "Ref": "Internal"
+        },
+        "Yes"
+      ]
+    },
+    "Private": {
+      "Fn::Equals": [
+        {
+          "Ref": "Private"
+        },
+        "Yes"
+      ]
+    },
+    "RegionHasECR": {
+      "Fn::Or": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "us-east-1"
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "us-west-1"
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "us-west-2"
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "eu-central-1"
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "eu-west-1"
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "ap-northeast-1"
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "ap-southeast-1"
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "ap-southeast-2"
+          ]
+        }
+      ]
+    }
+  },
+  "Mappings": {
+    "PortProtocol": {
+      "http": {
+        "InstanceProtocol": "HTTP",
+        "ListenerProtocol": "HTTP",
+        "SecureInstanceProtocol": "HTTPS"
+      },
+      "https": {
+        "InstanceProtocol": "HTTP",
+        "ListenerProtocol": "HTTPS",
+        "SecureInstanceProtocol": "HTTPS"
+      },
+      "tcp": {
+        "InstanceProtocol": "TCP",
+        "ListenerProtocol": "TCP",
+        "SecureInstanceProtocol": "SSL"
+      },
+      "tls": {
+        "InstanceProtocol": "TCP",
+        "ListenerProtocol": "SSL",
+        "SecureInstanceProtocol": "SSL"
+      }
+    }
+  },
+  "Outputs": {
+    "BalancerMainHost": {
+      "Condition": "EnabledMain",
+      "Value": {
+        "Fn::GetAtt": [
+          "BalancerMain",
+          "DNSName"
+        ]
+      }
+    },
+    "LogGroup": {
+      "Value": {
+        "Ref": "LogGroup"
+      }
+    },
+    "MainPort443Balancer": {
+      "Condition": "EnabledMain",
+      "Value": "443"
+    },
+    "MainPort443BalancerName": {
+      "Condition": "EnabledMain",
+      "Value": "httpd-main-KQSNMIK"
+    },
+    "RegistryId": {
+      "Condition": "RegionHasECR",
+      "Value": {
+        "Ref": "AWS::AccountId"
+      }
+    },
+    "RegistryRepository": {
+      "Condition": "RegionHasECR",
+      "Value": {
+        "Fn::GetAtt": [
+          "RegistryRepository",
+          "RepositoryName"
+        ]
+      }
+    },
+    "Settings": {
+      "Value": {
+        "Ref": "Settings"
+      }
+    }
+  },
+  "Parameters": {
+    "Cluster": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "DeploymentMaximum": {
+      "Default": "200",
+      "Description": "Maximum percentage of processes to keep running while deploying",
+      "Type": "Number"
+    },
+    "DeploymentMinimum": {
+      "Default": "100",
+      "Description": "Minimum percentage of processes to keep running while deploying",
+      "Type": "Number"
+    },
+    "Environment": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "Internal": {
+      "AllowedValues": [
+        "Yes",
+        "No"
+      ],
+      "Default": "No",
+      "Description": "Only allow access to this app from inside the VPC",
+      "Type": "String"
+    },
+    "Key": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "MainFormation": {
+      "Default": "1,0,256",
+      "Description": "Number of processes to run, CPU units to reserve, and MB of RAM to reserve",
+      "Type": "CommaDelimitedList"
+    },
+    "MainPort443Certificate": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "MainPort443Host": {
+      "Default": "5000",
+      "Description": "",
+      "Type": "String"
+    },
+    "Private": {
+      "AllowedValues": [
+        "Yes",
+        "No"
+      ],
+      "Default": "No",
+      "Description": "Use SubnetsPrivate to specify VPC-side load balancer endpoints",
+      "Type": "String"
+    },
+    "ReallyLongProcessTypeNameFormation": {
+      "Default": "1,0,256",
+      "Description": "Number of processes to run, CPU units to reserve, and MB of RAM to reserve",
+      "Type": "CommaDelimitedList"
+    },
+    "Release": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "Repository": {
+      "Default": "",
+      "Description": "Source code repository",
+      "Type": "String"
+    },
+    "SecurityGroup": {
+      "Default": "",
+      "Description": "The Load balancer security group for this app",
+      "Type": "String"
+    },
+    "Subnets": {
+      "Default": "",
+      "Description": "VPC subnets for this app",
+      "Type": "List\u003cAWS::EC2::Subnet::Id\u003e"
+    },
+    "SubnetsPrivate": {
+      "Default": "",
+      "Description": "VPC private subnets for this app",
+      "Type": "List\u003cAWS::EC2::Subnet::Id\u003e"
+    },
+    "VPC": {
+      "Default": "",
+      "Description": "VPC for this app",
+      "Type": "AWS::EC2::VPC::Id"
+    },
+    "VPCCIDR": {
+      "Default": "",
+      "Description": "VPC CIDR for this app",
+      "Type": "String"
+    },
+    "Version": {
+      "Description": "(REQUIRED) Lambda CustomTopic Handler Release Version",
+      "MinLength": "1",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "BalancerMain": {
+      "Condition": "EnabledMain",
+      "DependsOn": [
+        "BalancerMainSecurityGroup"
+      ],
+      "Properties": {
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 60
+        },
+        "ConnectionSettings": {
+          "IdleTimeout": "3600"
+        },
+        "CrossZone": true,
+        "HealthCheck": {
+          "HealthyThreshold": "2",
+          "Interval": "5",
+          "Target": {
+            "Fn::Join": [
+              "",
+              [
+                "TCP:",
+                {
+                  "Ref": "MainPort443Host"
+                },
+                ""
+              ]
+            ]
+          },
+          "Timeout": "3",
+          "UnhealthyThreshold": "2"
+        },
+        "LBCookieStickinessPolicy": [
+          {
+            "PolicyName": "affinity"
+          }
+        ],
+        "Listeners": [
+          {
+            "InstancePort": {
+              "Ref": "MainPort443Host"
+            },
+            "InstanceProtocol": "TCP",
+            "LoadBalancerPort": "443",
+            "Protocol": {
+              "Fn::If": [
+                "BlankBalancerMainPort443Certificate",
+                "TCP",
+                "SSL"
+              ]
+            },
+            "SSLCertificateId": {
+              "Fn::If": [
+                "BlankBalancerMainPort443Certificate",
+                {
+                  "Ref": "AWS::NoValue"
+                },
+                {
+                  "Ref": "MainPort443Certificate"
+                }
+              ]
+            }
+          },
+          {
+            "Ref": "AWS::NoValue"
+          }
+        ],
+        "LoadBalancerName": "httpd-main-KQSNMIK",
+        "Policies": [
+          {
+            "Ref": "AWS::NoValue"
+          }
+        ],
+        "Scheme": {
+          "Fn::If": [
+            "Internal",
+            "internal",
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "SecurityGroups": [
+          {
+            "Fn::If": [
+              "BlankSecurityGroup",
+              {
+                "Ref": "BalancerMainSecurityGroup"
+              },
+              {
+                "Ref": "SecurityGroup"
+              }
+            ]
+          }
+        ],
+        "Subnets": {
+          "Fn::If": [
+            "Internal",
+            {
+              "Ref": "SubnetsPrivate"
+            },
+            {
+              "Ref": "Subnets"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+    },
+    "BalancerMainSecurityGroup": {
+      "Condition": "EnabledMain",
+      "Properties": {
+        "GroupDescription": {
+          "Fn::Join": [
+            " ",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "-balancer"
+            ]
+          ]
+        },
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": "443",
+            "IpProtocol": "tcp",
+            "ToPort": "443"
+          },
+          {
+            "Ref": "AWS::NoValue"
+          }
+        ],
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
+    "CronFunction": {
+      "DependsOn": [
+        "CronRole"
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "\n",
+              [
+                "'use strict';",
+                "var aws = require('aws-sdk');",
+                "var ecs = new aws.ECS();",
+                "var cluster = '';",
+                "var taskDefinitions = {",
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "    'main': '",
+                      {
+                        "Ref": "MainECSTaskDefinition"
+                      },
+                      "',"
+                    ]
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "    'really-long-process-type-name': '",
+                      {
+                        "Ref": "ReallyLongProcessTypeNameECSTaskDefinition"
+                      },
+                      "',"
+                    ]
+                  ]
+                },
+                "    '':''",
+                "}",
+                "exports.handler = function(event, context) {",
+                "    var params = {",
+                "        startedBy: 'cron',",
+                "        taskDefinition: taskDefinitions[event.process],",
+                "        cluster: cluster,",
+                "        count: 1,",
+                "        overrides: {",
+                "            containerOverrides: [",
+                "                { name:event.process, command:[ 'sh', '-c', event.command ] }",
+                "            ]",
+                "        }",
+                "    };",
+                "    ecs.runTask(params, context.done);",
+                "};"
+              ]
+            ]
+          }
+        },
+        "FunctionName": "convox-test-httpd-cron",
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "CronRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs",
+        "Timeout": 10
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "CronRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "ecs:RunTask",
+                  "Condition": {
+                    "ArnEquals": {
+                      "ecs:cluster": {
+                        "Fn::Join": [
+                          "",
+                          [
+                            "arn:aws:ecs:",
+                            {
+                              "Ref": "AWS::Region"
+                            },
+                            ":",
+                            {
+                              "Ref": "AWS::AccountId"
+                            },
+                            ":cluster/",
+                            ""
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "Administrator"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "CustomTopic": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Join": [
+              "-",
+              [
+                "convox",
+                {
+                  "Ref": "AWS::Region"
+                }
+              ]
+            ]
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                "release/",
+                {
+                  "Ref": "Version"
+                },
+                "/lambda/formation.zip"
+              ]
+            ]
+          }
+        },
+        "Handler": "index.external",
+        "MemorySize": "128",
+        "Role": {
+          "Fn::GetAtt": [
+            "CustomTopicRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs",
+        "Timeout": "300"
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "CustomTopicRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "Administrator"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "LogGroup": {
+      "Type": "AWS::Logs::LogGroup"
+    },
+    "MainECSTaskDefinition": {
+      "DependsOn": [
+        "CustomTopic",
+        "ServiceRole"
+      ],
+      "Properties": {
+        "Environment": {
+          "Ref": "Environment"
+        },
+        "Key": {
+          "Ref": "Key"
+        },
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "main"
+            ]
+          ]
+        },
+        "Release": {
+          "Ref": "Release"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        },
+        "Tasks": [
+          {
+            "Cpu": {
+              "Fn::Select": [
+                1,
+                {
+                  "Ref": "MainFormation"
+                }
+              ]
+            },
+            "Environment": {
+              "APP": "httpd",
+              "AWS_REGION": "test",
+              "LOG_GROUP": {
+                "Ref": "LogGroup"
+              },
+              "PROCESS": "main",
+              "RACK": "convox-test"
+            },
+            "ExtraHosts": [
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ],
+            "Image": "",
+            "Memory": {
+              "Fn::Select": [
+                2,
+                {
+                  "Ref": "MainFormation"
+                }
+              ]
+            },
+            "Name": "main",
+            "PortMappings": [
+              {
+                "Fn::Join": [
+                  ":",
+                  [
+                    {
+                      "Ref": "MainPort443Host"
+                    },
+                    "5000"
+                  ]
+                ]
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ],
+            "Privileged": "false",
+            "Services": [
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ],
+            "Volumes": [
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          }
+        ]
+      },
+      "Type": "Custom::ECSTaskDefinition",
+      "Version": "1.0"
+    },
+    "Really-Long-Process-Type-NameMy-JobLambdaPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "CronFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "Really-Long-Process-Type-NameMy-JobRule",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "Really-Long-Process-Type-NameMy-JobRule": {
+      "Properties": {
+        "Name": "convox-test-httpd-really-long-process-type-name-my-job-schedule",
+        "ScheduleExpression": "cron(0 * * * ? *)",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "CronFunction",
+                "Arn"
+              ]
+            },
+            "Id": "convox-test-httpd-really-long-process-type-name-my-jobTarget",
+            "Input": "{\"process\": \"really-long-process-type-name\", \"command\": \"bin/myjob\"}"
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "Really-Long-Process-Type-NameReally-Long-Cron-Job-NameLambdaPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "CronFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "Really-Long-Process-Type-NameReally-Long-Cron-Job-NameRule",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "Really-Long-Process-Type-NameReally-Long-Cron-Job-NameRule": {
+      "Properties": {
+        "Name": "convox-test-httpd-really-long-process-type-name-really-long-cron-job-name-schedule",
+        "ScheduleExpression": "cron(0 * * * ? *)",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "CronFunction",
+                "Arn"
+              ]
+            },
+            "Id": "convox-test-httpd-really-long-process-type-name-really-long-cron-job-nameTarget",
+            "Input": "{\"process\": \"really-long-process-type-name\", \"command\": \"bin/myjob\"}"
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "ReallyLongProcessTypeNameECSTaskDefinition": {
+      "DependsOn": [
+        "CustomTopic",
+        "ServiceRole"
+      ],
+      "Properties": {
+        "Environment": {
+          "Ref": "Environment"
+        },
+        "Key": {
+          "Ref": "Key"
+        },
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "really-long-process-type-name"
+            ]
+          ]
+        },
+        "Release": {
+          "Ref": "Release"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        },
+        "Tasks": [
+          {
+            "Cpu": {
+              "Fn::Select": [
+                1,
+                {
+                  "Ref": "ReallyLongProcessTypeNameFormation"
+                }
+              ]
+            },
+            "Environment": {
+              "APP": "httpd",
+              "AWS_REGION": "test",
+              "LOG_GROUP": {
+                "Ref": "LogGroup"
+              },
+              "PROCESS": "really-long-process-type-name",
+              "RACK": "convox-test"
+            },
+            "ExtraHosts": [
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ],
+            "Image": "",
+            "Memory": {
+              "Fn::Select": [
+                2,
+                {
+                  "Ref": "ReallyLongProcessTypeNameFormation"
+                }
+              ]
+            },
+            "Name": "really-long-process-type-name",
+            "PortMappings": [
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ],
+            "Privileged": "false",
+            "Services": [
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ],
+            "Volumes": [
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          }
+        ]
+      },
+      "Type": "Custom::ECSTaskDefinition",
+      "Version": "1.0"
+    },
+    "RegistryRepository": {
+      "Condition": "RegionHasECR",
+      "Properties": {
+        "RepositoryName": {
+          "Ref": "AWS::StackName"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "Custom::ECRRepository",
+      "Version": "1.0"
+    },
+    "ServiceMain": {
+      "Condition": "EnabledMain",
+      "DependsOn": [
+        "BalancerMain",
+        "CustomTopic",
+        "ServiceRole"
+      ],
+      "Properties": {
+        "Cluster": {
+          "Ref": "Cluster"
+        },
+        "DeploymentConfiguration": {
+          "MaximumPercent": "200",
+          "MinimumHealthyPercent": "100"
+        },
+        "DesiredCount": {
+          "Fn::Select": [
+            0,
+            {
+              "Ref": "MainFormation"
+            }
+          ]
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "main",
+            "ContainerPort": "5000",
+            "LoadBalancerName": {
+              "Ref": "BalancerMain"
+            }
+          }
+        ],
+        "Role": {
+          "Fn::GetAtt": [
+            "ServiceRole",
+            "Arn"
+          ]
+        },
+        "TaskDefinition": {
+          "Ref": "MainECSTaskDefinition"
+        }
+      },
+      "Type": "AWS::ECS::Service"
+    },
+    "ServiceReallyLongProcessTypeName": {
+      "Condition": "EnabledReallyLongProcessTypeName",
+      "DependsOn": [
+        "CustomTopic",
+        "ServiceRole"
+      ],
+      "Properties": {
+        "Cluster": {
+          "Ref": "Cluster"
+        },
+        "DeploymentConfiguration": {
+          "MaximumPercent": "200",
+          "MinimumHealthyPercent": "100"
+        },
+        "DesiredCount": {
+          "Fn::Select": [
+            0,
+            {
+              "Ref": "ReallyLongProcessTypeNameFormation"
+            }
+          ]
+        },
+        "TaskDefinition": {
+          "Ref": "ReallyLongProcessTypeNameECSTaskDefinition"
+        }
+      },
+      "Type": "AWS::ECS::Service"
+    },
+    "ServiceRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ecs.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "elasticloadbalancing:Describe*",
+                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                    "ec2:Describe*",
+                    "ec2:AuthorizeSecurityGroupIngress"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    "*"
+                  ]
+                }
+              ]
+            },
+            "PolicyName": "ServiceRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "Settings": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AccessControl": "Private",
+        "Tags": [
+          {
+            "Key": "system",
+            "Value": "convox"
+          },
+          {
+            "Key": "app",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          }
+        ]
+      },
+      "Type": "AWS::S3::Bucket"
+    }
+  }
+}

--- a/api/models/fixtures/cron_labels.json
+++ b/api/models/fixtures/cron_labels.json
@@ -780,7 +780,7 @@
     },
     "Really-Long-Process-Type-NameMy-JobRule": {
       "Properties": {
-        "Name": "convox-test-httpd-really-long-process-type-name-my-job-schedule",
+        "Name": "convox-test-httpd-really-long-process-type-name-M6MEVIK-schedule",
         "ScheduleExpression": "cron(0 * * * ? *)",
         "Targets": [
           {
@@ -790,7 +790,7 @@
                 "Arn"
               ]
             },
-            "Id": "convox-test-httpd-really-long-process-type-name-my-jobTarget",
+            "Id": "convox-test-httpd-really-long-process-type-name-M6MEVIKTarget",
             "Input": "{\"process\": \"really-long-process-type-name\", \"command\": \"bin/myjob\"}"
           }
         ]
@@ -818,7 +818,7 @@
     },
     "Really-Long-Process-Type-NameReally-Long-Cron-Job-NameRule": {
       "Properties": {
-        "Name": "convox-test-httpd-really-long-process-type-name-really-long-cron-job-name-schedule",
+        "Name": "convox-test-httpd-really-long-process-type-name-BAZNKBZ-schedule",
         "ScheduleExpression": "cron(0 * * * ? *)",
         "Targets": [
           {
@@ -828,7 +828,7 @@
                 "Arn"
               ]
             },
-            "Id": "convox-test-httpd-really-long-process-type-name-really-long-cron-job-nameTarget",
+            "Id": "convox-test-httpd-really-long-process-type-name-BAZNKBZTarget",
             "Input": "{\"process\": \"really-long-process-type-name\", \"command\": \"bin/myjob\"}"
           }
         ]

--- a/api/models/fixtures/cron_labels.json
+++ b/api/models/fixtures/cron_labels.json
@@ -759,7 +759,7 @@
       "Type": "Custom::ECSTaskDefinition",
       "Version": "1.0"
     },
-    "Really-Long-Process-Type-NameMy-JobLambdaPermission": {
+    "MainMy-JobLambdaPermission": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -771,16 +771,16 @@
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "Really-Long-Process-Type-NameMy-JobRule",
+            "MainMy-JobRule",
             "Arn"
           ]
         }
       },
       "Type": "AWS::Lambda::Permission"
     },
-    "Really-Long-Process-Type-NameMy-JobRule": {
+    "MainMy-JobRule": {
       "Properties": {
-        "Name": "convox-test-httpd-really-long-process-type-name-M6MEVIK-schedule",
+        "Name": "convox-test-httpd-main-my-job-VZPBTBB-schedule",
         "ScheduleExpression": "cron(0 * * * ? *)",
         "Targets": [
           {
@@ -790,8 +790,8 @@
                 "Arn"
               ]
             },
-            "Id": "convox-test-httpd-really-long-process-type-name-M6MEVIKTarget",
-            "Input": "{\"process\": \"really-long-process-type-name\", \"command\": \"bin/myjob\"}"
+            "Id": "convox-test-httpd-main-my-job-VZPBTBBTarget",
+            "Input": "{\"process\": \"main\", \"command\": \"bin/myjob\"}"
           }
         ]
       },

--- a/api/models/fixtures/cron_labels.yml
+++ b/api/models/fixtures/cron_labels.yml
@@ -1,0 +1,10 @@
+main:
+  build: .
+  labels:
+    - convox.cron.my-job=0 * * * ? bin/myjob
+  ports:
+    - 443:5000
+really-long-process-type-name:
+  build: .
+  labels:
+    - convox.cron.really-long-cron-job-name=0 * * * ? bin/myjob


### PR DESCRIPTION
The Name property of the AWS::Events::Rule resource must be less than 64 characters to avoid a validation error:

```1 validation error detected: Value 'convox-long-app-name-with-cron-extractinfcand-mylongjobname-schedule' at 'name' failed to satisfy constraint: Member must have length less than or equal to 64```

This guarantees that by changing the format of the property from:

`convox-test-httpd-really-long-process-type-name-really-long-cron-job-name-schedule`

to:

`convox-test-httpd-really-long-process-type-name-BAZNKBZ-schedule`