### PR TITLE
ECR login improvements

### DIFF
--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -55,9 +55,9 @@ func TestBuildCreate(t *testing.T) {
 		cycleBuildDescribeStackResources,
 		cycleBuildDescribeStacks,
 		cycleEnvironmentGetRack,
-		cycleBuildGetAuthorizationToken,
+		cycleBuildGetAuthorizationTokenPrivate1,
 		cycleBuildDescribeStacks,
-		cycleBuildGetAuthorizationToken,
+		cycleBuildGetAuthorizationTokenPrivate2,
 		cycleBuildRunTask,
 		cycleBuildGetItem,
 		cycleBuildDescribeStacks,
@@ -674,6 +674,54 @@ var cycleBuildGetAuthorizationToken = awsutil.Cycle{
 		RequestURI: "/",
 		Operation:  "AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken",
 		Body:       `{}`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `{
+			"authorizationData": [
+				{
+					"authorizationToken": "dXNlcjoxMjM0NQo=",
+					"expiresAt": 1473039114.46,
+					"proxyEndpoint": "https://778743527532.dkr.ecr.us-east-1.amazonaws.com"
+				}
+			]
+		}`,
+	},
+}
+
+var cycleBuildGetAuthorizationTokenPrivate1 = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Operation:  "AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken",
+		Body: `{
+			"registryIds": [
+				"922560784203"
+			]
+		}`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `{
+			"authorizationData": [
+				{
+					"authorizationToken": "dXNlcjoxMjM0NQo=",
+					"expiresAt": 1473039114.46,
+					"proxyEndpoint": "https://778743527532.dkr.ecr.us-east-1.amazonaws.com"
+				}
+			]
+		}`,
+	},
+}
+
+var cycleBuildGetAuthorizationTokenPrivate2 = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Operation:  "AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken",
+		Body: `{
+			"registryIds": [
+				"132866487567"
+			]
+		}`,
 	},
 	Response: awsutil.Response{
 		StatusCode: 200,


### PR DESCRIPTION
- Extract the right account ID from the registry hostname to use when fetching the auth token
- Use just the registry hostname, rather than the full path, to log in