### PR TITLE
populate Type from Service tag if Resource tag is empty

### DIFF
--- a/provider/aws/resource.go
+++ b/provider/aws/resource.go
@@ -548,10 +548,15 @@ func resourceFromStack(stack *cloudformation.Stack) structs.Resource {
 		exports["URL"] = url
 	}
 
+	rtype := tags["Resource"]
+	if rtype == "" {
+		rtype = tags["Service"]
+	}
+
 	return structs.Resource{
 		Name:       name,
 		Stack:      *stack.StackName,
-		Type:       tags["Resource"],
+		Type:       rtype,
 		Status:     humanStatus(*stack.StackStatus),
 		Outputs:    stackOutputs(stack),
 		Parameters: params,


### PR DESCRIPTION
Fixes missing type from resource listing and errors like `ERROR: Resource type  does not have a link strategy`