### PR TITLE
Optionally specify a service and or command with convox start 

### DIFF
--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -206,7 +206,10 @@ func build(dir string) error {
 
 	defer close(s)
 
-	if err := m.Build("", dir, flagApp, s, (flagCache == "true")); err != nil {
+	err = m.Build(dir, flagApp, s, manifest.BuildOptions{
+		NoCache: !(flagCache == "true"),
+	})
+	if err != nil {
 		return err
 	}
 

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -207,7 +207,7 @@ func build(dir string) error {
 	defer close(s)
 
 	err = m.Build(dir, flagApp, s, manifest.BuildOptions{
-		NoCache: !(flagCache == "true"),
+		Cache: flagCache == "true",
 	})
 	if err != nil {
 		return err

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -206,7 +206,7 @@ func build(dir string) error {
 
 	defer close(s)
 
-	if err := m.Build(dir, flagApp, s, (flagCache == "true")); err != nil {
+	if err := m.Build("", dir, flagApp, s, (flagCache == "true")); err != nil {
 		return err
 	}
 

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -45,6 +46,10 @@ func init() {
 
 func cmdStart(c *cli.Context) error {
 	// go handleResize()
+	log.Printf("%#v", c.Args())
+	if len(c.Args()) == 1 {
+		//startProc
+	}
 
 	id, err := currentId()
 	if err != nil {

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -19,7 +19,7 @@ func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "start",
 		Description: "start an app for local development",
-		Usage:       "[directory]",
+		Usage:       "[service] [command]",
 		Action:      cmdStart,
 		Flags: []cli.Flag{
 			cli.StringFlag{

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -77,6 +77,13 @@ func cmdStart(c *cli.Context) error {
 		return stdcli.ExitError(err)
 	}
 
+	if service != "" {
+		_, ok := m.Services[service]
+		if !ok {
+			return stdcli.ExitError(fmt.Errorf("Service %s not found in manifest", service))
+		}
+	}
+
 	if err := m.Shift(c.Int("shift")); err != nil {
 		return stdcli.ExitError(err)
 	}

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -45,15 +45,15 @@ func init() {
 
 func cmdStart(c *cli.Context) error {
 	// go handleResize()
-	var targetService string
-	var targetCommand []string
+	var service string
+	var command []string
 
 	if len(c.Args()) > 0 {
-		targetService = c.Args()[0]
+		service = c.Args()[0]
 	}
 
 	if len(c.Args()) > 1 {
-		targetCommand = c.Args()[1:]
+		command = c.Args()[1:]
 	}
 
 	id, err := currentId()
@@ -96,7 +96,12 @@ func cmdStart(c *cli.Context) error {
 	cache := !c.Bool("no-cache")
 	sync := !c.Bool("no-sync")
 
-	r := m.Run(targetService, targetCommand, dir, app, cache, sync)
+	r := m.Run(dir, app, manifest.RunOptions{
+		Cache:   cache,
+		Sync:    sync,
+		Service: service,
+		Command: command,
+	})
 
 	err = r.Start()
 	if err != nil {

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -46,9 +45,15 @@ func init() {
 
 func cmdStart(c *cli.Context) error {
 	// go handleResize()
-	log.Printf("%#v", c.Args())
-	if len(c.Args()) == 1 {
-		//startProc
+	var targetService string
+	var targetCommand []string
+
+	if len(c.Args()) > 0 {
+		targetService = c.Args()[0]
+	}
+
+	if len(c.Args()) > 1 {
+		targetCommand = c.Args()[1:]
 	}
 
 	id, err := currentId()
@@ -91,7 +96,7 @@ func cmdStart(c *cli.Context) error {
 	cache := !c.Bool("no-cache")
 	sync := !c.Bool("no-sync")
 
-	r := m.Run(dir, app, cache, sync)
+	r := m.Run(targetService, targetCommand, dir, app, cache, sync)
 
 	err = r.Start()
 	if err != nil {

--- a/manifest/build.go
+++ b/manifest/build.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 )
 
-func (m *Manifest) Build(dir, appName string, s Stream, cache bool) error {
+func (m *Manifest) Build(targetService, dir, appName string, s Stream, cache bool) error {
 	pulls := map[string][]string{}
 	builds := []Service{}
 
-	services, err := m.runOrder("")
+	services, err := m.runOrder(targetService)
 	if err != nil {
 		return err
 	}

--- a/manifest/build.go
+++ b/manifest/build.go
@@ -10,7 +10,12 @@ func (m *Manifest) Build(dir, appName string, s Stream, cache bool) error {
 	pulls := map[string][]string{}
 	builds := []Service{}
 
-	for _, service := range m.runOrder() {
+	services, err := m.runOrder("")
+	if err != nil {
+		return err
+	}
+
+	for _, service := range services {
 		dockerFile := service.Build.Dockerfile
 		if dockerFile == "" {
 			dockerFile = service.Dockerfile

--- a/manifest/build.go
+++ b/manifest/build.go
@@ -7,7 +7,7 @@ import (
 )
 
 type BuildOptions struct {
-	NoCache bool
+	Cache   bool
 	Service string
 }
 
@@ -49,7 +49,7 @@ func (m *Manifest) Build(dir, appName string, s Stream, opts BuildOptions) error
 
 		args := []string{"build"}
 
-		if opts.NoCache {
+		if !opts.Cache {
 			args = append(args, "--no-cache")
 		}
 
@@ -78,7 +78,7 @@ func (m *Manifest) Build(dir, appName string, s Stream, opts BuildOptions) error
 
 		args = append(args, image)
 
-		if opts.NoCache || len(output) == 0 {
+		if !opts.Cache || len(output) == 0 {
 			if err := DefaultRunner.Run(s, Docker("pull", image)); err != nil {
 				return fmt.Errorf("build error: %s", err)
 			}

--- a/manifest/build.go
+++ b/manifest/build.go
@@ -6,11 +6,16 @@ import (
 	"strings"
 )
 
-func (m *Manifest) Build(targetService, dir, appName string, s Stream, cache bool) error {
+type BuildOptions struct {
+	NoCache bool
+	Service string
+}
+
+func (m *Manifest) Build(dir, appName string, s Stream, opts BuildOptions) error {
 	pulls := map[string][]string{}
 	builds := []Service{}
 
-	services, err := m.runOrder(targetService)
+	services, err := m.runOrder(opts.Service)
 	if err != nil {
 		return err
 	}
@@ -44,7 +49,7 @@ func (m *Manifest) Build(targetService, dir, appName string, s Stream, cache boo
 
 		args := []string{"build"}
 
-		if !cache {
+		if opts.NoCache {
 			args = append(args, "--no-cache")
 		}
 
@@ -73,7 +78,7 @@ func (m *Manifest) Build(targetService, dir, appName string, s Stream, cache boo
 
 		args = append(args, image)
 
-		if !cache || len(output) == 0 {
+		if opts.NoCache || len(output) == 0 {
 			if err := DefaultRunner.Run(s, Docker("pull", image)); err != nil {
 				return fmt.Errorf("build error: %s", err)
 			}

--- a/manifest/build_test.go
+++ b/manifest/build_test.go
@@ -90,7 +90,7 @@ func TestBuildWithCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build(".", "web", str, true)
+	err = m.Build("", ".", "web", str, true)
 
 	cmd1 := []string{"docker", "build", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
 	cmd2 := []string{"docker", "tag", "convox/postgres:latest", "web/database"}
@@ -120,7 +120,7 @@ func TestBuildCacheNoImage(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build(".", "web", str, true)
+	err = m.Build("", ".", "web", str, true)
 
 	cmd1 := []string{"docker", "build", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
 	cmd2 := []string{"docker", "pull", "convox/postgres:latest"}
@@ -130,6 +130,36 @@ func TestBuildCacheNoImage(t *testing.T) {
 	assert.Equal(t, te.Commands[0].Args, cmd1)
 	assert.Equal(t, te.Commands[1].Args, cmd2)
 	assert.Equal(t, te.Commands[2].Args, cmd3)
+}
+
+func TestBuildWithSpecificService(t *testing.T) {
+	output := manifest.NewOutput()
+	str := output.Stream("build")
+	dr := manifest.DefaultRunner
+	te := NewTestExecer()
+	te.CannedResponses = []ExecResponse{
+		ExecResponse{
+			Output: []byte("dockerid"),
+			Error:  nil,
+		},
+	}
+
+	manifest.DefaultRunner = te
+	defer func() { manifest.DefaultRunner = dr }()
+
+	m, err := manifestFixture("specific-service")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = m.Build("web", ".", "web", str, true)
+
+	cmd1 := []string{"docker", "build", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
+	cmd2 := []string{"docker", "tag", "convox/postgres:latest", "web/database"}
+
+	assert.Equal(t, len(te.Commands), 2)
+	assert.Equal(t, te.Commands[0].Args, cmd1)
+	assert.Equal(t, te.Commands[1].Args, cmd2)
 }
 
 func TestBuildNoCache(t *testing.T) {
@@ -152,7 +182,7 @@ func TestBuildNoCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build(".", "web", str, false)
+	err = m.Build("", ".", "web", str, false)
 
 	cmd1 := []string{"docker", "build", "--no-cache", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
 	cmd2 := []string{"docker", "pull", "convox/postgres:latest"}
@@ -177,7 +207,7 @@ func TestBuildRepeatSimple(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build(".", "web", str, false)
+	err = m.Build("", ".", "web", str, false)
 
 	cmd1 := []string{"docker", "build", "--no-cache", "-f", "./Dockerfile", "-t", "web/monitor", "."}
 	cmd2 := []string{"docker", "build", "--no-cache", "-f", "other/Dockerfile", "-t", "web/other", "other"}
@@ -208,7 +238,7 @@ func TestBuildRepeatImage(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build(".", "web", str, false)
+	err = m.Build("", ".", "web", str, false)
 
 	cmd1 := []string{"docker", "pull", "convox/rails:latest"}
 	cmd2 := []string{"docker", "tag", "convox/rails:latest", "web/web1"}
@@ -234,7 +264,7 @@ func TestBuildRepeatComplex(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build(".", "web", str, false)
+	err = m.Build("", ".", "web", str, false)
 
 	te.AssertCommands(t, TestCommands{
 		[]string{"docker", "build", "--no-cache", "-f", "./Dockerfile", "-t", "web/first", "."},

--- a/manifest/build_test.go
+++ b/manifest/build_test.go
@@ -90,7 +90,7 @@ func TestBuildWithCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build("", ".", "web", str, true)
+	err = m.Build(".", "web", str, manifest.BuildOptions{})
 
 	cmd1 := []string{"docker", "build", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
 	cmd2 := []string{"docker", "tag", "convox/postgres:latest", "web/database"}
@@ -120,7 +120,7 @@ func TestBuildCacheNoImage(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build("", ".", "web", str, true)
+	err = m.Build(".", "web", str, manifest.BuildOptions{})
 
 	cmd1 := []string{"docker", "build", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
 	cmd2 := []string{"docker", "pull", "convox/postgres:latest"}
@@ -152,7 +152,10 @@ func TestBuildWithSpecificService(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build("web", ".", "web", str, true)
+	err = m.Build(".", "web", str, manifest.BuildOptions{
+		Service: "web",
+		NoCache: false,
+	})
 
 	cmd1 := []string{"docker", "build", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
 	cmd2 := []string{"docker", "tag", "convox/postgres:latest", "web/database"}
@@ -182,7 +185,10 @@ func TestBuildNoCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build("", ".", "web", str, false)
+	err = m.Build(".", "web", str, manifest.BuildOptions{
+		Service: "web",
+		NoCache: true,
+	})
 
 	cmd1 := []string{"docker", "build", "--no-cache", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
 	cmd2 := []string{"docker", "pull", "convox/postgres:latest"}
@@ -207,7 +213,9 @@ func TestBuildRepeatSimple(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build("", ".", "web", str, false)
+	err = m.Build(".", "web", str, manifest.BuildOptions{
+		NoCache: true,
+	})
 
 	cmd1 := []string{"docker", "build", "--no-cache", "-f", "./Dockerfile", "-t", "web/monitor", "."}
 	cmd2 := []string{"docker", "build", "--no-cache", "-f", "other/Dockerfile", "-t", "web/other", "other"}
@@ -238,7 +246,9 @@ func TestBuildRepeatImage(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build("", ".", "web", str, false)
+	err = m.Build(".", "web", str, manifest.BuildOptions{
+		NoCache: true,
+	})
 
 	cmd1 := []string{"docker", "pull", "convox/rails:latest"}
 	cmd2 := []string{"docker", "tag", "convox/rails:latest", "web/web1"}
@@ -264,7 +274,9 @@ func TestBuildRepeatComplex(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build("", ".", "web", str, false)
+	err = m.Build(".", "web", str, manifest.BuildOptions{
+		NoCache: true,
+	})
 
 	te.AssertCommands(t, TestCommands{
 		[]string{"docker", "build", "--no-cache", "-f", "./Dockerfile", "-t", "web/first", "."},

--- a/manifest/build_test.go
+++ b/manifest/build_test.go
@@ -90,7 +90,9 @@ func TestBuildWithCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build(".", "web", str, manifest.BuildOptions{})
+	err = m.Build(".", "web", str, manifest.BuildOptions{
+		Cache: true,
+	})
 
 	cmd1 := []string{"docker", "build", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
 	cmd2 := []string{"docker", "tag", "convox/postgres:latest", "web/database"}
@@ -120,7 +122,9 @@ func TestBuildCacheNoImage(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.Build(".", "web", str, manifest.BuildOptions{})
+	err = m.Build(".", "web", str, manifest.BuildOptions{
+		Cache: true,
+	})
 
 	cmd1 := []string{"docker", "build", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
 	cmd2 := []string{"docker", "pull", "convox/postgres:latest"}
@@ -154,7 +158,7 @@ func TestBuildWithSpecificService(t *testing.T) {
 
 	err = m.Build(".", "web", str, manifest.BuildOptions{
 		Service: "web",
-		NoCache: false,
+		Cache:   true,
 	})
 
 	cmd1 := []string{"docker", "build", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
@@ -187,7 +191,7 @@ func TestBuildNoCache(t *testing.T) {
 
 	err = m.Build(".", "web", str, manifest.BuildOptions{
 		Service: "web",
-		NoCache: true,
+		Cache:   false,
 	})
 
 	cmd1 := []string{"docker", "build", "--no-cache", "-f", "./Dockerfile.dev", "-t", "web/web", "."}
@@ -214,7 +218,7 @@ func TestBuildRepeatSimple(t *testing.T) {
 	}
 
 	err = m.Build(".", "web", str, manifest.BuildOptions{
-		NoCache: true,
+		Cache: false,
 	})
 
 	cmd1 := []string{"docker", "build", "--no-cache", "-f", "./Dockerfile", "-t", "web/monitor", "."}
@@ -247,7 +251,7 @@ func TestBuildRepeatImage(t *testing.T) {
 	}
 
 	err = m.Build(".", "web", str, manifest.BuildOptions{
-		NoCache: true,
+		Cache: false,
 	})
 
 	cmd1 := []string{"docker", "pull", "convox/rails:latest"}
@@ -275,7 +279,7 @@ func TestBuildRepeatComplex(t *testing.T) {
 	}
 
 	err = m.Build(".", "web", str, manifest.BuildOptions{
-		NoCache: true,
+		Cache: false,
 	})
 
 	te.AssertCommands(t, TestCommands{

--- a/manifest/fixtures/specific-service.yml
+++ b/manifest/fixtures/specific-service.yml
@@ -1,0 +1,36 @@
+version: "2"
+services:
+  web:
+    build: .
+    command: bin/web
+    dockerfile: Dockerfile.dev
+    entrypoint: /sbin/init
+    environment:
+      - FOO=bar
+      - BAZ
+    extra_hosts:
+      - foo:10.10.10.10
+      - bar:20.20.20.20
+    labels:
+      - convox.foo=bar
+      - convox.baz=4
+    links:
+      - database
+    ports:
+      - 80:5000
+      - 443:5001
+    privileged: true
+    volumes:
+      - /var/db
+  database:
+    environment:
+      FOO: bar
+      BAZ: qux
+    image: convox/postgres
+    labels:
+      convox.aaa: 4
+      convox.ccc: ddd
+    ports:
+      - 5432
+  extra:
+    build: ./extra

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -193,8 +193,8 @@ func (m *Manifest) PortConflicts() ([]int, error) {
 }
 
 // Run Instantiate a Run object based on this manifest to be run via 'convox start'
-func (m *Manifest) Run(targetService string, targetCommand []string, dir, app string, cache, sync bool) Run {
-	return NewRun(targetService, targetCommand, dir, app, *m, cache, sync)
+func (m *Manifest) Run(dir, app string, opts RunOptions) Run {
+	return NewRun(*m, dir, app, opts)
 }
 
 func (m *Manifest) getDeps(root, dep string, deps map[string]bool) error {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -198,7 +198,14 @@ func (m *Manifest) Run(dir, app string, cache, sync bool) Run {
 }
 
 // Return the Services of this Manifest in the order you should run them
-func (m *Manifest) runOrder() Services {
+func (m *Manifest) runOrder(target string) (Services, error) {
+	if target != "" {
+		targetService, ok := m.Services[target]
+		if !ok {
+			return nil, fmt.Errorf("%s not found in manifest")
+		}
+	}
+
 	services := Services{}
 
 	for _, service := range m.Services {
@@ -220,7 +227,7 @@ func (m *Manifest) runOrder() Services {
 		}
 	}
 
-	return services
+	return services, nil
 }
 
 // Shift all external ports in this Manifest by the given amount and their shift labels

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -201,7 +201,7 @@ func (m *Manifest) getDeps(root, dep string, deps map[string]bool) error {
 	deps[dep] = true
 	targetService, ok := m.Services[dep]
 	if !ok {
-		return fmt.Errorf("Dependence %s of %s not found in manifest", dep, root)
+		return fmt.Errorf("Dependency %s of %s not found in manifest", dep, root)
 	}
 
 	for _, x := range targetService.Links {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"regexp"
 	"sort"
@@ -215,7 +214,6 @@ func (m *Manifest) getDeps(root, dep string, deps map[string]bool) error {
 			}
 		}
 	}
-	log.Printf("%#v", deps)
 	return nil
 }
 

--- a/manifest/push.go
+++ b/manifest/push.go
@@ -6,7 +6,12 @@ import (
 )
 
 func (m *Manifest) Push(template, app, build string, stream Stream) error {
-	for _, s := range m.runOrder() {
+	services, err := m.runOrder("")
+	if err != nil {
+		return err
+	}
+
+	for _, s := range services {
 		local := fmt.Sprintf("%s/%s", app, s.Name)
 
 		remote := template

--- a/manifest/run.go
+++ b/manifest/run.go
@@ -121,7 +121,7 @@ func (r *Run) Start() error {
 	r.done = make(chan error)
 
 	err = r.manifest.Build(r.Dir, r.App, r.output.Stream("build"), BuildOptions{
-		NoCache: !r.Opts.Cache,
+		Cache:   r.Opts.Cache,
 		Service: r.Opts.Service,
 	})
 	if err != nil {

--- a/manifest/run.go
+++ b/manifest/run.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,7 +120,7 @@ func (r *Run) Start() error {
 
 	r.done = make(chan error)
 
-	err = r.manifest.Build(r.Dir, r.App, r.output.Stream("build"), r.Cache)
+	err = r.manifest.Build(r.TargetService, r.Dir, r.App, r.output.Stream("build"), r.Cache)
 	if err != nil {
 		return err
 	}
@@ -131,19 +130,12 @@ func (r *Run) Start() error {
 	for _, s := range services {
 		proxies := s.Proxies(r.App)
 
-		log.Printf("HERE")
-		log.Printf("%#v", r.TargetCommand)
 		if r.TargetCommand != nil && len(r.TargetCommand) > 0 && s.Name == r.TargetService {
-			log.Printf("HERE 2")
 			s.Command.String = ""
 			s.Command.Array = r.TargetCommand
 		}
 
 		p := s.Process(r.App, r.manifest)
-		log.Print("herre")
-		log.Print(len(services))
-		log.Print(r.App)
-		log.Print(p.Name)
 
 		Docker("rm", "-f", p.Name).Run()
 


### PR DESCRIPTION
This patch provides support for specifying a specific service to start within an application and additionally/optionally a particular command to run in the following format

```
convox start
convox start api
convox start api rake db:migrate
```

The main motivation is for one off tasks such as migrations and data seeding tasks.
It was decide to add these to start as opposed to adding something like a --local flag to run as in the future we may want a "local" rack "provider" and I didn't want to pollute the run namespace/command/api