### PR TITLE
Handle process names with hyphens

### DIFF
--- a/api/models/cronjob.go
+++ b/api/models/cronjob.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/base32"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/convox/rack/manifest"
@@ -45,7 +46,14 @@ func (cr *CronJob) Process() string {
 }
 
 func (cr *CronJob) ShortName() string {
-	return fmt.Sprintf("%s%s", strings.Title(cr.Service.Name), strings.Title(cr.Name))
+	reg, err := regexp.Compile("[^A-Za-z0-9]+")
+	if err != nil {
+		panic(err)
+	}
+
+	formattedServiceName := strings.Title(cr.Service.Name)
+	formattedServiceName = reg.ReplaceAllString(formattedServiceName, "")
+	return fmt.Sprintf("%s%s", formattedServiceName, strings.Title(cr.Name))
 }
 
 func (cr *CronJob) LongName() string {

--- a/api/models/cronjob.go
+++ b/api/models/cronjob.go
@@ -46,14 +46,14 @@ func (cr *CronJob) Process() string {
 }
 
 func (cr *CronJob) ShortName() string {
+	shortName := fmt.Sprintf("%s%s", strings.Title(cr.Service.Name), strings.Title(cr.Name))
+
 	reg, err := regexp.Compile("[^A-Za-z0-9]+")
 	if err != nil {
 		panic(err)
 	}
 
-	formattedServiceName := strings.Title(cr.Service.Name)
-	formattedServiceName = reg.ReplaceAllString(formattedServiceName, "")
-	return fmt.Sprintf("%s%s", formattedServiceName, strings.Title(cr.Name))
+	return reg.ReplaceAllString(shortName, "")
 }
 
 func (cr *CronJob) LongName() string {

--- a/api/models/fixtures/cron_labels.json
+++ b/api/models/fixtures/cron_labels.json
@@ -797,44 +797,6 @@
       },
       "Type": "AWS::Events::Rule"
     },
-    "Really-Long-Process-Type-NameReally-Long-Cron-Job-NameLambdaPermission": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "CronFunction",
-            "Arn"
-          ]
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "Really-Long-Process-Type-NameReally-Long-Cron-Job-NameRule",
-            "Arn"
-          ]
-        }
-      },
-      "Type": "AWS::Lambda::Permission"
-    },
-    "Really-Long-Process-Type-NameReally-Long-Cron-Job-NameRule": {
-      "Properties": {
-        "Name": "convox-test-httpd-really-long-process-type-name-BAZNKBZ-schedule",
-        "ScheduleExpression": "cron(0 * * * ? *)",
-        "Targets": [
-          {
-            "Arn": {
-              "Fn::GetAtt": [
-                "CronFunction",
-                "Arn"
-              ]
-            },
-            "Id": "convox-test-httpd-really-long-process-type-name-BAZNKBZTarget",
-            "Input": "{\"process\": \"really-long-process-type-name\", \"command\": \"bin/myjob\"}"
-          }
-        ]
-      },
-      "Type": "AWS::Events::Rule"
-    },
     "ReallyLongProcessTypeNameECSTaskDefinition": {
       "DependsOn": [
         "CustomTopic",
@@ -922,6 +884,44 @@
       },
       "Type": "Custom::ECSTaskDefinition",
       "Version": "1.0"
+    },
+    "ReallyLongProcessTypeNameReallyLongCronJobNameLambdaPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "CronFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "ReallyLongProcessTypeNameReallyLongCronJobNameRule",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "ReallyLongProcessTypeNameReallyLongCronJobNameRule": {
+      "Properties": {
+        "Name": "convox-test-httpd-really-long-process-type-name-573WYWT-schedule",
+        "ScheduleExpression": "cron(0 * * * ? *)",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "CronFunction",
+                "Arn"
+              ]
+            },
+            "Id": "convox-test-httpd-really-long-process-type-name-573WYWTTarget",
+            "Input": "{\"process\": \"really-long-process-type-name\", \"command\": \"bin/myjob\"}"
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
     },
     "RegistryRepository": {
       "Condition": "RegionHasECR",

--- a/api/models/fixtures/cron_labels.json
+++ b/api/models/fixtures/cron_labels.json
@@ -759,7 +759,7 @@
       "Type": "Custom::ECSTaskDefinition",
       "Version": "1.0"
     },
-    "MainMy-JobLambdaPermission": {
+    "MainMyJobLambdaPermission": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -771,14 +771,14 @@
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "MainMy-JobRule",
+            "MainMyJobRule",
             "Arn"
           ]
         }
       },
       "Type": "AWS::Lambda::Permission"
     },
-    "MainMy-JobRule": {
+    "MainMyJobRule": {
       "Properties": {
         "Name": "convox-test-httpd-main-my-job-VZPBTBB-schedule",
         "ScheduleExpression": "cron(0 * * * ? *)",
@@ -906,7 +906,7 @@
     },
     "ReallyLongProcessTypeNameReallyLongCronJobNameRule": {
       "Properties": {
-        "Name": "convox-test-httpd-really-long-process-type-name-573WYWT-schedule",
+        "Name": "convox-test-httpd-really-long-process-type-name-BAZNKBZ-schedule",
         "ScheduleExpression": "cron(0 * * * ? *)",
         "Targets": [
           {
@@ -916,7 +916,7 @@
                 "Arn"
               ]
             },
-            "Id": "convox-test-httpd-really-long-process-type-name-573WYWTTarget",
+            "Id": "convox-test-httpd-really-long-process-type-name-BAZNKBZTarget",
             "Input": "{\"process\": \"really-long-process-type-name\", \"command\": \"bin/myjob\"}"
           }
         ]

--- a/api/models/fixtures/cron_labels.yml
+++ b/api/models/fixtures/cron_labels.yml
@@ -7,4 +7,4 @@ main:
 really-long-process-type-name:
   build: .
   labels:
-    - convox.cron.really-long-cron-job-name=0 * * * ? bin/myjob
+    - convox.cron.ReallyLongCronJobName=0 * * * ? bin/myjob

--- a/api/models/fixtures/cron_labels.yml
+++ b/api/models/fixtures/cron_labels.yml
@@ -7,4 +7,4 @@ main:
 really-long-process-type-name:
   build: .
   labels:
-    - convox.cron.ReallyLongCronJobName=0 * * * ? bin/myjob
+    - convox.cron.really-long-cron-job-name=0 * * * ? bin/myjob


### PR DESCRIPTION
When process names have hyphens they can get added to the Rule and LambdaPermission items in the CF template, causing a template error.

This change drops them. It also allows dashes in cronjob names.

This doc change should be deployed when this is released https://github.com/convox/site/pull/235