### PR TITLE
Make 'convox start' respect mem_limit and cpu_shares

### DIFF
--- a/manifest/fixtures/invalid-memory-below-minimum.yml
+++ b/manifest/fixtures/invalid-memory-below-minimum.yml
@@ -1,4 +1,4 @@
 version: "2"
 services:
   web:
-    mem_limit: 2
+    mem_limit: 2m

--- a/manifest/fixtures/invalid-memory-below-minimum.yml
+++ b/manifest/fixtures/invalid-memory-below-minimum.yml
@@ -1,0 +1,4 @@
+version: "2"
+services:
+  web:
+    mem_limit: 2

--- a/manifest/fixtures/invalid-memory-has-unit.yml
+++ b/manifest/fixtures/invalid-memory-has-unit.yml
@@ -1,4 +1,0 @@
-version: "2"
-services:
-  web:
-    mem_limit: 3mb

--- a/manifest/fixtures/invalid-memory-has-unit.yml
+++ b/manifest/fixtures/invalid-memory-has-unit.yml
@@ -1,0 +1,4 @@
+version: "2"
+services:
+  web:
+    mem_limit: 3mb

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -128,14 +128,10 @@ func (m Manifest) Validate() []error {
 			}
 		}
 
-		// TODO test cpu_shares
-
-		// test mem_limit
-		// FIXME: Do we accept text labels or not?
-		mem_as_str := fmt.Sprintf("%#v", entry.Memory)
-		mem, err := strconv.Atoi(mem_as_str)
-		if err != nil || (mem < 4 && mem != 0) || mem > 10000 {
-			errors = append(errors, fmt.Errorf("%s has invalid mem_limit %s: should be a number in MB without a text unit label between 4 and 10000", entry.Name, mem_as_str))
+		// test mem_limit: Docker requires a mem_limit of at least 4mb (or 0)
+		mem_min := Memory(4194304)
+		if entry.Memory < mem_min && entry.Memory != 0 {
+			errors = append(errors, fmt.Errorf("%s has invalid mem_limit %#v: should be either 0, or at least %#v", entry.Name, entry.Memory, mem_min))
 		}
 	}
 

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/go-units"
 	"gopkg.in/yaml.v2"
 )
 
@@ -129,9 +130,15 @@ func (m Manifest) Validate() []error {
 		}
 
 		// test mem_limit: Docker requires a mem_limit of at least 4mb (or 0)
-		mem_min := Memory(4194304)
-		if entry.Memory < mem_min && entry.Memory != 0 {
-			errors = append(errors, fmt.Errorf("%s has invalid mem_limit %#v: should be either 0, or at least %#v", entry.Name, entry.Memory, mem_min))
+		mem_min := Memory(units.MB * 4)
+		mem := entry.Memory
+
+		if mem < mem_min && mem != 0 { //Memory(0) {
+			e := fmt.Errorf("%s has invalid mem_limit %#v: should be either 0, or at least %#vMB",
+								entry.Name,
+								mem / units.MB,
+								mem_min / units.MB)
+			errors = append(errors, e)
 		}
 	}
 

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -127,6 +127,16 @@ func (m Manifest) Validate() []error {
 				errors = append(errors, fmt.Errorf("%s links to service: %s which does not expose any ports", entry.Name, l))
 			}
 		}
+
+		// TODO test cpu_shares
+
+		// test mem_limit
+		// FIXME: Do we accept text labels or not?
+		mem_as_str := fmt.Sprintf("%#v", entry.Memory)
+		mem, err := strconv.Atoi(mem_as_str)
+		if err != nil || (mem < 4 && mem != 0) || mem > 10000 {
+			errors = append(errors, fmt.Errorf("%s has invalid mem_limit %s: should be a number in MB without a text unit label between 4 and 10000", entry.Name, mem_as_str))
+		}
 	}
 
 	return errors

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -515,19 +515,6 @@ func TestManifestValidate(t *testing.T) {
 		assert.Equal(t, herr[0].Error(), "convox.health.timeout is invalid for web, must be a number between 0 and 60")
 	}
 
-	// test mem_limit
-	m, err = manifestFixture("invalid-memory-has-unit")
-	if err != nil {
-		t.Error(err.Error())
-		return
-	}
-
-	merru := m.Validate()
-	if assert.NotNil(t, merru) {
-		// FIXME: Fixture says "3mb" not 3145728
-		assert.Equal(t, merru[0].Error(), "web has invalid mem_limit 3145728: should be a number in MB without a text unit label between 4 and 10000")
-	}
-
 	m, err = manifestFixture("invalid-memory-below-minimum")
 	if err != nil {
 		t.Error(err.Error())
@@ -536,7 +523,7 @@ func TestManifestValidate(t *testing.T) {
 
 	merrm := m.Validate()
 	if assert.NotNil(t, merrm) {
-		assert.Equal(t, merrm[0].Error(), "web has invalid mem_limit 2: should be a number in MB without a text unit label between 4 and 10000")
+		assert.Equal(t, merrm[0].Error(), "web has invalid mem_limit 2097152: should be either 0, or at least 4194304")
 	}
 }
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -523,7 +523,7 @@ func TestManifestValidate(t *testing.T) {
 
 	merrm := m.Validate()
 	if assert.NotNil(t, merrm) {
-		assert.Equal(t, merrm[0].Error(), "web has invalid mem_limit 2097152: should be either 0, or at least 4194304")
+		assert.Equal(t, merrm[0].Error(), "web has invalid mem_limit 2: should be either 0, or at least 4MB")
 	}
 }
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -524,7 +524,8 @@ func TestManifestValidate(t *testing.T) {
 
 	merru := m.Validate()
 	if assert.NotNil(t, merru) {
-		assert.Equal(t, merru[0].Error(), "web has invalid mem_limit 3mb: should be a number in MB without a text unit label between 4 and 10000")
+		// FIXME: Fixture says "3mb" not 3145728
+		assert.Equal(t, merru[0].Error(), "web has invalid mem_limit 3145728: should be a number in MB without a text unit label between 4 and 10000")
 	}
 
 	m, err = manifestFixture("invalid-memory-below-minimum")

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -514,6 +514,29 @@ func TestManifestValidate(t *testing.T) {
 	if assert.NotNil(t, herr) {
 		assert.Equal(t, herr[0].Error(), "convox.health.timeout is invalid for web, must be a number between 0 and 60")
 	}
+
+	// test mem_limit
+	m, err = manifestFixture("invalid-memory-has-unit")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	merru := m.Validate()
+	if assert.NotNil(t, merru) {
+		assert.Equal(t, merru[0].Error(), "web has invalid mem_limit 3mb: should be a number in MB without a text unit label between 4 and 10000")
+	}
+
+	m, err = manifestFixture("invalid-memory-below-minimum")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	merrm := m.Validate()
+	if assert.NotNil(t, merrm) {
+		assert.Equal(t, merrm[0].Error(), "web has invalid mem_limit 2: should be a number in MB without a text unit label between 4 and 10000")
+	}
 }
 
 func manifestFixture(name string) (*manifest.Manifest, error) {

--- a/manifest/process.go
+++ b/manifest/process.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/convox/rack/sync"
@@ -85,6 +86,14 @@ func NewProcess(app string, s Service, m Manifest) Process {
 			volume = fmt.Sprintf("%s:%s", hostPath, volume)
 		}
 		args = append(args, "-v", volume)
+	}
+
+	if s.Cpu != 0 {
+		args = append(args, "--cpu-shares",  strconv.FormatInt(s.Cpu, 10))
+	}
+
+	if s.Memory != 0 {
+		args = append(args, "--memory", fmt.Sprintf("%#vMB", s.Memory))
 	}
 
 	args = append(args, s.Tag(app))

--- a/manifest/process.go
+++ b/manifest/process.go
@@ -93,7 +93,7 @@ func NewProcess(app string, s Service, m Manifest) Process {
 	}
 
 	if s.Memory != 0 {
-		args = append(args, "--memory", fmt.Sprintf("%#vMB", s.Memory))
+		args = append(args, "--memory", fmt.Sprintf("%#v", s.Memory))
 	}
 
 	args = append(args, s.Tag(app))


### PR DESCRIPTION
Currently, convox only reads `cpu_shares` and `mem_limit` from `docker-compose.yml` when a user runs `convox deploy`. It doesn't read those keys when running locally via `convox start`.

This PR is intended to make `convox start` read and respect those values.

**Point of confusion regarding `mem_limit`:** Earlier this week, I was under the impression that convox needed this to be an integer (i.e. without a text label), and treated it as MB. But while testing, it seems like convox can in fact convert unit labels? If someone could help me understand the current behavior, that would be much appreciated. (Edit: Maybe it's just the fact that I'm [appending `MB` here](https://github.com/convox/rack/blob/25ec6602eb5ffeef33c57237af751cadf0234255/manifest/process.go#L96)).

**Feedback needed:** I attempted to add a test for `mem_limit`, and would like to get some feedback before adding a test for `cpu_shares`.

FYI: These keys `cpu_shares` and `mem_limit` are read only once, during the first run of `convox deploy`; subsequent deploys do not re-read them if they are changed in `docker-compose.yml`. That's not addressed in this PR, though.)
