### PR TITLE
Allow running a subset of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ templates:
 	make -C sync templates
 
 test:
-	env PROVIDER=test bin/test
+	env PROVIDER=test CONVOX_WAIT= bin/test
 
 vendor:
 	godep save ./...

--- a/bin/test
+++ b/bin/test
@@ -6,6 +6,11 @@ go get -t ./...
 
 rm -f coverage.txt
 
+if [ ! -z ${TEST} ]; then
+    go test -coverprofile=profile.out -covermode=atomic "$TEST"
+    exit
+fi
+
 for d in $(find . -not \( -name vendor -prune \) -name '*.go' -exec dirname {} \; | sort -u); do
   go test -coverprofile=profile.out -covermode=atomic $d
 


### PR DESCRIPTION
Since we [un]set some local envvars (`PROVIDER`, `CONVOX_WAIT`) in the Makefile, running subsets of tests via `go test` doesn't result in identical environments.

This PR allows running only some tests, e.g.:

`$ make test TEST=github.com/convox/rack/cmd/convox`