### PR TITLE
Change sync Contains logic to check string paths

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -57,23 +57,11 @@ func NewSync(container, local, remote string) (*Sync, error) {
 }
 
 func (s *Sync) Contains(t Sync) bool {
-	if !filepath.HasPrefix(t.Local, s.Local) {
+	if s.Local != t.Local {
 		return false
 	}
 
-	lr, err := filepath.Rel(s.Local, t.Local)
-
-	if err != nil {
-		return false
-	}
-
-	rr, err := filepath.Rel(s.Remote, t.Remote)
-
-	if err != nil {
-		return false
-	}
-
-	return lr == rr
+	return s.Remote == t.Remote
 }
 
 func (s *Sync) Start(st Stream) error {


### PR DESCRIPTION
Using `Rel()` in the sync's `Contains()` was causing issues with similar file/directory names. (e.g migration file vs migrations directory).

Originally `filepath.HasPrefix()` was used to compare paths based simply on strings, I thought using the same logic in `Contains()` would simplify it. (Side note: filepath.HasPrefix() just calls `strings.HasPrefix()` and only provided for backwards compatibility).

I'd really appreciate extra eyes here (especially @ddollar since he was the original author of this block) to see if I might be missing some case that isn't obvious to me.