### PR TITLE
Log output streaming

### DIFF
--- a/provider/aws/logs.go
+++ b/provider/aws/logs.go
@@ -55,22 +55,18 @@ func (p *AWSProvider) fetchLogs(w io.Writer, group, filter string, start int64) 
 		Interleaved:  aws.Bool(true),
 		LogGroupName: aws.String(group),
 		StartTime:    aws.Int64(start),
-		EndTime:      aws.Int64(start + (1000 * 60 * 10)),
-		Limit:        aws.Int64(10000),
 	}
 
 	if filter != "" {
 		req.FilterPattern = aws.String(filter)
 	}
 
-	events := []*cloudwatchlogs.FilteredLogEvent{}
-
 	for {
 		res, err := p.cloudwatchlogs().FilterLogEvents(req)
 		if ae, ok := err.(awserr.Error); ok && ae.Code() == "ThrottlingException" {
 			// backoff
 			log.Error(err)
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 			continue
 		}
 		if err != nil {
@@ -78,7 +74,15 @@ func (p *AWSProvider) fetchLogs(w io.Writer, group, filter string, start int64) 
 			return 0, err
 		}
 
-		events = append(events, res.Events...)
+		latest, err := p.writeLogEvents(w, res.Events)
+		if err != nil {
+			log.Error(err)
+			return 0, err
+		}
+
+		if latest > start {
+			start = latest
+		}
 
 		if res.NextToken == nil {
 			break
@@ -87,14 +91,8 @@ func (p *AWSProvider) fetchLogs(w io.Writer, group, filter string, start int64) 
 		req.NextToken = res.NextToken
 	}
 
-	latest, err := p.writeLogEvents(w, events)
-	if err != nil {
-		log.Error(err)
-		return 0, err
-	}
-
-	log.Successf("end=%d", latest)
-	return latest, nil
+	log.Successf("end=%d", start)
+	return start, nil
 }
 
 func (p *AWSProvider) writeLogEvents(w io.Writer, events []*cloudwatchlogs.FilteredLogEvent) (int64, error) {

--- a/provider/aws/logs_test.go
+++ b/provider/aws/logs_test.go
@@ -27,14 +27,19 @@ func TestLogStream(t *testing.T) {
 	})
 
 	assert.Nil(t, err)
-	assert.Equal(t, "2014-03-28T19:36:18Z event1\n2014-03-28T19:36:18Z event2\n2014-03-28T19:36:18Z event3\n2014-03-28T19:36:18Z event4\n2014-03-28T19:36:18Z event5\n", buf.String())
+	assert.Equal(t, "2014-03-28T19:36:18Z event2\n2014-03-28T19:36:18Z event3\n2014-03-28T19:36:18Z event4\n2014-03-28T19:36:18Z event1\n2014-03-28T19:36:18Z event5\n", buf.String())
 }
 
 var cycleLogFilterLogEvents1 = awsutil.Cycle{
 	Request: awsutil.Request{
 		RequestURI: "/",
 		Operation:  "Logs_20140328.FilterLogEvents",
-		Body:       `{"endTime":1472946823000,"filterPattern":"test","interleaved":true,"limit":10000,"logGroupName":"convox-httpd-LogGroup-L4V203L35WRM","startTime":1472946223000}`,
+		Body: `{
+			"filterPattern": "test",
+			"interleaved": true,
+			"logGroupName": "convox-httpd-LogGroup-L4V203L35WRM",
+			"startTime": 1.472946223e+12
+		}`,
 	},
 	Response: awsutil.Response{
 		StatusCode: 200,
@@ -85,7 +90,13 @@ var cycleLogFilterLogEvents2 = awsutil.Cycle{
 	Request: awsutil.Request{
 		RequestURI: "/",
 		Operation:  "Logs_20140328.FilterLogEvents",
-		Body:       `{"endTime":1472946823000,"filterPattern":"test","interleaved":true,"limit":10000,"logGroupName":"convox-httpd-LogGroup-L4V203L35WRM","startTime":1472946223000,"nextToken":"ZNUEPl7FcQuXbIH4Swk9D9eFu2XBg-ijZIZlvzz4ea9zZRjw-MMtQtvcoMdmq4T29K7Q6Y1e_KvyfpcT_f_tUw"}`,
+		Body: `{
+			"filterPattern": "test",
+			"interleaved": true,
+			"logGroupName": "convox-httpd-LogGroup-L4V203L35WRM",
+			"nextToken": "ZNUEPl7FcQuXbIH4Swk9D9eFu2XBg-ijZIZlvzz4ea9zZRjw-MMtQtvcoMdmq4T29K7Q6Y1e_KvyfpcT_f_tUw",
+			"startTime": 1.472946223e+12
+		}`,
 	},
 	Response: awsutil.Response{
 		StatusCode: 200,


### PR DESCRIPTION
Get logs out as fast as possible without trying to ensure that they are in the right order. We could potentially add client-side optional sorting or something like that.

Currently only apps with lots of log streams (frequently crashing processes or frequent cron) will have potentially weirdly out-of-order logs.