### PR TITLE
Lessen chance of throttling during builds

### DIFF
--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -62,6 +62,13 @@ func BuildGet(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		return httperr.Server(err)
 	}
 
+	l, err := models.Provider().BuildGetLogs(app, build)
+	if err != nil {
+		return httperr.Server(err)
+	}
+
+	b.Logs = l
+
 	return RenderJson(rw, b)
 }
 

--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -62,7 +62,7 @@ func BuildGet(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		return httperr.Server(err)
 	}
 
-	l, err := models.Provider().BuildGetLogs(app, build)
+	l, err := models.Provider().BuildLogs(app, build)
 	if err != nil {
 		return httperr.Server(err)
 	}

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -239,7 +239,8 @@ func (p *AWSProvider) BuildGet(app, id string) (*structs.Build, error) {
 	return build, nil
 }
 
-func (p *AWSProvider) BuildGetLogs(app, id string) (string, error) {
+// BuildLogs gets a Build's logs from S3. If there is no log file in S3, that is not an error.
+func (p *AWSProvider) BuildLogs(app, id string) (string, error) {
 	a, err := p.AppGet(app)
 	if err != nil {
 		return "", err

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -254,6 +254,9 @@ func (p *AWSProvider) BuildGetLogs(app, id string) (string, error) {
 
 	res, err := p.s3().GetObject(req)
 	if err != nil {
+		if awsError(err) == "NoSuchKey" {
+			return "", nil
+		}
 		return "", err
 	}
 

--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -21,10 +21,7 @@ func init() {
 
 func TestBuildGet(t *testing.T) {
 	aws, provider := StubAwsProvider(
-		describeStacksCycle,
-
 		build1GetItemCycle,
-		build1GetObjectCycle,
 	)
 	defer aws.Close()
 
@@ -34,7 +31,7 @@ func TestBuildGet(t *testing.T) {
 	assert.EqualValues(t, &structs.Build{
 		Id:       "BHINCLZYYVN",
 		App:      "httpd",
-		Logs:     "RUNNING: docker pull httpd",
+		Logs:     "",
 		Manifest: "web:\n  image: httpd\n  ports:\n  - 80:80\n",
 		Release:  "RVFETUHHKKD",
 		Status:   "complete",
@@ -45,10 +42,7 @@ func TestBuildGet(t *testing.T) {
 
 func TestBuildDelete(t *testing.T) {
 	aws, provider := StubAwsProvider(
-		describeStacksCycle,
-
 		build2GetItemCycle,
-		build2GetObjectCycle,
 
 		describeStacksCycle,
 		releasesBuild2DeleteItemCycle,
@@ -66,7 +60,7 @@ func TestBuildDelete(t *testing.T) {
 	assert.EqualValues(t, &structs.Build{
 		Id:       "BNOARQMVHUO",
 		App:      "httpd",
-		Logs:     "RUNNING: docker pull httpd",
+		Logs:     "",
 		Manifest: "web:\n  image: httpd\n  ports:\n  - 80:80\n",
 		Release:  "RFVZFLKVTYO",
 		Status:   "complete",
@@ -93,7 +87,7 @@ func TestBuildList(t *testing.T) {
 		structs.Build{
 			Id:       "BHINCLZYYVN",
 			App:      "httpd",
-			Logs:     "RUNNING: docker pull httpd",
+			Logs:     "",
 			Manifest: "web:\n  image: httpd\n  ports:\n  - 80:80\n",
 			Release:  "RVFETUHHKKD",
 			Status:   "complete",
@@ -103,7 +97,7 @@ func TestBuildList(t *testing.T) {
 		structs.Build{
 			Id:       "BNOARQMVHUO",
 			App:      "httpd",
-			Logs:     "RUNNING: docker pull httpd",
+			Logs:     "",
 			Manifest: "web:\n  image: httpd\n  ports:\n  - 80:80\n",
 			Release:  "RFVZFLKVTYO",
 			Status:   "complete",
@@ -111,6 +105,19 @@ func TestBuildList(t *testing.T) {
 			Ended:    time.Unix(1459709198, 984281955).UTC(),
 		},
 	}, b)
+}
+
+func TestBuildLogs(t *testing.T) {
+	aws, provider := StubAwsProvider(
+		describeStacksCycle,
+		build1GetObjectCycle,
+	)
+	defer aws.Close()
+
+	l, err := provider.BuildLogs("httpd", "BHINCLZYYVN")
+
+	assert.Nil(t, err)
+	assert.Equal(t, "RUNNING: docker pull httpd", l)
 }
 
 var describeStacksCycle = awsutil.Cycle{

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,7 +19,7 @@ type Provider interface {
 	BuildCreateTar(app string, src io.Reader, manifest, description string, cache bool) (*structs.Build, error)
 	BuildDelete(app, id string) (*structs.Build, error)
 	BuildGet(app, id string) (*structs.Build, error)
-	BuildGetLogs(app, id string) (string, error)
+	BuildLogs(app, id string) (string, error)
 	BuildList(app string, limit int64) (structs.Builds, error)
 	BuildRelease(*structs.Build) (*structs.Release, error)
 	BuildSave(*structs.Build) error

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,6 +19,7 @@ type Provider interface {
 	BuildCreateTar(app string, src io.Reader, manifest, description string, cache bool) (*structs.Build, error)
 	BuildDelete(app, id string) (*structs.Build, error)
 	BuildGet(app, id string) (*structs.Build, error)
+	BuildGetLogs(app, id string) (string, error)
 	BuildList(app string, limit int64) (structs.Builds, error)
 	BuildRelease(*structs.Build) (*structs.Release, error)
 	BuildSave(*structs.Build) error

--- a/provider/test.go
+++ b/provider/test.go
@@ -71,8 +71,8 @@ func (p *TestProvider) BuildGet(app, id string) (*structs.Build, error) {
 	return &p.Build, nil
 }
 
-// BuildGetLogs gets a Build's logs
-func (p *TestProvider) BuildGetLogs(app, id string) (string, error) {
+// BuildLogs gets a Build's logs
+func (p *TestProvider) BuildLogs(app, id string) (string, error) {
 	p.Called(app, id)
 	return "", nil
 }

--- a/provider/test.go
+++ b/provider/test.go
@@ -71,6 +71,12 @@ func (p *TestProvider) BuildGet(app, id string) (*structs.Build, error) {
 	return &p.Build, nil
 }
 
+// BuildGetLogs gets a Build's logs
+func (p *TestProvider) BuildGetLogs(app, id string) (string, error) {
+	p.Called(app, id)
+	return "", nil
+}
+
 // BuildList lists the Builds
 func (p *TestProvider) BuildList(app string, limit int64) (structs.Builds, error) {
 	p.Called(app, limit)


### PR DESCRIPTION
Before this patch GetBuild() always calls:
- CloudFormation DescribeStack on the app
- DynamoDB Query for the build ID
- S3 Get for the build logs

GetBuild is also called every 1 second during a build, to poll build status for the build log websocket to know when to disconnect.

This seems like a probable cause for throttling during builds.

This patch makes GetBuild() only call DynamoDB which we can poll more reliably, and introduces GetBuildLogs() which uses CF and S3 and is only needed on a `convox builds info`.