### PR TITLE
use provided repo proxy endpoint for logging in

### DIFF
--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -1170,7 +1170,7 @@ var cycleBuildDockerLogin = awsutil.Cycle{
 		RequestURI: "/v1.24/auth",
 		Body: `{
 			"password": "12345\n",
-			"serveraddress": "778743527532.dkr.ecr.us-east-1.amazonaws.com/convox-rails-sslibosttb",
+			"serveraddress": "https://778743527532.dkr.ecr.us-east-1.amazonaws.com",
 			"username": "user"
 		}`,
 	},


### PR DESCRIPTION
Previous method was including the repo name (`devrack-personal-httpd-fmxrisgqpk`)
in the URI and missing an explicit https protocol. Latter makes sense as it was a URI.

Before
`123456.dkr.ecr.us-east-1.amazonaws.com/rack-app-abcdefg`

After 
`https://123456.dkr.ecr.us-east-1.amazonaws.com`