### PR TITLE
Convox start proc parsing

### DIFF
--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -96,16 +96,19 @@ func cmdStart(c *cli.Context) error {
 		return stdcli.Error(err)
 	}
 
-	if pcc, err := m.PortConflicts(); err != nil || len(pcc) > 0 {
-		if err == nil {
-			err = fmt.Errorf("ports in use: %v", pcc)
-		}
-		stdcli.QOSEventSend("cli-start", id, stdcli.QOSEventProperties{
-			ValidationError: err,
-			AppType:         appType,
-		})
+	// one-off commands don't need port validation
+	if len(command) == 0 {
+		if pcc, err := m.PortConflicts(); err != nil || len(pcc) > 0 {
+			if err == nil {
+				err = fmt.Errorf("ports in use: %v", pcc)
+			}
+			stdcli.QOSEventSend("cli-start", id, stdcli.QOSEventProperties{
+				ValidationError: err,
+				AppType:         appType,
+			})
 
-		return stdcli.Error(err)
+			return stdcli.Error(err)
+		}
 	}
 
 	cache := !c.Bool("no-cache")

--- a/manifest/run.go
+++ b/manifest/run.go
@@ -135,7 +135,7 @@ func (r *Run) Start() error {
 
 		if r.Opts.Command != nil && len(r.Opts.Command) > 0 && s.Name == r.Opts.Service {
 			s.Command.String = ""
-			s.Command.Array = r.Opts.Command
+			s.Command.Array = []string{"sh", "-c", strings.Join(r.Opts.Command, " ")}
 		}
 
 		p := s.Process(r.App, r.manifest)


### PR DESCRIPTION
This enables running more complex commands with the `convox start web [cmd]` syntax:

```
$ convox start web 'node -e "console.log(\"hello\")"'
...
web    │ hello
```

It does not fully address https://github.com/convox/rack/issues/1327