### PR TITLE
Fix disconnected agent

### DIFF
--- a/api/workers/cluster.go
+++ b/api/workers/cluster.go
@@ -67,6 +67,7 @@ func StartCluster() {
 
 				if !seenBefore {
 					disconnectedInstances[i.Id] = struct{}{}
+					fmt.Printf("who=\"convox/monitor\" what=\"instance %s missed it's first heartbeat\" why=\"ECS reported agent disconnected\"\n", i.Id)
 					continue
 				}
 				// Not registered or not connected => set Unhealthy

--- a/api/workers/cluster.go
+++ b/api/workers/cluster.go
@@ -37,6 +37,7 @@ func StartCluster() {
 		helpers.Error(log, err)
 	})
 
+	disconnectedInstances := map[string]struct{}{}
 	for range time.Tick(5 * time.Minute) {
 		log.Logf("tick")
 
@@ -62,6 +63,12 @@ func StartCluster() {
 			}
 
 			if !i.ECS {
+				_, seenBefore := disconnectedInstances[i.Id]
+
+				if !seenBefore {
+					disconnectedInstances[i.Id] = struct{}{}
+					continue
+				}
 				// Not registered or not connected => set Unhealthy
 				_, err := models.AutoScaling().SetInstanceHealth(
 					&autoscaling.SetInstanceHealthInput{
@@ -82,6 +89,7 @@ func StartCluster() {
 				// log for humans
 				fmt.Printf("who=\"convox/monitor\" what=\"marked instance %s unhealthy\" why=\"ECS reported agent disconnected\"\n", i.Id)
 			}
+			delete(disconnectedInstances, i.Id)
 		}
 
 		log.Logf(instances.log())


### PR DESCRIPTION
waits for missed heartbeats before terminating an instance