### PR TITLE
Add ECR region to config

### DIFF
--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -721,13 +721,15 @@ func (p *AWSProvider) authECR(host, access, secret string) (string, string, erro
 		config.Credentials = credentials.NewStaticCredentials(access, secret, "")
 	}
 
-	e := ecr.New(session.New(), config)
-
 	if !regexpECRHost.MatchString(host) {
 		return "", "", fmt.Errorf("invalid ECR hostname")
 	}
 
 	registry := regexpECRHost.FindStringSubmatch(host)
+
+	config.Region = &registry[2]
+
+	e := ecr.New(session.New(), config)
 
 	res, err := e.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{
 		RegistryIds: []*string{aws.String(registry[1])},


### PR DESCRIPTION
This enables private console builds for Racks in regions other than us-east-1.