### PR TITLE
Correctly use existing values during stack updates

### DIFF
--- a/provider/aws/system_test.go
+++ b/provider/aws/system_test.go
@@ -85,7 +85,27 @@ func TestSystemSave(t *testing.T) {
 		cycleSystemDescribeStacks,
 		cycleReleasePutItem,
 		cycleSystemUpdateNotificationPublish,
+		cycleSystemDescribeStacks,
 		cycleSystemUpdateStack,
+	)
+	defer provider.Close()
+
+	err := provider.SystemSave(structs.System{
+		Count:   5,
+		Type:    "t2.small",
+		Version: "20160820033210",
+	})
+
+	assert.Nil(t, err)
+}
+
+func TestSystemSaveNewParameter(t *testing.T) {
+	provider := StubAwsProvider(
+		cycleSystemDescribeStacks,
+		cycleReleasePutItem,
+		cycleSystemUpdateNotificationPublish,
+		cycleSystemDescribeStacksMissingParameters,
+		cycleSystemUpdateStackNewParameter,
 	)
 	defer provider.Close()
 
@@ -185,7 +205,7 @@ var cycleSystemDescribeStacks = awsutil.Cycle{
 								<ParameterValue/>
 							</member>
 							<member>
-						<ParameterKey>InstanceType</ParameterKey>
+								<ParameterKey>InstanceType</ParameterKey>
 								<ParameterValue>t2.small</ParameterValue>
 							</member>
 							<member>
@@ -251,6 +271,43 @@ var cycleSystemDescribeStacks = awsutil.Cycle{
 	},
 }
 
+var cycleSystemDescribeStacksMissingParameters = awsutil.Cycle{
+	awsutil.Request{"/", "", `Action=DescribeStacks&StackName=convox&Version=2010-05-15`},
+	awsutil.Response{
+		200,
+		`<DescribeStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+			<DescribeStacksResult>
+				<Stacks>
+					<member>
+						<Outputs>
+						</Outputs>
+						<Capabilities>
+							<member>CAPABILITY_IAM</member>
+						</Capabilities>
+						<CreationTime>2015-10-28T16:14:09.590Z</CreationTime>
+						<NotificationARNs/>
+						<StackId>arn:aws:cloudformation:us-east-1:778743527532:stack/convox/eb743e00-7d8e-11e5-8280-50ba0727c06e</StackId>
+						<StackName>convox</StackName>
+						<StackStatus>UPDATE_COMPLETE</StackStatus>
+						<DisableRollback>false</DisableRollback>
+						<Tags/>
+						<LastUpdatedTime>2016-08-27T16:29:05.963Z</LastUpdatedTime>
+						<Parameters>
+							<member>
+								<ParameterKey>Ami</ParameterKey>
+								<ParameterValue/>
+							</member>
+						</Parameters>
+					</member>
+				</Stacks>
+			</DescribeStacksResult>
+			<ResponseMetadata>
+				<RequestId>9715cab7-6c75-11e6-837d-ebe72becd936</RequestId>
+			</ResponseMetadata>
+		</DescribeStacksResponse>`,
+	},
+}
+
 var cycleSystemReleaseList = awsutil.Cycle{
 	Request: awsutil.Request{
 		RequestURI: "/",
@@ -299,6 +356,26 @@ var cycleSystemUpdateStack = awsutil.Cycle{
 	Request: awsutil.Request{
 		RequestURI: "/",
 		Body:       `Action=UpdateStack&Capabilities.member.1=CAPABILITY_IAM&Parameters.member.1.ParameterKey=Ami&Parameters.member.1.UsePreviousValue=true&Parameters.member.10.ParameterKey=InstanceBootCommand&Parameters.member.10.UsePreviousValue=true&Parameters.member.11.ParameterKey=InstanceCount&Parameters.member.11.ParameterValue=5&Parameters.member.12.ParameterKey=InstanceRunCommand&Parameters.member.12.UsePreviousValue=true&Parameters.member.13.ParameterKey=InstanceType&Parameters.member.13.ParameterValue=t2.small&Parameters.member.14.ParameterKey=InstanceUpdateBatchSize&Parameters.member.14.UsePreviousValue=true&Parameters.member.15.ParameterKey=Internal&Parameters.member.15.UsePreviousValue=true&Parameters.member.16.ParameterKey=Key&Parameters.member.16.UsePreviousValue=true&Parameters.member.17.ParameterKey=Password&Parameters.member.17.UsePreviousValue=true&Parameters.member.18.ParameterKey=Private&Parameters.member.18.UsePreviousValue=true&Parameters.member.19.ParameterKey=PrivateApi&Parameters.member.19.UsePreviousValue=true&Parameters.member.2.ParameterKey=ApiCpu&Parameters.member.2.UsePreviousValue=true&Parameters.member.20.ParameterKey=Subnet0CIDR&Parameters.member.20.UsePreviousValue=true&Parameters.member.21.ParameterKey=Subnet1CIDR&Parameters.member.21.UsePreviousValue=true&Parameters.member.22.ParameterKey=Subnet2CIDR&Parameters.member.22.UsePreviousValue=true&Parameters.member.23.ParameterKey=SubnetPrivate0CIDR&Parameters.member.23.UsePreviousValue=true&Parameters.member.24.ParameterKey=SubnetPrivate1CIDR&Parameters.member.24.UsePreviousValue=true&Parameters.member.25.ParameterKey=SubnetPrivate2CIDR&Parameters.member.25.UsePreviousValue=true&Parameters.member.26.ParameterKey=SwapSize&Parameters.member.26.UsePreviousValue=true&Parameters.member.27.ParameterKey=Tenancy&Parameters.member.27.UsePreviousValue=true&Parameters.member.28.ParameterKey=VPCCIDR&Parameters.member.28.UsePreviousValue=true&Parameters.member.29.ParameterKey=Version&Parameters.member.29.ParameterValue=20160820033210&Parameters.member.3.ParameterKey=ApiMemory&Parameters.member.3.UsePreviousValue=true&Parameters.member.30.ParameterKey=VolumeSize&Parameters.member.30.UsePreviousValue=true&Parameters.member.4.ParameterKey=Autoscale&Parameters.member.4.UsePreviousValue=true&Parameters.member.5.ParameterKey=ClientId&Parameters.member.5.UsePreviousValue=true&Parameters.member.6.ParameterKey=ContainerDisk&Parameters.member.6.UsePreviousValue=true&Parameters.member.7.ParameterKey=Development&Parameters.member.7.UsePreviousValue=true&Parameters.member.8.ParameterKey=Encryption&Parameters.member.8.UsePreviousValue=true&Parameters.member.9.ParameterKey=ExistingVpc&Parameters.member.9.UsePreviousValue=true&StackName=convox&TemplateURL=https%3A%2F%2Fconvox.s3.amazonaws.com%2Frelease%2F20160820033210%2Fformation.json&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `
+			<UpdateStackResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+				<UpdateStackResult>
+					<StackId>arn:aws:cloudformation:us-east-1:901416387788:stack/convox/9a10bbe0-51d5-11e5-b85a-5001dc3ed8d2</StackId>
+				</UpdateStackResult>
+				<ResponseMetadata>
+					<RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
+				</ResponseMetadata>
+			</UpdateStackResponse>
+		`,
+	},
+}
+
+var cycleSystemUpdateStackNewParameter = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Body:       `Action=UpdateStack&Capabilities.member.1=CAPABILITY_IAM&Parameters.member.1.ParameterKey=Ami&Parameters.member.1.UsePreviousValue=true&Parameters.member.2.ParameterKey=InstanceCount&Parameters.member.2.ParameterValue=5&Parameters.member.3.ParameterKey=InstanceType&Parameters.member.3.ParameterValue=t2.small&Parameters.member.4.ParameterKey=Version&Parameters.member.4.ParameterValue=20160820033210&StackName=convox&TemplateURL=https%3A%2F%2Fconvox.s3.amazonaws.com%2Frelease%2F20160820033210%2Fformation.json&Version=2010-05-15`,
 	},
 	Response: awsutil.Response{
 		StatusCode: 200,


### PR DESCRIPTION
This fixes a case where stack updating would break when faces with a new parameter as it tries to `UsePreviousValue` for it.