### PR TITLE
invalid login links to signup

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -21,7 +21,7 @@ func (c *Client) Auth() error {
 	}
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("invalid login. Create an account at https://convox.com/signup")
+		return fmt.Errorf("invalid login\nHave you created an account at https://convox.com/signup?")
 	}
 
 	resp.Body.Close()

--- a/client/auth.go
+++ b/client/auth.go
@@ -21,7 +21,7 @@ func (c *Client) Auth() error {
 	}
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("invalid login")
+		return fmt.Errorf("invalid login. Create an account at https://convox.com/signup")
 	}
 
 	resp.Body.Close()

--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -102,7 +102,7 @@ func cmdLogin(c *cli.Context) error {
 
 	if err != nil {
 		if strings.Contains(err.Error(), "401") {
-			return stdcli.Error(fmt.Errorf("invalid login. Create an account at https://convox.com/signup"))
+			return stdcli.Error(fmt.Errorf("invalid login\nHave you created an account at https://convox.com/signup?"))
 		} else {
 			return stdcli.Error(err)
 		}

--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -102,7 +102,7 @@ func cmdLogin(c *cli.Context) error {
 
 	if err != nil {
 		if strings.Contains(err.Error(), "401") {
-			return stdcli.Error(fmt.Errorf("invalid login"))
+			return stdcli.Error(fmt.Errorf("invalid login. Create an account at https://convox.com/signup"))
 		} else {
 			return stdcli.Error(err)
 		}

--- a/cmd/convox/login_test.go
+++ b/cmd/convox/login_test.go
@@ -24,7 +24,7 @@ func TestInvalidLogin(t *testing.T) {
 			Command: fmt.Sprintf("convox login --password foobar %s", ts.URL),
 			Env:     map[string]string{"CONVOX_CONFIG": temp},
 			Exit:    1,
-			Stderr:  "ERROR: invalid login\n",
+			Stderr:  "ERROR: invalid login. Create an account at https://convox.com/signup\n",
 		},
 		test.ExecRun{
 			Command: "convox login --password foobar BAD",

--- a/cmd/convox/login_test.go
+++ b/cmd/convox/login_test.go
@@ -24,7 +24,7 @@ func TestInvalidLogin(t *testing.T) {
 			Command: fmt.Sprintf("convox login --password foobar %s", ts.URL),
 			Env:     map[string]string{"CONVOX_CONFIG": temp},
 			Exit:    1,
-			Stderr:  "ERROR: invalid login. Create an account at https://convox.com/signup\n",
+			Stderr:  "ERROR: invalid login\nHave you created an account at https://convox.com/signup?\n",
 		},
 		test.ExecRun{
 			Command: "convox login --password foobar BAD",


### PR DESCRIPTION
Copy change to the login error message. Links to a redirect that's in https://github.com/convox/site/pull/320

```
$ convox login
Password: 
ERROR: invalid login. Create an account at https://convox.com/signup
```

