### PR TITLE
Rack instance count must be >= 3

### DIFF
--- a/api/controllers/system.go
+++ b/api/controllers/system.go
@@ -56,8 +56,8 @@ func SystemUpdate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 			return httperr.Errorf(403, "scaling count prohibited when autoscale enabled")
 		case c == -1:
 			// -1 indicates no change
-		case c <= 1:
-			return httperr.Errorf(403, "count must be greater than 1")
+		case c <= 2:
+			return httperr.Errorf(403, "count must be greater than 2")
 		default:
 			rack.Count = c
 		}

--- a/api/controllers/system_test.go
+++ b/api/controllers/system_test.go
@@ -204,7 +204,30 @@ func TestSystemUpdateBadCount(t *testing.T) {
 
 		if assert.Nil(t, hf.Request("PUT", "/system", v)) {
 			hf.AssertCode(t, 403)
-			hf.AssertError(t, "count must be greater than 1")
+			hf.AssertError(t, "count must be greater than 2")
+		}
+	})
+
+	models.Test(t, func() {
+		before := &structs.System{
+			Count:   3,
+			Name:    "test",
+			Region:  "us-test-1",
+			Status:  "running",
+			Type:    "t2.small",
+			Version: "dev",
+		}
+
+		models.TestProvider.On("SystemGet").Return(before, nil)
+
+		hf := test.NewHandlerFunc(controllers.HandlerFunc)
+
+		v := url.Values{}
+		v.Add("count", "2")
+
+		if assert.Nil(t, hf.Request("PUT", "/system", v)) {
+			hf.AssertCode(t, 403)
+			hf.AssertError(t, "count must be greater than 2")
 		}
 	})
 }

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -180,8 +180,8 @@ func cmdInstall(c *cli.Context) error {
 
 	numInstances := c.Int("instance-count")
 	instanceCount := fmt.Sprintf("%d", numInstances)
-	if numInstances < 2 {
-		stdcli.Error(fmt.Errorf("instance-count must be greater than 1"))
+	if numInstances <= 2 {
+		return stdcli.Error(fmt.Errorf("instance-count must be greater than 2"))
 	}
 
 	var subnet0CIDR, subnet1CIDR, subnet2CIDR string

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -260,7 +260,7 @@
     "InstanceCount": {
       "Default": "3",
       "Description": "The number of instances in the runtime cluster",
-      "MinValue": "2",
+      "MinValue": "3",
       "Type": "Number"
     },
     "InstanceType": {


### PR DESCRIPTION
Enforce minimum of 3 Rack instances instead of 2.

A Rack with an instance count <= 2 will have to bump the instance count to at least 3 before updating.