### PR TITLE
Proper error message when no racks are present

### DIFF
--- a/cmd/convox/switch.go
+++ b/cmd/convox/switch.go
@@ -69,7 +69,12 @@ func cmdSwitch(c *cli.Context) error {
 	}
 
 	if len(matched) == 0 {
-		return stdcli.Error(fmt.Errorf("Rack not found. Try one of:\n" + strings.Join(all, "\n")))
+		errMessages := []string{"Rack not found."}
+
+		if len(all) > 0 {
+			errMessages = append(errMessages, ("Try one of the following:\n" + strings.Join(all, "\n")))
+		}
+		return stdcli.Error(fmt.Errorf(strings.Join(errMessages, " ")))
 	}
 
 	if len(matched) > 1 {


### PR DESCRIPTION
If no racks were found the message used to say "Try one of: " and then an empty line.

![screen shot 2016-10-17 at 18 58 37](https://cloud.githubusercontent.com/assets/6284234/19446985/c0848b8a-949b-11e6-9da8-6fceff272b68.png)