### PR TITLE
Extract app name from log group

### DIFF
--- a/provider/aws/service.go
+++ b/provider/aws/service.go
@@ -199,10 +199,12 @@ func (p *AWSProvider) ServiceGet(name string) (*structs.Service, error) {
 	}
 
 	// Populate linked apps
-	for k, _ := range s.Outputs {
-		if strings.HasSuffix(k, "Link") {
-			n := dashName(k)
-			app := n[:len(n)-5] // 5 == len("-link")
+	for key, value := range s.Outputs {
+		if strings.HasSuffix(key, "Link") {
+			// Extract app name from log group
+			index := strings.Index(value, "-LogGroup")
+			r := strings.NewReplacer(fmt.Sprintf("%s-", p.Rack), "", value[index:], "")
+			app := r.Replace(value)
 
 			a, err := p.AppGet(app)
 			if err != nil {

--- a/provider/aws/service.go
+++ b/provider/aws/service.go
@@ -202,7 +202,7 @@ func (p *AWSProvider) ServiceGet(name string) (*structs.Service, error) {
 	for k, _ := range s.Outputs {
 		if strings.HasSuffix(k, "Link") {
 			n := dashName(k)
-			app := n[:len(n)-4]
+			app := n[:len(n)-5] // 5 == len("-link")
 
 			a, err := p.AppGet(app)
 			if err != nil {


### PR DESCRIPTION
Generally a length of 5 works. A catch is when an app ends in a number (e.g. httpd80). This would create a link output value of `Httpd80Link`. When an app name is retrieved from that, dashName() returns `foo80link`. Removing the last 5 characters results in `foo8`.

**UPDATE**: As a stop gap, extract app name from log group. This method helps avoid some edge cases but also could cause an issue if a user has two apps (following the pattern of foo80 and foo-80) they'll only be able to link to one or another.