### PR TITLE
Configure ASG lifecycle for instance launch

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1031,6 +1031,7 @@
               "  - ", { "Ref": "InstanceRunCommand" }, "\n"
               ] ] }
             ] },
+            "  - /usr/bin/aws autoscaling complete-lifecycle-action --lifecycle-hook-name InstancesLifecycleStarting --auto-scaling-group-name ", {"Ref":"Instances"}," --lifecycle-action-result CONTINUE\n"
             "  - /opt/aws/bin/cfn-signal --stack ", { "Ref": "AWS::StackName" }, " --region ", {"Ref":"AWS::Region"}, " --resource Instances\n"
           ] ] }
         }
@@ -1092,6 +1093,14 @@
           ],
           "WaitOnResourceSignals": "true"
         }
+      }
+    },
+    "InstancesLifecycleStarting": {
+      "Type": "AWS::AutoScaling::LifecycleHook",
+      "Properties": {
+        "AutoScalingGroupName": { "Ref": "Instances" },
+        "HeartbeatTimeout": "900",
+        "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING"
       }
     },
     "InstancesLifecycle": {

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1032,7 +1032,7 @@
               ] ] }
             ] },
             "  - export INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)\n",
-            "  - export AUTO_SCALING_GROUP_NAME=$(aws autoscaling describe-auto-scaling-instances --instance-ids=$INSTANCE_ID --query 'AutoScalingInstances[0].AutoScalingGroupName' --output text --region us-east-1)\n",
+            "  - export AUTO_SCALING_GROUP_NAME=$(/usr/bin/aws autoscaling describe-auto-scaling-instances --instance-ids=$INSTANCE_ID --query 'AutoScalingInstances[0].AutoScalingGroupName' --output text --region us-east-1)\n",
             "  - /usr/bin/aws autoscaling complete-lifecycle-action --lifecycle-hook-name InstancesLifecycleStarting --auto-scaling-group-name $AUTO_SCALING_GROUP_NAME --lifecycle-action-result CONTINUE\n",
             "  - /opt/aws/bin/cfn-signal --stack ", { "Ref": "AWS::StackName" }, " --region ", {"Ref":"AWS::Region"}, " --resource Instances\n"
           ] ] }

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1031,7 +1031,7 @@
               "  - ", { "Ref": "InstanceRunCommand" }, "\n"
               ] ] }
             ] },
-            "  - /usr/bin/aws autoscaling complete-lifecycle-action --lifecycle-hook-name InstancesLifecycleStarting --auto-scaling-group-name ", {"Ref":"Instances"}," --lifecycle-action-result CONTINUE\n"
+            "  - /usr/bin/aws autoscaling complete-lifecycle-action --lifecycle-hook-name InstancesLifecycleStarting --auto-scaling-group-name ", {"Ref":"Instances"}," --lifecycle-action-result CONTINUE\n",
             "  - /opt/aws/bin/cfn-signal --stack ", { "Ref": "AWS::StackName" }, " --region ", {"Ref":"AWS::Region"}, " --resource Instances\n"
           ] ] }
         }

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1031,7 +1031,9 @@
               "  - ", { "Ref": "InstanceRunCommand" }, "\n"
               ] ] }
             ] },
-            "  - /usr/bin/aws autoscaling complete-lifecycle-action --lifecycle-hook-name InstancesLifecycleStarting --auto-scaling-group-name ", {"Ref":"Instances"}," --lifecycle-action-result CONTINUE\n",
+            "  - export INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)\n",
+            "  - export AUTO_SCALING_GROUP_NAME=$(aws autoscaling describe-auto-scaling-instances --instance-ids=$INSTANCE_ID --query 'AutoScalingInstances[0].AutoScalingGroupName' --output text --region us-east-1)\n",
+            "  - /usr/bin/aws autoscaling complete-lifecycle-action --lifecycle-hook-name InstancesLifecycleStarting --auto-scaling-group-name $AUTO_SCALING_GROUP_NAME --lifecycle-action-result CONTINUE\n",
             "  - /opt/aws/bin/cfn-signal --stack ", { "Ref": "AWS::StackName" }, " --region ", {"Ref":"AWS::Region"}, " --resource Instances\n"
           ] ] }
         }


### PR DESCRIPTION
* Define a new `autoscaling:EC2_INSTANCE_LAUNCHING` transition
* Mark lifecycle as complete at end of UserData right before sending CFN success signal

This should help resolve the issue with instances being marked unhealthy immediately after launching if you have a bootstrap script running which takes a couple of minutes.

The problem was that instances are being moved into `InService` state in the ASG before their UserData has completed - and the `convox/monitor` gets a list of `InService` instances from the ASG and compares them to the registered instances in ECS to determine if the ECS agent is connected.

If you have a multiple minute bootstrap script, the ECS agent is often not started before the monitor runs (currently every 5 minutes).

If we configure an ASG lifecycle for instance launch, it shouldn't move into `InService` until the UserData has completed and the ECS agent can launch.