### PR TITLE
Give AWS credential csv files provided as an argument priority over env vars

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -370,7 +370,6 @@ func cmdInstall(c *cli.Context) error {
 		req.TemplateBody = aws.String(t.String())
 	}
 
-	//log.Fatal("Aborting before creating stack.")
 	res, err := CloudFormation.CreateStack(req)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
@@ -748,6 +747,7 @@ func readCredentials(fileName string) (creds *AwsCredentials, err error) {
 		}
 
 		if creds != nil {
+			// be clear about which AWS account we're installing the Rack to
 			fmt.Println("Using AWS Access Key ID: %s", creds.Access)
 			return creds, err
 		}

--- a/manifest/fixtures/dummy.csv
+++ b/manifest/fixtures/dummy.csv
@@ -1,0 +1,2 @@
+User name,Password,Access key ID,Secret access key,Console login link
+dummy,,AKIAIJAFAQL3V7HLQQAA,7KWaI3IQWodktvl/DlzMPMMu0rTgJLF75P6BYM5h,https://332653055745.signin.aws.amazon.com/console


### PR DESCRIPTION
By accepting this PR, we will:

- add a new test `TestConvoxInstallFileCredentialsInsufficientPermissions`
- check the format of the credentials file more carefully
- be more verbose about what AWS account we're installing to
- prefer credentials in provided file over envvars
- validate user access permissions, _kind of_ (see below)

**IMPORTANT**

Previously, the `validateUserAccess` function in `cmd/convox/install.go` simply returned `nil`. If this PR is accepted, it will only return `nil` if the provided secret key is `test`. This is necessary for the permissions error to bubble up, but there are two problems:

- I don't know what unexpected behaviors this change might cause, due to lacking test coverage
- we're not actually validating user permissions correctly (`Iam.GetUser` permissions is not what matters, IIUC), which I suppose is why the function was disabled in the first place.

Feedback welcome