### PR TITLE
Block underscore in service name

### DIFF
--- a/manifest/fixtures/underscore_service.yml
+++ b/manifest/fixtures/underscore_service.yml
@@ -1,0 +1,4 @@
+web_api:
+  image: httpd
+  ports:
+    - 80:80

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -53,6 +53,10 @@ func Load(data []byte) (*Manifest, error) {
 	}
 
 	for name, service := range m.Services {
+
+		if strings.Contains(name, "_") {
+			return nil, fmt.Errorf("service name cannot contain an underscore: %s", name)
+		}
 		service.Name = name
 
 		// there are two places in a docker-compose.yml to specify a dockerfile

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -283,6 +283,14 @@ func TestLoadNonexistentFile(t *testing.T) {
 	}
 }
 
+func TestUnderscoreInServiceName(t *testing.T) {
+	m, err := manifestFixture("underscore_service")
+
+	if assert.Nil(t, m) && assert.NotNil(t, err) {
+		assert.Equal(t, err.Error(), "service name cannot contain an underscore: web_api")
+	}
+}
+
 func TestLoadUnknownVersion(t *testing.T) {
 	m, err := manifestFixture("unknown-version")
 


### PR DESCRIPTION
Block the use of underscores in a service name. While a simple replace of an underscore with a dash would solve the issue with respect to tagging, it opens another path of potential issues with Cloudformation stack and parameters.

```
Promoting RBCMCAUEVTI... ERROR: Template format error: Parameter name Web_apiPort8080Certificate is non alphanumeric.
```