### PR TITLE
create release using provider API

### DIFF
--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -226,26 +226,8 @@ func build(dir string) error {
 }
 
 func success() error {
-	release := &structs.Release{
-		App: flagApp,
-	}
-
-	// TODO use provider.ReleaseFork()
-
-	if flagRelease != "" {
-		r, err := currentProvider.ReleaseGet(flagApp, flagRelease)
-		if err != nil {
-			return err
-		}
-		release = r
-	}
-
-	release.Build = flagId
-	release.Created = time.Now()
-	release.Id = id("R", 10)
-	release.Manifest = currentBuild.Manifest
-
-	if err := currentProvider.ReleaseSave(release); err != nil {
+	_, err := currentProvider.BuildRelease(currentBuild)
+	if err != nil {
 		return err
 	}
 
@@ -256,7 +238,6 @@ func success() error {
 
 	currentBuild.Ended = time.Now()
 	currentBuild.Logs = url
-	currentBuild.Release = release.Id
 	currentBuild.Status = "complete"
 
 	if err := currentProvider.BuildSave(currentBuild); err != nil {

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -19,15 +19,14 @@ import (
 )
 
 var (
-	flagApp     string
-	flagAuth    string
-	flagCache   string
-	flagId      string
-	flagConfig  string
-	flagMethod  string
-	flagPush    string
-	flagRelease string
-	flagUrl     string
+	flagApp    string
+	flagAuth   string
+	flagCache  string
+	flagId     string
+	flagConfig string
+	flagMethod string
+	flagPush   string
+	flagUrl    string
 
 	currentBuild    *structs.Build
 	currentLogs     string
@@ -54,7 +53,6 @@ func main() {
 	fs.StringVar(&flagId, "id", "latest", "build id")
 	fs.StringVar(&flagMethod, "method", "", "source method")
 	fs.StringVar(&flagPush, "push", "", "push to registry")
-	fs.StringVar(&flagRelease, "release", "", "release id to fork")
 	fs.StringVar(&flagUrl, "url", "", "source url")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -79,10 +77,6 @@ func main() {
 
 	if v := os.Getenv("BUILD_PUSH"); v != "" {
 		flagPush = v
-	}
-
-	if v := os.Getenv("BUILD_RELEASE"); v != "" {
-		flagRelease = v
 	}
 
 	if v := os.Getenv("BUILD_URL"); v != "" {

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -797,10 +797,6 @@ func (p *AWSProvider) runBuild(build *structs.Build, method, url string, opts st
 							Value: aws.String(push),
 						},
 						&ecs.KeyValuePair{
-							Name:  aws.String("BUILD_RELEASE"),
-							Value: aws.String(a.Release),
-						},
-						&ecs.KeyValuePair{
 							Name:  aws.String("BUILD_URL"),
 							Value: aws.String(url),
 						},

--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -1079,10 +1079,6 @@ var cycleBuildRunTask = awsutil.Cycle{
 								"value": "132866487567.dkr.ecr.us-test-1.amazonaws.com/convox-httpd-hqvvfosgxt:{service}.{build}"
 							},
 							{
-								"name": "BUILD_RELEASE",
-								"value": "RVFETUHHKKD"
-							},
-							{
 								"name": "BUILD_URL",
 								"value": "http://example.org/build.tgz"
 							},


### PR DESCRIPTION
This fix would address the #1349 where new environment variables aren't picked up in the next deploy.