### PR TITLE
Use .NoError() instead of .Nil() for error checking in tests

### DIFF
--- a/api/controllers/apps_test.go
+++ b/api/controllers/apps_test.go
@@ -27,7 +27,7 @@ func TestAppList(t *testing.T) {
 	var resp []map[string]string
 	err := json.Unmarshal([]byte(body), &resp)
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, "bar", resp[0]["name"])
 		assert.Equal(t, "running", resp[0]["status"])
 	}
@@ -44,7 +44,7 @@ func TestAppShow(t *testing.T) {
 	var resp map[string]string
 	err := json.Unmarshal([]byte(body), &resp)
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, "bar", resp["name"])
 		assert.Equal(t, "running", resp["status"])
 	}
@@ -62,7 +62,7 @@ func TestAppShowUnbound(t *testing.T) {
 	var resp map[string]string
 	err := json.Unmarshal([]byte(body), &resp)
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, "bar", resp["name"])
 		assert.Equal(t, "running", resp["status"])
 	}
@@ -99,7 +99,7 @@ func TestAppCreate(t *testing.T) {
 		var resp map[string]string
 		err := json.Unmarshal([]byte(body), &resp)
 
-		if assert.Nil(t, err) {
+		if assert.NoError(t, err) {
 			assert.Equal(t, "application", resp["name"])
 			assert.Equal(t, "running", resp["status"])
 		}
@@ -160,7 +160,7 @@ func TestAppDelete(t *testing.T) {
 	var resp map[string]bool
 	err := json.Unmarshal([]byte(body), &resp)
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, true, resp["success"])
 	}
 }

--- a/api/models/fixtures_test.go
+++ b/api/models/fixtures_test.go
@@ -23,7 +23,7 @@ func TestFixtures(t *testing.T) {
 	fixtures, err := availableFixtures()
 
 	require.NotNil(t, fixtures)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	for _, fixture := range fixtures {
 		assertFixture(t, fixture)
@@ -64,19 +64,19 @@ func assertFixture(t *testing.T, name string) {
 	}
 
 	data, err := ioutil.ReadFile(fmt.Sprintf("fixtures/%s.yml", name))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	manifest, err := manifest.Load(data)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	formation, err := app.Formation(*manifest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	pretty, err := models.PrettyJSON(formation)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	data, err = ioutil.ReadFile(fmt.Sprintf("fixtures/%s.json", name))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	diff1 := strings.Split(strings.TrimSpace(string(data)), "\n")
 	diff2 := strings.Split(strings.TrimSpace(pretty), "\n")

--- a/api/models/release_test.go
+++ b/api/models/release_test.go
@@ -51,13 +51,13 @@ func TestLinks(t *testing.T) {
 	os.Setenv("CLUSTER", "convox-test")
 
 	resp, err := ioutil.ReadFile("fixtures/get-app-template-response.xml")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	fixData, err := ioutil.ReadFile("fixtures/web_redis.json")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	yamlData, err := ioutil.ReadFile("fixtures/web_redis.yml")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	getAppTemplateCycle := test.GetAppTemplateCycle("web")
 	getAppTemplateCycle.Response.Body = string(resp)
@@ -77,7 +77,7 @@ func TestLinks(t *testing.T) {
 
 	ManifestRandomPorts = false
 	formation, err := release.Formation()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	ManifestRandomPorts = true
 
 	Diff(t, "web_redis", string(fixData), formation)

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -19,7 +19,7 @@ func TestGetApps(t *testing.T) {
 	apps, err := testClient(t, ts.URL).GetApps()
 
 	assert.NotNil(t, apps, "apps should not be nil")
-	assert.Nil(t, err, "err should be nil")
+	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(apps), 2, "there should be one app")
 	assert.Equal(t, "sinatra", apps[0].Name, "app name should be sinatra")
@@ -56,7 +56,7 @@ func TestGetApp(t *testing.T) {
 	app, err := testClient(t, ts.URL).GetApp("sinatra")
 
 	assert.NotNil(t, app, "apps should not be nil")
-	assert.Nil(t, err, "err should be nil")
+	assert.NoError(t, err)
 
 	assert.Equal(t, "sinatra", app.Name, "app name should be sinatra")
 	assert.Equal(t, "running", app.Status, "app status should be running")

--- a/client/service_test.go
+++ b/client/service_test.go
@@ -23,7 +23,7 @@ func TestGetService(t *testing.T) {
 	service, err := testClient(t, ts.URL).GetResource("convox-events")
 
 	assert.NotNil(t, service, "service should not be nil")
-	assert.Nil(t, err, "err should be nil")
+	assert.NoError(t, err)
 
 	assert.Equal(t, "convox-events", service.Name, ".Name should be convox-events")
 	assert.Equal(t, "running", service.Status, ".Status should be running")

--- a/client/system_test.go
+++ b/client/system_test.go
@@ -24,7 +24,7 @@ func TestGetSystem(t *testing.T) {
 	system, err := testClient(t, ts.URL).GetSystem()
 
 	assert.NotNil(t, system, "system should not be nil")
-	assert.Nil(t, err, "err should be nil")
+	assert.NoError(t, err)
 
 	assert.Equal(t, 1, system.Count, ".Count should be 1")
 	assert.Equal(t, "system", system.Name, ".Name should be system")

--- a/cmd/convox/install_test.go
+++ b/cmd/convox/install_test.go
@@ -103,11 +103,11 @@ func TestConvoxInstallFriendlyName(t *testing.T) {
 	}
 
 	data, err := ioutil.ReadFile("../../provider/aws/dist/rack.json")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, data)
 
 	err = json.Unmarshal(data, &formation)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	types := map[string]bool{}
 

--- a/cmd/convox/rack_test.go
+++ b/cmd/convox/rack_test.go
@@ -2,10 +2,10 @@ package main
 
 // func TestRackUpdateStable(t *testing.T) {
 //   versions, err := version.All()
-//   require.Nil(t, err)
+//   require.NoError(t, err)
 
 //   stable, err := versions.Resolve("stable")
-//   require.Nil(t, err)
+//   require.NoError(t, err)
 
 //   ts := testServer(t,
 //     test.Http{Method: "PUT", Body: fmt.Sprintf("version=%s", stable.Version), Path: "/system", Code: 200, Response: client.System{

--- a/manifest/balancer_test.go
+++ b/manifest/balancer_test.go
@@ -9,7 +9,7 @@ import (
 func TestBalancer(t *testing.T) {
 	m, err := manifestFixture("balancer")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		if assert.Equal(t, len(m.Balancers()), 1) {
 			balancer := m.Balancers()[0]
 
@@ -24,7 +24,7 @@ func TestBalancer(t *testing.T) {
 func TestBalancerLabels(t *testing.T) {
 	m, err := manifestFixture("balancer-labels")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		if assert.Equal(t, len(m.Balancers()), 1) {
 			balancer := m.Balancers()[0]
 
@@ -39,7 +39,7 @@ func TestBalancerLabels(t *testing.T) {
 func TestBalancerSecure(t *testing.T) {
 	m, err := manifestFixture("balancer-secure")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		if assert.Equal(t, len(m.Balancers()), 1) {
 			balancer := m.Balancers()[0]
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -18,7 +18,7 @@ import (
 func TestLoadVersion1(t *testing.T) {
 	m, err := manifestFixture("v1")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, m.Version, "1")
 		assert.Equal(t, len(m.Services), 1)
 
@@ -31,7 +31,7 @@ func TestLoadVersion1(t *testing.T) {
 func TestLoadVersion2(t *testing.T) {
 	m, err := manifestFixture("v2-number")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, m.Version, "2")
 		assert.Equal(t, len(m.Services), 1)
 
@@ -42,7 +42,7 @@ func TestLoadVersion2(t *testing.T) {
 
 	m, err = manifestFixture("v2-string")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, m.Version, "2")
 		assert.Equal(t, len(m.Services), 1)
 
@@ -55,7 +55,7 @@ func TestLoadVersion2(t *testing.T) {
 func TestLoadCommandString(t *testing.T) {
 	m, err := manifestFixture("command-string")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		if web := m.Services["web"]; assert.NotNil(t, web) {
 			assert.Equal(t, web.Command.String, manifest.Command{String: "ls -la"}.String)
 		}
@@ -65,7 +65,7 @@ func TestLoadCommandString(t *testing.T) {
 func TestLoadCommandArray(t *testing.T) {
 	m, err := manifestFixture("command-array")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		if web := m.Services["web"]; assert.NotNil(t, web) {
 			assert.Equal(t, web.Command.Array, manifest.Command{Array: []string{"ls", "-la"}}.Array)
 		}
@@ -75,7 +75,7 @@ func TestLoadCommandArray(t *testing.T) {
 func TestLoadFullVersion1(t *testing.T) {
 	m, err := manifestFixture("full-v1")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		if web := m.Services["web"]; assert.NotNil(t, web) {
 			assert.Equal(t, web.Build.Context, ".")
 			assert.Equal(t, web.Build.Dockerfile, "Dockerfile.dev")
@@ -136,7 +136,7 @@ func TestLoadFullVersion1(t *testing.T) {
 func TestLoadFullVersion2(t *testing.T) {
 	m, err := manifestFixture("full-v2")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		if web := m.Services["web"]; assert.NotNil(t, web) {
 			assert.Equal(t, web.Build.Context, ".")
 			assert.Equal(t, web.Build.Dockerfile, "Dockerfile.dev")
@@ -227,7 +227,7 @@ func TestLoadEnvVar(t *testing.T) {
 
 	m, err := manifestFixture("interpolate-env-var")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, m.Services["web"].Image, rando1)
 		assert.Equal(t, m.Services["web"].Entrypoint, fmt.Sprintf("%s/%s/%s", rando2, rando2, rando3))
 		assert.Equal(t, m.Services["web"].Build.Dockerfile, "$REMAIN")
@@ -239,10 +239,10 @@ func TestLoadEnvVar(t *testing.T) {
 func TestLoadIdleTimeoutUnset(t *testing.T) {
 	m, err := manifestFixture("idle-timeout-unset")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		if assert.Equal(t, 1, len(m.Balancers())) {
 			b := m.Balancers()[0]
-			if val, err := b.IdleTimeout(); assert.Nil(t, err) {
+			if val, err := b.IdleTimeout(); assert.NoError(t, err) {
 				assert.Equal(t, val, "3600")
 			}
 		}
@@ -252,10 +252,10 @@ func TestLoadIdleTimeoutUnset(t *testing.T) {
 func TestLoadIdleTimeoutSet(t *testing.T) {
 	m, err := manifestFixture("idle-timeout-set")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		if assert.Equal(t, 1, len(m.Balancers())) {
 			b := m.Balancers()[0]
-			if val, err := b.IdleTimeout(); assert.Nil(t, err) {
+			if val, err := b.IdleTimeout(); assert.NoError(t, err) {
 				assert.Equal(t, val, "99")
 			}
 		}
@@ -310,7 +310,7 @@ func TestLoadUnknownVersion(t *testing.T) {
 func TestExternalPorts(t *testing.T) {
 	m, err := manifestFixture("full-v1")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		ports := m.ExternalPorts()
 
 		if assert.Equal(t, len(ports), 2) {
@@ -323,10 +323,10 @@ func TestExternalPorts(t *testing.T) {
 func TestPortConflictsWithoutConflict(t *testing.T) {
 	m, err := manifestFixture("port-conflicts")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		pc, err := m.PortConflicts()
 
-		if assert.Nil(t, err) {
+		if assert.NoError(t, err) {
 			assert.Equal(t, len(pc), 0)
 		}
 	}
@@ -335,7 +335,7 @@ func TestPortConflictsWithoutConflict(t *testing.T) {
 func TestPortConflictsWithConflict(t *testing.T) {
 	m, err := manifestFixture("port-conflicts")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		l, err := net.Listen("tcp", "127.0.0.1:30544")
 
 		defer l.Close()
@@ -349,10 +349,10 @@ func TestPortConflictsWithConflict(t *testing.T) {
 			}
 		}()
 
-		if assert.Nil(t, err) {
+		if assert.NoError(t, err) {
 			pc, err := m.PortConflicts()
 
-			if assert.Nil(t, err) && assert.Equal(t, len(pc), 1) {
+			if assert.NoError(t, err) && assert.Equal(t, len(pc), 1) {
 				assert.Equal(t, pc[0], 30544)
 			}
 		}
@@ -367,7 +367,7 @@ func TestPortConflictsWithConflict(t *testing.T) {
 
 func TestManifestNetworks(t *testing.T) {
 	m, err := manifestFixture("networks")
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		for _, s := range m.Services {
 			assert.Equal(t, s.Networks, manifest.Networks{
 				"foo": manifest.InternalNetwork{
@@ -385,7 +385,7 @@ func TestManifestNetworks(t *testing.T) {
 func TestShift(t *testing.T) {
 	m, err := manifestFixture("shift")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		m.Shift(5000)
 
 		web := m.Services["web"]

--- a/manifest/ports_test.go
+++ b/manifest/ports_test.go
@@ -30,7 +30,7 @@ func TestPortsShift(t *testing.T) {
 	m, err := manifestFixture("shift")
 	m.Shift(5000)
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		web := m.Services["web"]
 
 		if assert.NotNil(t, web) {
@@ -50,7 +50,7 @@ func TestPortsShiftWithSSL(t *testing.T) {
 	// Shift the whole manifest by 2; this is evaluated in addition to any per-service convox.start.shift labels.
 	m.Shift(2)
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		// Web has a convox.start.shift label, for a total shift of 4.
 		web := m.Services["web"]
 

--- a/manifest/service_test.go
+++ b/manifest/service_test.go
@@ -87,7 +87,7 @@ func TestSyncPaths(t *testing.T) {
 	for _, s := range m.Services {
 		sp, err := s.SyncPaths()
 
-		if assert.Nil(t, err) {
+		if assert.NoError(t, err) {
 			assert.EqualValues(t, expectedMap, sp)
 		}
 	}

--- a/provider/aws/apps_test.go
+++ b/provider/aws/apps_test.go
@@ -22,7 +22,7 @@ func TestAppCancel(t *testing.T) {
 
 	err := provider.AppCancel("httpd")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppGet(t *testing.T) {
@@ -33,7 +33,7 @@ func TestAppGet(t *testing.T) {
 
 	a, err := provider.AppGet("httpd")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, &structs.App{
 		Name:    "httpd",
 		Release: "RVFETUHHKKD",

--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -33,7 +33,7 @@ func TestBuildGet(t *testing.T) {
 
 	b, err := provider.BuildGet("httpd", "B123")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, &structs.Build{
 		Id:       "BAFVEWUCAYT",
 		App:      "httpd",
@@ -80,7 +80,7 @@ func TestBuildCreate(t *testing.T) {
 		Cache: true,
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, &structs.Build{
 		Id:      "B123",
 		App:     "httpd",
@@ -104,7 +104,7 @@ func TestBuildDelete(t *testing.T) {
 
 	b, err := provider.BuildDelete("httpd", "B123")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, &structs.Build{
 		Id:       "BAFVEWUCAYT",
 		App:      "httpd",
@@ -137,30 +137,30 @@ func TestBuildExport(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	err := provider.BuildExport("httpd", "B123", buf)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	gz, err := gzip.NewReader(buf)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tr := tar.NewReader(gz)
 
 	h, err := tr.Next()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "build.json", h.Name)
 	assert.Equal(t, int64(400), h.Size)
 
 	data, err := ioutil.ReadAll(tr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var build structs.Build
 	err = json.Unmarshal(data, &build)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "BAFVEWUCAYT", build.Id)
 	assert.Equal(t, "httpd", build.App)
 	assert.Equal(t, "RVWOJNKRAXU", build.Release)
 
 	h, err = tr.Next()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "web.BAFVEWUCAYT.tar", h.Name)
 	assert.Equal(t, int64(13), h.Size)
 
@@ -199,7 +199,7 @@ func TestBuildImport(t *testing.T) {
 	}
 
 	data, err := json.Marshal(build)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	buf := &bytes.Buffer{}
 
@@ -211,10 +211,10 @@ func TestBuildImport(t *testing.T) {
 		Name:     "build.json",
 		Size:     int64(len(data)),
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	n, err := tw.Write(data)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 175, n)
 
 	lbuf := &bytes.Buffer{}
@@ -228,34 +228,34 @@ func TestBuildImport(t *testing.T) {
 		Name:     "manifest.json",
 		Size:     int64(len(data)),
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	n, err = ltw.Write(data)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 27, n)
 
 	err = ltw.Close()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = tw.WriteHeader(&tar.Header{
 		Typeflag: tar.TypeReg,
 		Name:     "web.B123.tar",
 		Size:     int64(lbuf.Len()),
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	n, err = tw.Write(lbuf.Bytes())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2048, n)
 
 	err = tw.Close()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = gz.Close()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	build, err = provider.BuildImport("httpd", buf)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "B12345", build.Id)
 	assert.Equal(t, "httpd", build.App)
 	assert.Equal(t, "R23456", build.Release)
@@ -270,7 +270,7 @@ func TestBuildList(t *testing.T) {
 
 	b, err := provider.BuildList("httpd", 20)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, structs.Builds{
 		structs.Build{
 			Id:       "BHINCLZYYVN",
@@ -316,7 +316,7 @@ func TestBuildLogsRunning(t *testing.T) {
 
 	err := provider.BuildLogs("httpd", "B123", buf)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "RUNNING: docker pull httpd", buf.String())
 }
 
@@ -331,7 +331,7 @@ func TestBuildLogsNotRunning(t *testing.T) {
 
 	err := provider.BuildLogs("httpd", "B123", buf)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "RUNNING: docker pull httpd", buf.String())
 }
 

--- a/provider/aws/capacity_test.go
+++ b/provider/aws/capacity_test.go
@@ -22,7 +22,7 @@ func TestCapacityGet(t *testing.T) {
 
 	r, err := provider.CapacityGet()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, &structs.Capacity{
 		ClusterCPU:     3072,
 		ClusterMemory:  6012,

--- a/provider/aws/formation_test.go
+++ b/provider/aws/formation_test.go
@@ -20,7 +20,7 @@ func TestFormationList(t *testing.T) {
 
 	r, err := provider.FormationList("httpd")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, structs.Formation{
 		structs.ProcessFormation{
 			Balancer: "httpd-web-7E5UPCM-1241527783.us-east-1.elb.amazonaws.com",
@@ -55,7 +55,7 @@ func TestFormationListEmptyRelease(t *testing.T) {
 	r, err := provider.FormationList("httpd")
 
 	assert.Equal(t, structs.Formation{}, r)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFormationListBadRelease(t *testing.T) {
@@ -111,7 +111,7 @@ func TestFormationGet(t *testing.T) {
 
 	r, err := provider.FormationGet("httpd", "web")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, &structs.ProcessFormation{
 		Balancer: "httpd-web-7E5UPCM-1241527783.us-east-1.elb.amazonaws.com",
 		Name:     "web",
@@ -215,7 +215,7 @@ func TestFormationSave(t *testing.T) {
 
 	err := provider.FormationSave("httpd", pf)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFormationSaveBadApp(t *testing.T) {

--- a/provider/aws/instances_test.go
+++ b/provider/aws/instances_test.go
@@ -23,7 +23,7 @@ func TestInstancesList(t *testing.T) {
 
 	is, err := provider.InstanceList()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, structs.Instances{
 		structs.Instance{
 			Agent:     true,

--- a/provider/aws/logs_test.go
+++ b/provider/aws/logs_test.go
@@ -26,7 +26,7 @@ func TestLogStream(t *testing.T) {
 		Since:  time.Unix(1472946223, 0),
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "2014-03-28T19:36:18Z event2\n2014-03-28T19:36:18Z event3\n2014-03-28T19:36:18Z event4\n2014-03-28T19:36:18Z event1\n2014-03-28T19:36:18Z event5\n", buf.String())
 }
 

--- a/provider/aws/processes_test.go
+++ b/provider/aws/processes_test.go
@@ -43,7 +43,7 @@ func TestProcessExec(t *testing.T) {
 		Width:  20,
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte(fmt.Sprintf("foo%s%d\n", aws.StatusCodePrefix, 0)), out.Bytes())
 }
 
@@ -106,7 +106,7 @@ func TestProcessList(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, ps, s)
 }
 
@@ -137,7 +137,7 @@ func TestProcessListEmpty(t *testing.T) {
 
 	s, err := provider.ProcessList("myapp")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, structs.Processes{}, s)
 }
 
@@ -182,7 +182,7 @@ func TestProcessRunAttached(t *testing.T) {
 		Width:   20,
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "5850760f0845", pid)
 	assert.Equal(t, []byte(fmt.Sprintf("foo%s%d\n", aws.StatusCodePrefix, 0)), out.Bytes())
 }
@@ -209,7 +209,7 @@ func TestProcessRunDetached(t *testing.T) {
 		Width:   0,
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "0f51f03ff369", pid)
 }
 
@@ -222,7 +222,7 @@ func TestProcessStop(t *testing.T) {
 
 	err := provider.ProcessStop("myapp", "5850760f0845")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 var cycleProcessDescribeContainerInstances = awsutil.Cycle{

--- a/provider/aws/registries_test.go
+++ b/provider/aws/registries_test.go
@@ -22,7 +22,7 @@ func TestRegistryDelete(t *testing.T) {
 
 	err := provider.RegistryDelete("r.example.org")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRegistryList(t *testing.T) {
@@ -36,7 +36,7 @@ func TestRegistryList(t *testing.T) {
 
 	r, err := provider.RegistryList()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, structs.Registries{
 		structs.Registry{
 			Server:   "quay.io",

--- a/provider/aws/releases_test.go
+++ b/provider/aws/releases_test.go
@@ -19,7 +19,7 @@ func TestReleaseGet(t *testing.T) {
 
 	r, err := provider.ReleaseGet("httpd", "RVFETUHHKKD")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, &structs.Release{
 		Id:       "RVFETUHHKKD",
 		App:      "httpd",
@@ -39,7 +39,7 @@ func TestReleaseList(t *testing.T) {
 
 	r, err := provider.ReleaseList("httpd", 20)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.EqualValues(t, structs.Releases{
 		structs.Release{

--- a/provider/aws/resource_test.go
+++ b/provider/aws/resource_test.go
@@ -23,7 +23,7 @@ func TestResourceWebhookURL(t *testing.T) {
 	url := "http://notifications.example.org/sns?endpoint=https%3A%2F%2Fwww.example.com"
 	s, err := provider.ResourceCreate("mywebhook", "webhook", params)
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, url, s.Parameters["Url"])
 	}
 }
@@ -98,7 +98,7 @@ func TestResourceGet(t *testing.T) {
 
 	s, err := provider.ResourceGet("syslog")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.EqualValues(t, expected, s)
 	}
 }

--- a/provider/aws/service_test.go
+++ b/provider/aws/service_test.go
@@ -23,7 +23,7 @@ func TestServiceWebhookURL(t *testing.T) {
 	url := "http://notifications.example.org/sns?endpoint=https%3A%2F%2Fwww.example.com"
 	s, err := provider.ResourceCreate("mywebhook", "webhook", params)
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, url, s.Parameters["Url"])
 	}
 }
@@ -100,7 +100,7 @@ func TestServiceGet(t *testing.T) {
 
 	s, err := provider.ResourceGet("syslog")
 
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.EqualValues(t, expected, s)
 	}
 }

--- a/provider/aws/system_test.go
+++ b/provider/aws/system_test.go
@@ -23,7 +23,7 @@ func TestSystemGet(t *testing.T) {
 
 	s, err := provider.SystemGet()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, &structs.System{
 		Count:   3,
 		Name:    "convox",
@@ -44,7 +44,7 @@ func TestSystemGetConverging(t *testing.T) {
 
 	s, err := provider.SystemGet()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, &structs.System{
 		Count:   3,
 		Name:    "convox",
@@ -76,7 +76,7 @@ func TestSystemReleases(t *testing.T) {
 
 	r, err := provider.SystemReleases()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.EqualValues(t, structs.Releases{
 		structs.Release{
@@ -108,7 +108,7 @@ func TestSystemSave(t *testing.T) {
 		Version: "20160820033210",
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSystemSaveNewParameter(t *testing.T) {
@@ -127,7 +127,7 @@ func TestSystemSaveNewParameter(t *testing.T) {
 		Version: "20160820033210",
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSystemSaveWrongType(t *testing.T) {
@@ -169,7 +169,7 @@ func TestSystemProcessesList(t *testing.T) {
 		All: false,
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSystemProcessesListAll(t *testing.T) {
@@ -196,7 +196,7 @@ func TestSystemProcessesListAll(t *testing.T) {
 		All: true,
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 var cycleSystemDescribeStacks = awsutil.Cycle{

--- a/test/exec.go
+++ b/test/exec.go
@@ -31,7 +31,7 @@ func (er ExecRun) Test(t *testing.T) {
 		t.Log("ExecRun", er.Command, stdout, stderr, code, err)
 	}
 
-	assert.Nil(t, err, "should be nil")
+	assert.NoError(t, err)
 	assert.Equal(t, er.Exit, code, "exit code should be equal")
 	if er.Stdout != "" {
 		assert.Equal(t, er.Stdout, stdout, "stdout should be equal")

--- a/test/handler_func.go
+++ b/test/handler_func.go
@@ -66,7 +66,7 @@ func (f *HandlerFuncTest) AssertJSON(t *testing.T, body string) {
 	b1, err1 := stripJSON([]byte(body))
 	b2, err2 := stripJSON(f.Body())
 
-	if assert.Nil(t, err1) && assert.Nil(t, err2) {
+	if assert.NoError(t, err1) && assert.NoError(t, err2) {
 		assert.Equal(t, string(b1), string(b2))
 	}
 }


### PR DESCRIPTION
Noticed this while working on my other PR. `.NoError()` is the more correct function, as it actually prints the error [instead of just saying it should've been `nil`, with an ugly pointer address to a string.](https://travis-ci.org/convox/rack/builds/190746511#L290)

I made this change with a regex find/replace. It was rather specific, so there shouldn't have been any lines changed by mistake (and I didn't notice any when looking at the diff), but it's possible I missed some lines that should've been changed.