### PR TITLE
Only fail the build on ExitErrors

### DIFF
--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -562,7 +562,14 @@ func (p *AWSProvider) buildWait(a *structs.App, b *structs.Build, cmd *exec.Cmd,
 	timeout := time.After(1 * time.Hour)
 
 	go func() {
-		waitErr <- cmd.Wait() // Make sure to read all stdout before calling this.
+		err := cmd.Wait()
+
+		switch err.(type) {
+		case *exec.ExitError:
+			waitErr <- err
+		default:
+			waitErr <- nil
+		}
 	}()
 
 	select {


### PR DESCRIPTION
https://golang.org/pkg/os/exec/#Cmd.Wait

Should fix the "No child processes" race some users have been reporting.