### PR TITLE
Mem limit patch

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -134,8 +134,9 @@ func (m Manifest) Validate() []error {
 		mem := entry.Memory
 
 		if mem < mem_min && mem != 0 { //Memory(0) {
-			e := fmt.Errorf("%s has invalid mem_limit %#v: should be either 0, or at least %#vMB",
+			e := fmt.Errorf("%s has invalid mem_limit %#v bytes / %#v MB: should be either 0, or at least %#vMB",
 				entry.Name,
+				mem,
 				mem/units.MB,
 				mem_min/units.MB)
 			errors = append(errors, e)

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -134,7 +134,7 @@ func (m Manifest) Validate() []error {
 		mem := entry.Memory
 
 		if mem < mem_min && mem != 0 { //Memory(0) {
-			e := fmt.Errorf("%s has invalid mem_limit %#v bytes / %#v MB: should be either 0, or at least %#vMB",
+			e := fmt.Errorf("%s service has invalid mem_limit %#v bytes (%#v MB): should be either 0, or at least %#vMB",
 				entry.Name,
 				mem,
 				mem/units.MB,

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -523,7 +523,7 @@ func TestManifestValidate(t *testing.T) {
 
 	merrm := m.Validate()
 	if assert.NotNil(t, merrm) {
-		assert.Equal(t, merrm[0].Error(), "web has invalid mem_limit 2097152 bytes / 2 MB: should be either 0, or at least 4MB")
+		assert.Equal(t, merrm[0].Error(), "web service has invalid mem_limit 2097152 bytes (2 MB): should be either 0, or at least 4MB")
 	}
 }
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -523,7 +523,7 @@ func TestManifestValidate(t *testing.T) {
 
 	merrm := m.Validate()
 	if assert.NotNil(t, merrm) {
-		assert.Equal(t, merrm[0].Error(), "web has invalid mem_limit 2: should be either 0, or at least 4MB")
+		assert.Equal(t, merrm[0].Error(), "web has invalid mem_limit 2097152 bytes / 2 MB: should be either 0, or at least 4MB")
 	}
 }
 


### PR DESCRIPTION
Print mem_limit in both bytes and MB in error message.

If `docker-compose.yml` contains `mem_limit: 2048`, the current error is:

```
$ convox start
ERROR: counter has invalid mem_limit 0: should be either 0, or at least 4MB
```

New error will be:

```
$ convox start
ERROR: counter service has invalid mem_limit 2048 bytes (0 MB): should be either 0, or at least 4MB
```

edit: update format.