### PR TITLE
read default cpu and memory scale from manifest

### DIFF
--- a/api/models/release.go
+++ b/api/models/release.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"math"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -194,7 +195,7 @@ func (r *Release) Promote() error {
 		}
 
 		if entry.Memory > 0 {
-			scale[2] = fmt.Sprintf("%d", entry.Memory)
+			scale[2] = fmt.Sprintf("%d", int64(math.Ceil(float64(entry.Memory)/(1024*1024))))
 		}
 
 		switch {

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -35,6 +35,9 @@ type Service struct {
 	Privileged  bool        `yaml:"privileged,omitempty"`
 	Volumes     []string    `yaml:"volumes,omitempty"`
 
+	Cpu    int64  `yaml:"cpu_shares,omitempty"`
+	Memory Memory `yaml:"mem_limit,omitempty"`
+
 	//TODO from models manifest, not passive and used at runtime
 	Exports  map[string]string        `yaml:"-"`
 	LinkVars map[string]template.HTML `yaml:"-"`
@@ -61,7 +64,7 @@ type Command struct {
 }
 type Environment map[string]string
 type Labels map[string]string
-
+type Memory int64
 type Networks map[string]InternalNetwork
 
 type InternalNetwork map[string]ExternalNetwork
@@ -367,6 +370,10 @@ func (s Service) ContainerPorts() []string {
 	sort.Strings(ext)
 
 	return ext
+}
+
+func (s Service) ParamName(name string) string {
+	return fmt.Sprintf("%s%s", UpperName(s.Name), name)
 }
 
 func (s Service) RegistryImage(appName, buildId string, outputs map[string]string) string {

--- a/manifest/yaml.go
+++ b/manifest/yaml.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/docker/go-units"
 )
 
 // MarshalYAML implements the Marshaller interface for the Manifest type
@@ -214,6 +216,31 @@ func (l *Labels) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	default:
 		return fmt.Errorf("cannot parse labels: %v", t)
+	}
+
+	return nil
+}
+
+func (m *Memory) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var v interface{}
+
+	if err := unmarshal(&v); err != nil {
+		return err
+	}
+
+	switch t := v.(type) {
+	case string:
+		ram, err := units.RAMInBytes(t)
+		if err != nil {
+			return err
+		}
+		*m = Memory(ram)
+	case int:
+		*m = Memory(t)
+	case float64:
+		*m = Memory(t)
+	default:
+		return fmt.Errorf("could not parse mem_limit: %v", t)
 	}
 
 	return nil


### PR DESCRIPTION
Reads the default CPU and Memory settings for a process from the `docker-compose.yml`.

```
web:
  cpu_shares: 100
  mem_limit: 20MB
```

Closes #353 