### PR TITLE
fix race condition with --private installs

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -637,15 +637,17 @@
         "ManagedPolicyArns": [ { "Ref": "KernelUserPolicy" }, { "Ref": "KernelUserIAMPolicy" } ]
       }
     },
-    "KernelUserPolicy": {
+    "KernelUserGeneralPolicy": {
       "Type" : "AWS::IAM::ManagedPolicy",
       "Properties" : {
         "Path": "/convox/",
-        "Description" : "Policy used by the KernelUser",
+        "Description" : "Limited general policy used by the KernelUser",
         "PolicyDocument" : {
             "Version": "2012-10-17",
             "Statement": [
                 {
+                    "Sid": "LimitedGeneralPermissions",
+                    "Effect": "Allow",
                     "Action": [
                       "acm:DescribeCertificate",
                       "acm:ListCertificates",
@@ -775,9 +777,21 @@
                       "sqs:GetQueueAttributes",
                       "sqs:SetQueueAttributes"
                     ],
-                    "Effect": "Allow",
                     "Resource": "*"
-                }, {
+                }
+            ]
+        }
+      }
+    },
+    "KernelUserPolicy": {
+      "Type" : "AWS::IAM::ManagedPolicy",
+      "Properties" : {
+        "Path": "/convox/",
+        "Description" : "Policy used by the KernelUser",
+        "PolicyDocument" : {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
                   "Sid": "LimitedDynamoDBAccess",
                   "Action": "dynamodb:*",
                   "Effect": "Allow",

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1431,6 +1431,21 @@
             "Key": "GatewayAttachment",
             "Value": { "Fn::If": [ "ExistingVpc", "existing", { "Ref": "GatewayAttachment" } ] },
             "PropagateAtLaunch": false
+          },
+          {
+            "Key": "SubnetPrivate0Routes",
+            "Value": { "Fn::If": ["Private", { "Ref": "SubnetPrivate0Routes" }, "" ] },
+            "PropagateAtLaunch": false
+          },
+          {
+            "Key": "SubnetPrivate1Routes",
+            "Value": { "Fn::If": ["Private", { "Ref": "SubnetPrivate1Routes" }, "" ] },
+            "PropagateAtLaunch": false
+          },
+          {
+            "Key": "SubnetPrivate2Routes",
+            "Value": { "Fn::If": ["PrivateAndThirdAvailabilityZone", { "Ref": "SubnetPrivate2Routes" }, "" ] },
+            "PropagateAtLaunch": false
           }
         ]
       },

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -634,7 +634,11 @@
       "Type": "AWS::IAM::User",
       "Properties": {
         "Path": "/convox/",
-        "ManagedPolicyArns": [ { "Ref": "KernelUserPolicy" }, { "Ref": "KernelUserIAMPolicy" } ]
+        "ManagedPolicyArns": [
+          { "Ref": "KernelUserPolicy" },
+          { "Ref": "KernelUserIAMPolicy" },
+          { "Ref": "KernelUserGeneralPolicy" }
+        ]
       }
     },
     "KernelUserGeneralPolicy": {

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -651,7 +651,9 @@
                       "acm:ListCertificates",
                       "acm:RequestCertificate",
                       "autoscaling:CreateLaunchConfiguration",
+                      "autoscaling:CreateOrUpdateTags",
                       "autoscaling:DeleteLaunchConfiguration",
+                      "autoscaling:DeleteTags",
                       "autoscaling:DescribeAutoScalingGroups",
                       "autoscaling:DescribeAutoScalingInstances",
                       "autoscaling:DescribeLaunchConfigurations",
@@ -1445,6 +1447,21 @@
           {
             "Key": "SubnetPrivate2Routes",
             "Value": { "Fn::If": ["PrivateAndThirdAvailabilityZone", { "Ref": "SubnetPrivate2Routes" }, "" ] },
+            "PropagateAtLaunch": false
+          },
+          {
+            "Key": "Nat0",
+            "Value": { "Fn::If": ["Private", { "Ref": "Nat0" }, "" ] },
+            "PropagateAtLaunch": false
+          },
+          {
+            "Key": "Nat1",
+            "Value": { "Fn::If": ["Private", { "Ref": "Nat1" }, "" ] },
+            "PropagateAtLaunch": false
+          },
+          {
+            "Key": "Nat2",
+            "Value": { "Fn::If": ["PrivateAndThirdAvailabilityZone", { "Ref": "Nat2" }, "" ] },
             "PropagateAtLaunch": false
           }
         ]


### PR DESCRIPTION
There were several recent user reports of installations with --private failing.

These seem to be happening because instances are booting before the private network stack is fully set up. That means there is no route to the Internet, so `yum` commands are failing in the instance boot script.

This change uses a Tags hack to make private stacks wait for the NATs and subnet associations to be set up before creating the AutoScaling Group that boots the instances.