### PR TITLE
avoid crashes when switching git branches

### DIFF
--- a/changes/changes.go
+++ b/changes/changes.go
@@ -137,6 +137,10 @@ func watchForChanges(files map[string]map[string]time.Time, dir string, ignore [
 				return nil
 			}
 
+			if info == nil {
+				return nil
+			}
+
 			if info.IsDir() {
 				return nil
 			}


### PR DESCRIPTION
This prevents a panic that sometimes occurs when switching branches underneath `convox start`