### PR TITLE
Use Dockerfile ENV value if present

### DIFF
--- a/manifest/fixtures/Dockerfile-env-dir
+++ b/manifest/fixtures/Dockerfile-env-dir
@@ -1,0 +1,21 @@
+FROM convox/rails
+
+ENV DIR /app
+ENV FOO bar
+
+# copy only the files needed for bundle install
+# uncomment the vendor/cache line if you `bundle package` your gems
+COPY Gemfile      $DIR/Gemfile
+COPY Gemfile.lock $DIR/Gemfile.lock
+# COPY vendor/cache $DIR/vendor/cache
+RUN bundle install
+
+# copy just the files needed for assets:precompile
+COPY Rakefile   $DIR/Rakefile
+COPY config     $DIR/config/$FOO
+COPY public     $DIR/public/$FAKE
+COPY app/assets /app$DIR/assets
+RUN rake assets:precompile
+
+# copy the rest of the app
+COPY . $DIR

--- a/manifest/fixtures/sync-path.yml
+++ b/manifest/fixtures/sync-path.yml
@@ -1,0 +1,9 @@
+web:
+  build: .
+  dockerfile: fixtures/Dockerfile-env-dir
+  labels:
+    - convox.port.443.protocol=tls
+    - convox.port.443.proxy=true
+  ports:
+    - 80:4000
+    - 443:4001

--- a/manifest/service_test.go
+++ b/manifest/service_test.go
@@ -1,6 +1,7 @@
 package manifest_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/convox/rack/manifest"
@@ -65,4 +66,29 @@ func TestDefaultNetworkName(t *testing.T) {
 	}
 
 	assert.Equal(t, s.NetworkName(), "")
+}
+
+func TestSyncPaths(t *testing.T) {
+	m, err := manifestFixture("sync-path")
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("failed to read fixture: %s", err.Error()))
+	}
+
+	expectedMap := map[string]string{
+		".":            "/app",
+		"Gemfile":      "/app/Gemfile",
+		"Gemfile.lock": "/app/Gemfile.lock",
+		"Rakefile":     "/app/Rakefile",
+		"config":       "/app/config/bar",
+		"public":       "/app/public/$FAKE",
+		"app/assets":   "/app/app/assets",
+	}
+
+	for _, s := range m.Services {
+		sp, err := s.SyncPaths()
+
+		if assert.Nil(t, err) {
+			assert.EqualValues(t, expectedMap, sp)
+		}
+	}
 }


### PR DESCRIPTION
This change will allow code sync to use a Dockerfile `ENV` value if present in an `ADD` or `COPY` statement.

Fixes #1055