### PR TITLE
Reuse certs

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -62,17 +62,19 @@ After this, `which convox` should refer to `$GOPATH/bin/convox`.
 
 The local Rack is running an API process that has AWS Access Keys, AWS resource names, and other various settings in its environment. You need to copy this to your laptop.
 
+First update the CloudFormation stack `Development` parameter to `Yes`. 
+```
+convox rack params set Development=Yes
+```
+
+Then run:
+
 ```
 $ cd $GOPATH/src/github.com/convox/rack
 
 # Introspect the dev rack to find the PID of the API web process
-
 $ STACK_NAME=$(convox api get /system | jq -r .name)
-$ WEB_PID=$(convox api get /apps/$STACK_NAME/processes | jq -r '.[] | select(.name == "web") | .id' | head -1)
-
-# Introspect the API web process to get its environment
-
-$ convox exec $WEB_PID env --app $STACK_NAME > .env
+$ bin/export-env $STACK_NAME > .env
 ```
 
 Now you have a bunch of secrets that will let you interact with AWS APIs from your laptop:

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -175,6 +175,10 @@
         { "Ref": "Vpc" },
         { "Ref": "ExistingVpc" }
       ] }
+    },
+    "VPCCIDR": {
+      "Condition": "Development",
+      "Value": { "Ref": "VPCCIDR" }
     }
   },
   "Parameters": {


### PR DESCRIPTION
# Demo

```bash
# no certs exist
$ convox certs
ID                DOMAIN       EXPIRES

$ cd convox-guide
$ convox apps create

# first deploy creates a cert and SSL endpoints
$ convox deploy
...
Promoting RZEXQRXNHTI... UPDATING

$ convox apps info
Name       convox-guide
Status     running
Release    RZEXQRXNHTI
Processes  redis web worker
Endpoints  convox-guide-web-NQKTDIJ-553968778.us-east-1.elb.amazonaws.com:80 (web)
           convox-guide-web-NQKTDIJ-553968778.us-east-1.elb.amazonaws.com:443 (web)
           internal-convox-guide-redis-FGGZQIL-i-518573721.us-east-1.elb.amazonaws.com:6379 (redis)

$ convox certs
ID                              DOMAIN                 EXPIRES
cert-dev-east-1479341785-53506  *.*.elb.amazonaws.com  1 year from now

# second app create / deploy reuses the cert
$ convox apps create guide2
$ convox deploy --app guide2

$ convox apps info
Name       guide2
Status     running
Release    RZEXQRXNHTI
Processes  redis web worker
Endpoints  guide2-web-NQKTDIJ-553968778.us-east-1.elb.amazonaws.com:80 (web)
           guide2-web-NQKTDIJ-553968778.us-east-1.elb.amazonaws.com:443 (web)
           internal-guide2-redis-FGGZQIL-i-518573721.us-east-1.elb.amazonaws.com:6379 (redis)


$ convox certs
ID                              DOMAIN                 EXPIRES
cert-dev-east-1479341785-53506  *.*.elb.amazonaws.com  1 year from now
```