### PR TITLE
Fix logic for IsTerminal()

### DIFF
--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -328,7 +328,7 @@ func cmdBuildsExport(c *cli.Context) error {
 		return stdcli.ExitError(err)
 	}
 
-	if !stdcli.IsTerminal(os.Stdout) && c.String("file") == "" {
+	if stdcli.IsTerminal(os.Stdout) && c.String("file") == "" {
 		return stdcli.ExitError(fmt.Errorf("please pipe the output of this command to a file or specify -f"))
 	}
 
@@ -367,7 +367,7 @@ func cmdBuildsImport(c *cli.Context) error {
 		return stdcli.ExitError(err)
 	}
 
-	if !stdcli.IsTerminal(os.Stdin) && c.String("file") == "" {
+	if stdcli.IsTerminal(os.Stdin) && c.String("file") == "" {
 		return stdcli.ExitError(fmt.Errorf("please pipe a file into this command or specify -f"))
 	}
 

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -242,7 +242,9 @@ func IsTerminal(f *os.File) bool {
 		return false
 	}
 
-	return (stat.Mode() & os.ModeCharDevice) == 0
+	// stat.Mode() & os.ModeCharDevice) == 0 means data is being piped to stdin
+	// otherwise stdin is from a terminal
+	return (stat.Mode() & os.ModeCharDevice) != 0
 }
 
 func Usage(c *cli.Context, name string) {


### PR DESCRIPTION
`stat.Mode() & os.ModeCharDevice) == 0` means data is being piped to stdin, otherwise stdin is from a terminal.

## Quick CLI Release Playbook
- [x] Code review
- [ ] Merge into master
- [ ] Release CLI