### PR TITLE
Add service creation and deletion tests.

### DIFF
--- a/cmd/convox/services_test.go
+++ b/cmd/convox/services_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+
+    "github.com/convox/rack/client"
+    "github.com/convox/rack/test"
+)
+
+func TestServices(t *testing.T) {
+	ts := testServer(t,
+		test.Http{Method: "GET", Path: "/services", Code: 200, Response: client.Services{
+			client.Service{Name: "syslog-1234", Type: "syslog", Status: "running"},
+		}},
+	)
+
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox services",
+			Exit:	 0,
+			Stdout:	 "NAME         TYPE    STATUS\nsyslog-1234  syslog  running\n",
+		},
+	)
+}
+
+func TestServicesCreate(t *testing.T) {
+    ts := testServer(t,
+        test.Http{Method: "POST", Path: "/services", Body: "name=syslog-1234&type=syslog&url=tcp%2Btls%3A%2F%2Flogs1.example.com%3A12345", Code: 200, Response: client.Service{}},
+    )
+
+    defer ts.Close()
+
+    test.Runs(t,
+        test.ExecRun{
+            Command: "convox services create syslog --name=syslog-1234 --url=tcp+tls://logs1.example.com:12345",
+            Exit:    0,
+            Stdout:  "Creating syslog-1234 (syslog: name=\"syslog-1234\" url=\"tcp+tls://logs1.example.com:12345\")... CREATING\n",
+        },
+    )
+}
+
+func TestServicesDelete(t *testing.T) {
+
+	ts := testServer(t,
+		test.Http{Method: "GET", Path: "/services", Code: 200, Response: client.Services{
+			client.Service{Name: "syslog-1234", Type: "syslog", Status: "running"},
+		}},
+	)
+
+	defer ts.Close()
+
+    tsd := testServer(t,
+        test.Http{Method: "DELETE", Path: "/services/syslog-1234", Code: 200, Response: client.Service{}},
+    )
+
+    defer tsd.Close()
+
+    test.Runs(t,
+        test.ExecRun{
+            Command: "convox services delete syslog-1234",
+            Exit:    0,
+            Stdout:  "Deleting syslog-1234... DELETING\n",
+        },
+    )
+}
+


### PR DESCRIPTION
1. I can't reproduce reliably, but sometimes I get failures such as the following, where the content is correct but the keys are in the wrong order:

```
$ go test github.com/convox/rack/cmd/convox 
--- FAIL: TestServicesCreate (0.03s)
        Error Trace:    exec.go:37
	Error:		Not equal: "Creating syslog-1234 (syslog: name=\"syslog-1234\" url=\"tcp+tls://logs1.example.com:12345\")... CREATING\n" (expected)
			        != "Creating syslog-1234 (syslog: url=\"tcp+tls://logs1.example.com:12345\" name=\"syslog-1234\")... CREATING\n" (actual)
	Messages:	stdout should be equal
		
FAIL
FAIL	github.com/convox/rack/cmd/convox	2.090s
```

I tried adding a line `sort.Strings(optionsList)` after [line 215 in services.go](https://github.com/convox/rack/blob/master/cmd/convox/services.go#L215) but the issue still occurred (seemingly randomly). 
 
2. Please review in particular `TestServicesDelete`. I couldn't find another example in the code where we `DELETE` something, so I'm not sure how to go about creating a test case.