### PR TITLE
paging support for describing stacks

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -34,7 +34,6 @@ type Apps []App
 
 func ListApps() (Apps, error) {
 	res, err := DescribeStacks()
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If the output from `DescribeStacks` exceeds 1 MB in size, we wouldn't have all the stacks in Cloudformation. This change adds next token ("paging") support.