### PR TITLE
Make 'convox services create' respect '-h' flag.

### DIFF
--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -181,7 +181,7 @@ func cmdServiceCreate(c *cli.Context) error {
 
 	t := c.Args()[0]
 
-	if t == "help" || t == "--help" {
+	if t == "help" || t == "--help" || t == "-h" {
 		stdcli.Usage(c, "create")
 		return nil
 	}


### PR DESCRIPTION
Current behavior:

```
$ convox services create -h
Creating -h-6179 (-h)... ERROR: Invalid service type: -h
```

New behavior:

```
$ convox services create -h
convox services create: create a new service.

Usage:
  convox services create <type> [--name=value] [--option-name=value]

Supported types / options:
  memcached   [--instance-type=db.t2.micro] [--num-cache-nodes=1] [--private]
[...]
```