### PR TITLE
Update ELB name when switching to PrivateApi

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1300,9 +1300,10 @@
             "InstancePort": "4101"
           }
         ],
-        "LoadBalancerName": {
-          "Ref": "AWS::StackName"
-        },
+        "LoadBalancerName": { "Fn::If": [ "PrivateApi",
+          { "Fn::Join": [ "-", [ { "Ref": "AWS::StackName" }, "i" ] ] },
+          { "Ref": "AWS::StackName" }
+        ] },
         "Scheme": { "Fn::If": [ "PrivateApi", "internal", { "Ref": "AWS::NoValue" } ] },
         "SecurityGroups": [
           {


### PR DESCRIPTION
This avoids a CloudFormation error that occurs when trying to replace a custom-named resource.