### PR TITLE
When shifting ports, also shift 'convox.port.xxx.protocol'.

### DIFF
--- a/manifest/fixtures/shift-with-ssl.yml
+++ b/manifest/fixtures/shift-with-ssl.yml
@@ -1,0 +1,10 @@
+version: "2"
+services:
+  web:
+    build: .
+    labels:
+      - convox.start.shift=2
+      - convox.port.443.protocol=https
+    ports:
+      - 80:4001
+      - 443:4001

--- a/manifest/labels.go
+++ b/manifest/labels.go
@@ -1,0 +1,47 @@
+package manifest
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+
+// Trim "convox.port." and ".protocol" from beginning and end of label
+//
+func extractPort(label string) string {
+	label = strings.TrimSuffix(label, ".protocol")
+	label = strings.TrimPrefix(label, "convox.port.")
+	return label
+}
+
+// "convox.port.xxx.protocol" label can be set to https.
+// Increment the 'xxx' part by the given shift amount.
+//
+func (labels Labels) Shift(shift int) Labels {
+
+	// Make a copy of the old labels, since we can't update them on the fly
+	oldlabels := make(map[string]string)
+	for k,v := range labels {
+	  oldlabels[k] = v
+	}
+
+	for ol := range oldlabels {
+
+		// If we have a label called 'convox.port.xxx.protocol', treat 'xxx' as a port.
+		if strings.HasPrefix(ol, "convox.port.") && strings.HasSuffix(ol, ".protocol") {
+			p := extractPort(ol)
+			if p != "" {
+				p, _ := strconv.Atoi(p)
+				new_port := p + shift
+				new_label := fmt.Sprintf("convox.port.%d.protocol", new_port)
+				labels[new_label] = labels[ol]
+
+				// Delete the old label, since we want to replace e.g. 'convox.port.443.protocol' 
+				// with 'convox.port.444.protocol' entirely instead of duplicating them when we shift.
+				delete(labels, ol)
+			}
+		}
+	}
+	return labels
+}

--- a/manifest/labels.go
+++ b/manifest/labels.go
@@ -37,7 +37,7 @@ func (labels Labels) Shift(shift int) Labels {
 				new_label := fmt.Sprintf("convox.port.%d.protocol", new_port)
 				labels[new_label] = labels[ol]
 
-				// Delete the old label, since we want to replace e.g. 'convox.port.443.protocol' 
+				// Delete the old label, since we want to replace e.g. 'convox.port.443.protocol'
 				// with 'convox.port.444.protocol' entirely instead of duplicating them when we shift.
 				delete(labels, ol)
 			}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -252,9 +252,10 @@ func (m *Manifest) runOrder(target string) (Services, error) {
 	return services, nil
 }
 
-// Shift all external ports in this Manifest by the given amount and their shift labels
+// Shift all external ports and labels in this Manifest by the given amount and their shift labels
 func (m *Manifest) Shift(shift int) error {
 	for _, service := range m.Services {
+		service.Labels.Shift(shift)
 		service.Ports.Shift(shift)
 
 		if ss, ok := service.Labels["convox.start.shift"]; ok {
@@ -263,6 +264,7 @@ func (m *Manifest) Shift(shift int) error {
 				return fmt.Errorf("invalid shift: %s", ss)
 			}
 
+			service.Labels.Shift(shift)
 			service.Ports.Shift(shift)
 		}
 	}

--- a/manifest/ports_test.go
+++ b/manifest/ports_test.go
@@ -28,12 +28,12 @@ func TestPortsBadData(t *testing.T) {
 
 func TestPortsShift(t *testing.T) {
 	m, err := manifestFixture("shift")
+	m.Shift(5000)
 
 	if assert.Nil(t, err) {
 		web := m.Services["web"]
 
 		if assert.NotNil(t, web) {
-			web.Ports.Shift(5000)
 
 			if assert.Equal(t, len(web.Ports), 2) {
 				assert.Equal(t, web.Ports[0].Balancer, 5000)
@@ -41,6 +41,35 @@ func TestPortsShift(t *testing.T) {
 				assert.Equal(t, web.Ports[1].Balancer, 11000)
 				assert.Equal(t, web.Ports[1].Container, 7000)
 			}
+		}
+	}
+}
+
+func TestPortsShiftWithSSL(t *testing.T) {
+	m, err := manifestFixture("shift-with-ssl")
+	// Shift the whole manifest by 2; this is evaluated in addition to any per-service convox.start.shift labels.
+	m.Shift(2)
+
+	if assert.Nil(t, err) {
+		// Web has a convox.start.shift label, for a total shift of 4.
+		web := m.Services["web"]
+
+		if assert.NotNil(t, web) {
+
+			if assert.Equal(t, len(web.Ports), 2) {
+				assert.Equal(t, web.Ports[0].Balancer, 84)
+				assert.Equal(t, web.Ports[0].Container, 4001)
+				assert.Equal(t, web.Ports[1].Balancer, 447)
+				assert.Equal(t, web.Ports[1].Container, 4001)
+			}
+
+			assert.Equal(t, web.Labels["convox.start.shift"], "2")
+
+			// The label should have been changed from 443 to 445 with --shift,
+			// and from 445 to 447 with convox.start.shift.
+			assert.Equal(t, web.Labels["convox.port.443.protocol"], "")
+			assert.Equal(t, web.Labels["convox.port.445.protocol"], "")
+			assert.Equal(t, web.Labels["convox.port.447.protocol"], "https")
 		}
 	}
 }


### PR DESCRIPTION
When shifting ports, look for a `convox.port.xxx.protocol` label and also increment it by the given shift amount.

Note: this works for me running `convox start` locally with `--shift 2`, but when I try with the `convox.start.shift=2` label, I get logs like:

`web    │ 172.18.0.4 - - [15/Dec/2016:21:21:44 +0000] "\x16\x03\x01\x00\xB9\x01\x00\x00\xB5\x03\x03\xFAL\xB1\xE3T1.\xA0L\x16\xD3\x84\x08&\xC3%\x1D\x1C\x86\x14\xFB=\x84\xB3{=\x1A\x08\xBC\x0C\xA9\x91\x00\x00\x22\xC0+\xC0/\xC0,\xC00\xCC\xA9\xCC\xA8\xCC\x14\xCC\x13\xC0\x09\xC0\x13\xC0" 400 182 "-" "-"`

... and browsing to https://localhost:445/ I get an error message:
```
This site can’t provide a secure connection

localhost sent an invalid response.
ERR_SSL_PROTOCOL_ERROR
```
