### PR TITLE
In docker-compose.yml files generated by 'convox init', version should be a string, not an integer.

### DIFF
--- a/cmd/convox/templates/init/django/docker-compose.yml
+++ b/cmd/convox/templates/init/django/docker-compose.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 services:
   web:
     build: .

--- a/cmd/convox/templates/init/rails/docker-compose.yml
+++ b/cmd/convox/templates/init/rails/docker-compose.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 services:
   web:
     build: .

--- a/cmd/convox/templates/init/ruby/docker-compose.yml
+++ b/cmd/convox/templates/init/ruby/docker-compose.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 services:
   web:
     build: .

--- a/cmd/convox/templates/init/sinatra/docker-compose.yml
+++ b/cmd/convox/templates/init/sinatra/docker-compose.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 services:
   web:
     build: .

--- a/cmd/convox/templates/init/unknown/docker-compose.yml
+++ b/cmd/convox/templates/init/unknown/docker-compose.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 services:
   main:
     build: .


### PR DESCRIPTION
Our `convox init` templates have an invalid format:
```
$ docker-compose config
ERROR: Version in "./docker-compose.yml" is invalid - it should be a string.
```

This is because `docker-compose` expects `version: "2"` and not `version: 2`.