### PR TITLE
[RELEASE] 20161215

### DIFF
--- a/api/manifest.yml
+++ b/api/manifest.yml
@@ -6,9 +6,9 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-host: docker.local
+host: cx.ngrok.io
 schemes:
-  - http
+  - https
 consumes:
   - application/x-www-form-urlencoded
 produces:
@@ -656,6 +656,7 @@ paths:
       - name: domains
         description: public key
         type: array
+
         items:
           type: string
       responses:
@@ -899,10 +900,11 @@ definitions:
       process-width:
         type: integer
   certificate:
+    properties:
       domain:
         type: string
       expiration:
-        type: date
+        type: string
       id:
         type: string
   error:

--- a/api/workers/autoscale.go
+++ b/api/workers/autoscale.go
@@ -43,7 +43,11 @@ func autoscaleRack() {
 	}
 
 	log.Logf("status=%q", system.Status)
-	if system.Status != "running" {
+
+	// only allow running and converging status through
+	switch system.Status {
+	case "running", "converging":
+	default:
 		return
 	}
 
@@ -79,14 +83,17 @@ func autoscaleRack() {
 		return
 	}
 
-	log.Logf("change=%d", (desired - system.Count))
-
-	// ok to start multiple but shut them down one at a time
+	// ok to start multiple
+	// when shutting down go one at a time but only if current status is "running"
 	if desired < system.Count {
-		system.Count--
+		if system.Status == "running" {
+			system.Count--
+		}
 	} else {
 		system.Count = desired
 	}
+
+	log.Logf("change=%d", (desired - system.Count))
 
 	err = models.Provider().SystemSave(*system)
 	if err != nil {

--- a/bin/checklinks.sh
+++ b/bin/checklinks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+urls=$(egrep -ri --exclude-dir=vendor 'DocsLink' ../* \
+    | awk '{ print $3}' \
+    | grep http \
+    | cut -d '"' -f 2)
+
+for url in $urls; do
+    curl -sL -w "%{http_code} %{url_effective}\\n" $url -o /dev/null
+done

--- a/manifest/fixtures/invalid-health-check.yml
+++ b/manifest/fixtures/invalid-health-check.yml
@@ -1,0 +1,8 @@
+version: "2"
+services:
+  web:
+    image: httpd
+    labels:
+      - convox.health.port=80
+    ports:
+      - 3000

--- a/manifest/fixtures/shift-with-ssl.yml
+++ b/manifest/fixtures/shift-with-ssl.yml
@@ -1,0 +1,10 @@
+version: "2"
+services:
+  web:
+    build: .
+    labels:
+      - convox.start.shift=2
+      - convox.port.443.protocol=https
+    ports:
+      - 80:4001
+      - 443:4001

--- a/manifest/labels.go
+++ b/manifest/labels.go
@@ -1,0 +1,47 @@
+package manifest
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+
+// Trim "convox.port." and ".protocol" from beginning and end of label
+//
+func extractPort(label string) string {
+	label = strings.TrimSuffix(label, ".protocol")
+	label = strings.TrimPrefix(label, "convox.port.")
+	return label
+}
+
+// "convox.port.xxx.protocol" label can be set to https.
+// Increment the 'xxx' part by the given shift amount.
+//
+func (labels Labels) Shift(shift int) Labels {
+
+	// Make a copy of the old labels, since we can't update them on the fly
+	oldlabels := make(map[string]string)
+	for k,v := range labels {
+	  oldlabels[k] = v
+	}
+
+	for ol := range oldlabels {
+
+		// If we have a label called 'convox.port.xxx.protocol', treat 'xxx' as a port.
+		if strings.HasPrefix(ol, "convox.port.") && strings.HasSuffix(ol, ".protocol") {
+			p := extractPort(ol)
+			if p != "" {
+				p, _ := strconv.Atoi(p)
+				new_port := p + shift
+				new_label := fmt.Sprintf("convox.port.%d.protocol", new_port)
+				labels[new_label] = labels[ol]
+
+				// Delete the old label, since we want to replace e.g. 'convox.port.443.protocol'
+				// with 'convox.port.444.protocol' entirely instead of duplicating them when we shift.
+				delete(labels, ol)
+			}
+		}
+	}
+	return labels
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -141,6 +141,27 @@ func (m Manifest) Validate() []error {
 				mem_min/units.MB)
 			errors = append(errors, e)
 		}
+
+		// check that health check port is valid
+		if port, ok := entry.Labels["convox.health.port"]; ok {
+			pi, err := strconv.Atoi(port)
+			if err != nil {
+				errors = append(errors, err)
+			} else {
+				found := false
+
+				for _, p := range entry.Ports {
+					if p.Container == pi {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					errors = append(errors, fmt.Errorf("%s service has convox.health.port set to a port it does not declare", entry.Name))
+				}
+			}
+		}
 	}
 
 	return errors

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -273,9 +273,10 @@ func (m *Manifest) runOrder(target string) (Services, error) {
 	return services, nil
 }
 
-// Shift all external ports in this Manifest by the given amount and their shift labels
+// Shift all external ports and labels in this Manifest by the given amount and their shift labels
 func (m *Manifest) Shift(shift int) error {
 	for _, service := range m.Services {
+		service.Labels.Shift(shift)
 		service.Ports.Shift(shift)
 
 		if ss, ok := service.Labels["convox.start.shift"]; ok {
@@ -284,6 +285,7 @@ func (m *Manifest) Shift(shift int) error {
 				return fmt.Errorf("invalid shift: %s", ss)
 			}
 
+			service.Labels.Shift(shift)
 			service.Ports.Shift(shift)
 		}
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -525,6 +525,16 @@ func TestManifestValidate(t *testing.T) {
 	if assert.NotNil(t, merrm) {
 		assert.Equal(t, merrm[0].Error(), "web service has invalid mem_limit 2097152 bytes (2 MB): should be either 0, or at least 4MB")
 	}
+
+	m, err = manifestFixture("invalid-health-check")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if errs := m.Validate(); assert.NotNil(t, errs) {
+		assert.Equal(t, errs[0].Error(), "web service has convox.health.port set to a port it does not declare")
+	}
 }
 
 func manifestFixture(name string) (*manifest.Manifest, error) {

--- a/manifest/ports_test.go
+++ b/manifest/ports_test.go
@@ -28,12 +28,12 @@ func TestPortsBadData(t *testing.T) {
 
 func TestPortsShift(t *testing.T) {
 	m, err := manifestFixture("shift")
+	m.Shift(5000)
 
 	if assert.Nil(t, err) {
 		web := m.Services["web"]
 
 		if assert.NotNil(t, web) {
-			web.Ports.Shift(5000)
 
 			if assert.Equal(t, len(web.Ports), 2) {
 				assert.Equal(t, web.Ports[0].Balancer, 5000)
@@ -41,6 +41,35 @@ func TestPortsShift(t *testing.T) {
 				assert.Equal(t, web.Ports[1].Balancer, 11000)
 				assert.Equal(t, web.Ports[1].Container, 7000)
 			}
+		}
+	}
+}
+
+func TestPortsShiftWithSSL(t *testing.T) {
+	m, err := manifestFixture("shift-with-ssl")
+	// Shift the whole manifest by 2; this is evaluated in addition to any per-service convox.start.shift labels.
+	m.Shift(2)
+
+	if assert.Nil(t, err) {
+		// Web has a convox.start.shift label, for a total shift of 4.
+		web := m.Services["web"]
+
+		if assert.NotNil(t, web) {
+
+			if assert.Equal(t, len(web.Ports), 2) {
+				assert.Equal(t, web.Ports[0].Balancer, 84)
+				assert.Equal(t, web.Ports[0].Container, 4001)
+				assert.Equal(t, web.Ports[1].Balancer, 447)
+				assert.Equal(t, web.Ports[1].Container, 4001)
+			}
+
+			assert.Equal(t, web.Labels["convox.start.shift"], "2")
+
+			// The label should have been changed from 443 to 445 with --shift,
+			// and from 445 to 447 with convox.start.shift.
+			assert.Equal(t, web.Labels["convox.port.443.protocol"], "")
+			assert.Equal(t, web.Labels["convox.port.445.protocol"], "")
+			assert.Equal(t, web.Labels["convox.port.447.protocol"], "https")
 		}
 	}
 }


### PR DESCRIPTION
## Pull Requests
  - closes #1475 Use console.convox.com instead of docker.local as host in swagger manifest [@soulshake]
  - closes #1476 validate convox.health.port [@ddollar]
  - closes #1478 When shifting ports, also shift 'convox.port.xxx.protocol'. [@soulshake]
  - closes #1479 Add a tiny shell script in bin/ to check DocsLink URLs. [@soulshake]
  - closes #1480 autoscale even when converging [@ddollar]

## Milestone Release
- [x] Release branch
- [x] Pass CI
- [x] Code review
- [ ] Merge into master
- [ ] Close milestone
- [ ] Release master
- [ ] Record release number: 
- [ ] Pass CI
- [ ] Update demo
- [ ] Deploy demo/httpd
- [ ] Deploy demo/rails
- [ ] Update staging
- [ ] Deploy staging/site-staging
- [ ] Deploy staging/console-staging
- [ ] Update [release notes](https://github.com/convox/rack/releases)
- [ ] Documentation review
- [ ] Publish release
- [ ] Release CLI
