### PR TITLE
remove port randomization

### DIFF
--- a/api/models/release.go
+++ b/api/models/release.go
@@ -161,8 +161,6 @@ func (r *Release) Promote() error {
 		return err
 	}
 
-	oldVersion := app.Parameters["Version"]
-
 	app.Parameters["Environment"] = r.EnvironmentUrl()
 	app.Parameters["Kernel"] = CustomTopic
 	app.Parameters["Release"] = r.Id
@@ -285,15 +283,6 @@ func (r *Release) Promote() error {
 
 					app.Parameters[certParam] = *res.ServerCertificateMetadata.Arn
 				}
-			}
-		}
-	}
-
-	// randomize the instance ports for older apps so we can upgrade smoothly
-	if oldVersion < "20160818013241" {
-		for key := range app.Parameters {
-			if strings.HasSuffix(key, "Host") {
-				app.Parameters[key] = strconv.Itoa(rand.Intn(50000) + 10000)
 			}
 		}
 	}


### PR DESCRIPTION
Increase rack instance count or use autoscale to get past service-replacement boundaries.