### PR TITLE
Restore HTTP SNS subscription confirmations

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -769,6 +769,7 @@
                       "sns:Publish",
                       "sns:SetTopicAttributes",
                       "sns:Subscribe",
+                      "sns:Unsubscribe",
                       "sqs:CreateQueue",
                       "sqs:DeleteQueue",
                       "sqs:GetQueueAttributes",

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1580,7 +1580,7 @@
         "HealthCheck": {
           "HealthyThreshold": "2",
           "Interval": 5,
-          "Target": "HTTPS:4001/check",
+          "Target": "HTTP:4000/check",
           "Timeout": 3,
           "UnhealthyThreshold": "2"
         },
@@ -1986,6 +1986,7 @@
             "Memory": { "Ref": "ApiMemory" },
             "Name": "web",
             "PortMappings": [
+              "4000:3000",
               "4001:4443"
             ],
             "Volumes": [

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -760,6 +760,7 @@
                       "rds:DescribeDBSubnetGroups",
                       "s3:CreateBucket",
                       "s3:GetObject",
+                      "sns:ConfirmSubscription",
                       "sns:CreateTopic",
                       "sns:DeleteTopic",
                       "sns:GetTopicAttributes",

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1592,6 +1592,12 @@
         "Listeners": [
           {
             "Protocol": "TCP",
+            "LoadBalancerPort": "80",
+            "InstanceProtocol": "TCP",
+            "InstancePort": "4000"
+          },
+          {
+            "Protocol": "TCP",
             "LoadBalancerPort": "443",
             "InstanceProtocol": "TCP",
             "InstancePort": "4001"


### PR DESCRIPTION
This fixes creating new webhooks.

The SNS subscription stuff was depending on the /sns endpoint on port 80 to confirm subscriptions. It was also depending on the sns:ConfirmSubscription capability.

SNS does not deliver notification messages to a self-signed cert. https://forums.aws.amazon.com/thread.jspa?messageID=204271&#204271

