### PR TITLE
Stop local containers on convox start error

### DIFF
--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -127,6 +127,8 @@ func cmdStart(c *cli.Context) error {
 
 	err = r.Start()
 	if err != nil {
+		r.Stop()
+
 		stdcli.QOSEventSend("cli-start", id, stdcli.QOSEventProperties{
 			ValidationError: err,
 			AppType:         appType,


### PR DESCRIPTION
Also increased the timeout on waiting for containers to start with an error message if needed: Fixes #1462