### PR TITLE
Accept AWS_DEFAULT_REGION as well as AWS_REGION when running `convox install`

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -117,7 +117,7 @@ func init() {
 				Name:   "region",
 				Value:  "us-east-1",
 				Usage:  "aws region",
-				EnvVar: "AWS_REGION",
+				EnvVar: "AWS_REGION,AWS_DEFAULT_REGION",
 			},
 			cli.StringFlag{
 				Name:   "stack-name",


### PR DESCRIPTION
Warning: I've run the tests but haven't verified manually (still need to figure out local dev workflow).

Addresses #1267 