### PR TITLE
Handle a v2 or v1 manifest

### DIFF
--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -667,9 +667,8 @@ func createTarball(base string) ([]byte, error) {
 // Image URLs that point to the convox-hosted registry, e.g. convox-826133048.us-east-1.elb.amazonaws.com:5000/myapp-web:BSUSBFCUCSA,
 // are not yet supported and return an error.
 func (p *AWSProvider) deleteImages(a *structs.App, b *structs.Build) error {
-	var m manifest.Manifest
 
-	err := yaml.Unmarshal([]byte(b.Manifest), &m)
+	m, err := manifest.Load([]byte(b.Manifest))
 	if err != nil {
 		return err
 	}

--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -46,11 +46,10 @@ func TestBuildDelete(t *testing.T) {
 
 		describeStacksCycle,
 		releasesBuild2DeleteItemCycle,
+		build2BatchDeleteImageCycle,
 
 		releasesBuild2BatchWriteItemCycle,
 		build2DeleteItemCycle,
-
-		build2BatchDeleteImageCycle,
 	)
 	defer provider.Close()
 


### PR DESCRIPTION
Let the Load() handle the different versions. Otherwise it would be:

v1
`yaml.Unmarshal([]byte(b.Manifest), &m.Services)`

v2
`yaml.Unmarshal([]byte(b.Manifest), &m)`

Deleteing images for a v1 manifest would return nil since Services would be empty