### PR TITLE
Existing VPC updates

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -104,6 +104,11 @@ func init() {
 				Value: "t2.small",
 				Usage: "type of instances in the rack",
 			},
+			cli.StringFlag{
+				Name:  "internet-gateway",
+				Value: "",
+				Usage: "internet gateway id to use in existing vpc",
+			},
 			cli.BoolFlag{
 				Name:  "private",
 				Usage: "use private subnets and NAT gateways to shield instances",
@@ -214,6 +219,10 @@ func cmdInstall(c *cli.Context) error {
 
 	if vpc := c.String("existing-vpc"); vpc != "" {
 		existingVPC = vpc
+	}
+
+	if (existingVPC != "") && (c.String("internet-gateway") == "") {
+		return stdcli.Error(fmt.Errorf("must specify valid Internet Gateway for existing VPC"))
 	}
 
 	private := "No"

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -142,10 +142,18 @@
       }
     },
     "SubnetsPrivate": {
-      "Value": { "Fn::If": [ "Private",
-        { "Fn::Join": [ ",", [ { "Ref": "SubnetPrivate0" }, { "Ref": "SubnetPrivate1" }, { "Ref": "SubnetPrivate2" } ] ] },
-        ""
-      ] }
+      "Value": { "Fn::If":
+        [ "Private",
+          { "Fn::Join": [ ",",
+            [
+              { "Ref": "SubnetPrivate0" },
+              { "Ref": "SubnetPrivate1" },
+              { "Fn::If": [ "PrivateAndThirdAvailabilityZone", { "Ref": "SubnetPrivate2" }, { "Ref": "AWS::NoValue" } ] }
+            ],
+            ""
+          ]}
+        ]
+      }
     },
     "StackId": {
       "Value": { "Ref": "AWS::StackId" }

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -581,7 +581,6 @@
     },
     "GatewayAttachment": {
       "Type": "AWS::EC2::VPCGatewayAttachment",
-      "Condition": "BlankExistingVpc",
       "Properties": {
         "InternetGatewayId": { "Fn::If": [ "BlankExistingVpc",
           { "Ref": "Gateway" },

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -581,6 +581,7 @@
     },
     "GatewayAttachment": {
       "Type": "AWS::EC2::VPCGatewayAttachment",
+      "DeletionPolicy": "Retain",
       "Properties": {
         "InternetGatewayId": { "Fn::If": [ "BlankExistingVpc",
           { "Ref": "Gateway" },

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -581,16 +581,19 @@
     },
     "GatewayAttachment": {
       "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Condition": "BlankExistingVpc",
+      "Properties": {
+        "InternetGatewayId": { "Ref": "Gateway" },
+        "VpcId": { "Ref": "Vpc" }
+      }
+    },
+    "ExistingGatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Condition": "ExistingVpc",
       "DeletionPolicy": "Retain",
       "Properties": {
-        "InternetGatewayId": { "Fn::If": [ "BlankExistingVpc",
-          { "Ref": "Gateway" },
-          { "Ref": "InternetGateway" }
-        ] },
-        "VpcId": { "Fn::If": [ "BlankExistingVpc",
-          { "Ref": "Vpc" },
-          { "Ref": "ExistingVpc" }
-        ] }
+        "InternetGatewayId": { "Ref": "InternetGateway" },
+        "VpcId": { "Ref": "ExistingVpc" }
       }
     },
     "Nat0": {
@@ -733,7 +736,6 @@
       }
     },
     "Routes": {
-      "DependsOn": [ "GatewayAttachment" ],
       "Type": "AWS::EC2::RouteTable",
       "Properties": {
         "VpcId": { "Fn::If": [ "BlankExistingVpc",
@@ -743,7 +745,7 @@
       }
     },
     "RouteDefault": {
-      "DependsOn": [ "GatewayAttachment", "Routes" ],
+      "DependsOn": [ "Routes" ],
       "Type": "AWS::EC2::Route",
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -258,6 +258,11 @@
       "MinValue": "1",
       "Type": "Number"
     },
+    "InternetGateway": {
+      "Description": "The InternetGatway to route to if an Existing VPC is specified",
+      "Type": "String",
+      "Default": ""
+    },
     "Key": {
       "Default": "",
       "Description": "SSH key name for access to cluster instances",
@@ -575,12 +580,17 @@
       }
     },
     "GatewayAttachment": {
-      "DependsOn": [ "Gateway", "Vpc" ],
       "Type": "AWS::EC2::VPCGatewayAttachment",
       "Condition": "BlankExistingVpc",
       "Properties": {
-        "InternetGatewayId": { "Ref": "Gateway" },
-        "VpcId": { "Ref": "Vpc" }
+        "InternetGatewayId": { "Fn::If": [ "BlankExistingVpc",
+          { "Ref": "Gateway" },
+          { "Ref": "InternetGateway" }
+        ] },
+        "VpcId": { "Fn::If": [ "BlankExistingVpc",
+          { "Ref": "Vpc" },
+          { "Ref": "ExistingVpc" }
+        ] }
       }
     },
     "Nat0": {
@@ -723,20 +733,24 @@
       }
     },
     "Routes": {
-      "DependsOn": [ "Gateway", "GatewayAttachment", "Vpc" ],
+      "DependsOn": [ "GatewayAttachment" ],
       "Type": "AWS::EC2::RouteTable",
-      "Condition": "BlankExistingVpc",
       "Properties": {
-        "VpcId": { "Ref": "Vpc" }
+        "VpcId": { "Fn::If": [ "BlankExistingVpc",
+          { "Ref": "Vpc" },
+          { "Ref": "ExistingVpc" }
+        ] }
       }
     },
     "RouteDefault": {
-      "DependsOn": [ "Gateway", "GatewayAttachment", "Routes" ],
+      "DependsOn": [ "GatewayAttachment", "Routes" ],
       "Type": "AWS::EC2::Route",
-      "Condition": "BlankExistingVpc",
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
-        "GatewayId": { "Ref": "Gateway" },
+        "GatewayId": { "Fn::If": [ "BlankExistingVpc",
+          { "Ref": "Gateway" },
+          { "Ref": "InternetGateway" }
+        ] },
         "RouteTableId": { "Ref": "Routes" }
       }
     },
@@ -804,7 +818,6 @@
       }
     },
     "Subnet0Routes": {
-      "Condition": "BlankExistingVpc",
       "DependsOn": [ "Subnet0", "Routes" ],
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {
@@ -813,7 +826,6 @@
       }
     },
     "Subnet1Routes": {
-      "Condition": "BlankExistingVpc",
       "DependsOn": [ "Subnet1", "Routes" ],
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {
@@ -822,7 +834,6 @@
       }
     },
     "Subnet2Routes": {
-      "Condition": "BlankExistingVpcAndThirdAvailabilityZone",
       "DependsOn": [ "Subnet2", "Routes" ],
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -148,10 +148,10 @@
             [
               { "Ref": "SubnetPrivate0" },
               { "Ref": "SubnetPrivate1" },
-              { "Fn::If": [ "PrivateAndThirdAvailabilityZone", { "Ref": "SubnetPrivate2" }, { "Ref": "AWS::NoValue" } ] }
-            ],
-            ""
-          ]}
+              { "Fn::If": [ "ThirdAvailabilityZone", { "Ref": "SubnetPrivate2" }, { "Ref": "AWS::NoValue" } ] }
+            ]
+          ]},
+          ""
         ]
       }
     },

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -834,6 +834,7 @@
       }
     },
     "Subnet2Routes": {
+      "Condition": "ThirdAvailabilityZone",
       "DependsOn": [ "Subnet2", "Routes" ],
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {


### PR DESCRIPTION
Changes rack template to add Gateway Attachment, Routes, and Route Table Associations when installing into an existing VPC.

Updates the client to require passing an existing Internet Gateway gateway via a new `--internet-gateway` option.