### PR TITLE
WIP: Add Rack to Console from CLI `convox install`

### DIFF
--- a/api/controllers/racks.go
+++ b/api/controllers/racks.go
@@ -7,5 +7,5 @@ import (
 )
 
 func RackList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
-	return httperr.Errorf(403, "only available on console")
+	return httperr.Errorf(403, "GET /racks API is not available on a single Rack. Try https://console.convox.com to manage multiple Racks.")
 }

--- a/client/racks.go
+++ b/client/racks.go
@@ -22,6 +22,16 @@ func (c *Client) Racks() (racks []Rack, err error) {
 	return racks, err
 }
 
+func (c *Client) CreateRack(name, host, password string) (rack *Rack, err error) {
+	params := map[string]string{
+		"name":     name,
+		"host":     host,
+		"password": password,
+	}
+	err = c.Post("/racks", params, &rack)
+	return rack, err
+}
+
 // StreamRackLogs streams the logs for a Rack
 func (c *Client) StreamRackLogs(filter string, follow bool, since time.Duration, output io.WriteCloser) error {
 	return c.Stream("/system/logs", map[string]string{

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -412,6 +412,12 @@ func cmdInstall(c *cli.Context) error {
 
 	fmt.Println("")
 
+	// Try to add to console. Any error falls back to old behavior
+	err = addToConsole(c, stackName, host, password)
+	if err == nil {
+		return stdcli.QOSEventSend("cli-install", distinctID, ep)
+	}
+
 	fmt.Println("Logging in...")
 
 	err = addLogin(host, password)
@@ -429,6 +435,35 @@ func cmdInstall(c *cli.Context) error {
 	fmt.Println("Success, try `convox apps`")
 
 	return stdcli.QOSEventSend("cli-install", distinctID, ep)
+}
+
+func addToConsole(c *cli.Context, name, host, password string) error {
+	consoleHost, err := currentHost()
+	if err != nil {
+		return err
+	}
+
+	rc := rackClient(c)
+	if rc == nil {
+		return fmt.Errorf("no Rack client")
+	}
+
+	// try console-only /racks API
+	_, err = rc.Racks()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Adding Rack to Console (%s)...\n", consoleHost)
+
+	_, err = rc.CreateRack(name, host, password)
+	if err != nil {
+		fmt.Println("Failed: %s", err.Error())
+		return err
+	}
+
+	fmt.Println("Success, try `convox racks`")
+	return nil
 }
 
 /// validateUserAccess checks for the "AdministratorAccess" policy needed to create a rack.


### PR DESCRIPTION
If logged into console, register the rack there instead of saving credentials locally.

There are a few design questions:

- [ ] How do you control what org and what rack name it is added to?
- [ ] Should switchHost not get called in other scenarios?