### PR TITLE
Reinstate `ssl update` `--rack` and `--app` flags

### DIFF
--- a/cmd/convox/ssl.go
+++ b/cmd/convox/ssl.go
@@ -23,6 +23,10 @@ func init() {
 				Description: "update the certificate associated with an endpoint",
 				Usage:       "<process:port> <certificate-id>",
 				Action:      cmdSSLUpdate,
+				Flags: []cli.Flag{
+					appFlag,
+					rackFlag,
+				},
 			},
 		},
 	})


### PR DESCRIPTION
`--rack` and `--app` flags seems to have been removed by mistake from the `ssl update` sub-command, which is currently breaking our builds. This PR reinstates them.