### PR TITLE
Add last line to docker error

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -44,13 +44,11 @@ func New(host, password, version string) *Client {
 
 func (c *Client) Get(path string, out interface{}) error {
 	req, err := c.request("GET", path, nil)
-
 	if err != nil {
 		return err
 	}
 
 	res, err := c.client().Do(req)
-
 	if err != nil {
 		return err
 	}

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -185,15 +185,13 @@ func (p *AWSProvider) BuildExport(app, id string, w io.Writer) error {
 		log.Step("pull").Logf("image=%q", image)
 		out, err := exec.Command("docker", "pull", image).CombinedOutput()
 		if err != nil {
-			log.Error(fmt.Errorf(lastline(out)))
-			return err
+			return log.Error(fmt.Errorf("%s: %s\n", lastline(out), err.Error()))
 		}
 
 		log.Step("save").Logf("image=%q file=%q", image, file)
 		out, err = exec.Command("docker", "save", "-o", file, image).CombinedOutput()
 		if err != nil {
-			log.Error(fmt.Errorf(lastline(out)))
-			return err
+			return log.Error(fmt.Errorf("%s: %s\n", lastline(out), err.Error()))
 		}
 
 		stat, err := os.Stat(file)
@@ -371,14 +369,12 @@ func (p *AWSProvider) BuildImport(app string, r io.Reader) (*structs.Build, erro
 
 			log.Step("tag").Logf("from=%q to=%q", image, target)
 			if out, err := exec.Command("docker", "tag", image, target).CombinedOutput(); err != nil {
-				log.Errorf(lastline(out))
-				return nil, err
+				return nil, log.Error(fmt.Errorf("%s: %s\n", lastline(out), err.Error()))
 			}
 
 			log.Step("push").Logf("to=%q", target)
 			if out, err := exec.Command("docker", "push", target).CombinedOutput(); err != nil {
-				log.Errorf(lastline(out))
-				return nil, err
+				return nil, log.Error(fmt.Errorf("%s: %s\n", lastline(out), err.Error()))
 			}
 		}
 	}
@@ -980,15 +976,13 @@ func (p *AWSProvider) dockerLogin() error {
 
 	registry, err := url.Parse(*tres.AuthorizationData[0].ProxyEndpoint)
 	if err != nil {
-		log.Error(err)
-		return err
+		return log.Error(err)
 	}
 
 	log.Step("login").Logf("host=%q user=%q", registry.Host, authParts[0])
 	out, err := exec.Command("docker", "login", "-u", authParts[0], "-p", authParts[1], registry.Host).CombinedOutput()
 	if err != nil {
-		log.Errorf(lastline(out))
-		return err
+		return log.Error(fmt.Errorf("%s: %s\n", lastline(out), err.Error()))
 	}
 
 	log.Success()

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -978,10 +978,14 @@ func (p *AWSProvider) dockerLogin() error {
 		return fmt.Errorf("invalid auth data")
 	}
 
-	repo := *tres.AuthorizationData[0].ProxyEndpoint
+	registry, err := url.Parse(*tres.AuthorizationData[0].ProxyEndpoint)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
 
-	log.Step("login").Logf("host=%q user=%q", repo, authParts[0])
-	out, err := exec.Command("docker", "login", "-u", authParts[0], "-p", authParts[1], repo).CombinedOutput()
+	log.Step("login").Logf("host=%q user=%q", registry.Host, authParts[0])
+	out, err := exec.Command("docker", "login", "-u", authParts[0], "-p", authParts[1], registry.Host).CombinedOutput()
 	if err != nil {
 		log.Errorf(lastline(out))
 		return err

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -338,7 +338,6 @@ func (p *AWSProvider) BuildImport(app string, r io.Reader) (*structs.Build, erro
 
 			cmd.Stdin = pr
 			cmd.Stdout = outb
-			cmd.Stderr = cmd.Stdout
 
 			if err := cmd.Start(); err != nil {
 				log.Error(err)
@@ -358,8 +357,7 @@ func (p *AWSProvider) BuildImport(app string, r io.Reader) (*structs.Build, erro
 			}
 
 			if err := cmd.Wait(); err != nil {
-				log.Errorf(lastline(outb.Bytes()))
-				return nil, err
+				return nil, log.Errorf("%s: %s\n", lastline(outb.Bytes()), err.Error())
 			}
 
 			if len(manifest) != 1 || len(manifest[0].RepoTags) != 1 {

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -338,6 +338,7 @@ func (p *AWSProvider) BuildImport(app string, r io.Reader) (*structs.Build, erro
 
 			cmd.Stdin = pr
 			cmd.Stdout = outb
+			cmd.Stderr = cmd.Stdout
 
 			if err := cmd.Start(); err != nil {
 				log.Error(err)

--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -1166,7 +1166,7 @@ var cycleBuildDockerLogin = awsutil.Cycle{
 		RequestURI: "/v1.24/auth",
 		Body: `{
 			"password": "12345\n",
-			"serveraddress": "https://778743527532.dkr.ecr.us-east-1.amazonaws.com",
+			"serveraddress": "778743527532.dkr.ecr.us-east-1.amazonaws.com",
 			"username": "user"
 		}`,
 	},


### PR DESCRIPTION
The previous error returned could be a vague "exit status 1". This way we get a more detailed error message.