### PR TITLE
'only available on console' -> 'only available when logged into console.convox.com'

### DIFF
--- a/api/controllers/racks.go
+++ b/api/controllers/racks.go
@@ -7,5 +7,5 @@ import (
 )
 
 func RackList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
-	return httperr.Errorf(403, "only available on console")
+	return httperr.Errorf(403, "Your CLI is pointing directly at a Rack. To log into Console instead, run `convox login`")
 }

--- a/api/controllers/switch.go
+++ b/api/controllers/switch.go
@@ -7,5 +7,5 @@ import (
 )
 
 func Switch(w http.ResponseWriter, r *http.Request) *httperr.Error {
-	return httperr.Errorf(403, "only available on console")
+	return httperr.Errorf(403, "Your CLI is pointing directly at a Rack. To log into Console instead, run `convox login`")
 }


### PR DESCRIPTION
Before:
```
$ convox racks
ERROR: only available in console
```

After:
```
$ convox racks
ERROR: only available when logged into console.convox.com (or your private console)
```

This change affects `convox switch` and `convox racks`.