### PR TITLE
Fix `convox ps stop`

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -690,6 +690,7 @@
                       "ecs:ListTasks",
                       "ecs:RegisterTaskDefinition",
                       "ecs:RunTask",
+                      "ecs:StopTask",
                       "ecs:UpdateService",
                       "elasticache:CreateCacheCluster",
                       "elasticache:CreateCacheSubnetGroup",


### PR DESCRIPTION
As a result of #1063, `convox ps stop` was broken due to missing permissions for `ecs:StopTask`. This PR simply adds it.

I haven't checked for any other missing permissions, I just happened to stumble onto this one during some debugging.