### PR TITLE
Remove the check/set for AWS_REGION

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -428,10 +428,6 @@ func awsConfig(region string, creds *AwsCredentials) *aws.Config {
 		config.Endpoint = aws.String(e)
 	}
 
-	if r := os.Getenv("AWS_REGION"); r != "" {
-		config.Region = aws.String(r)
-	}
-
 	return config
 }
 


### PR DESCRIPTION
The --region flag already checks AWS_REGION for a value. Checking the env variable directly will override the --region value.