### PR TITLE
fix race condition with --private installs (redux)

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1337,7 +1337,7 @@
             "bootcmd:\n",
             "  - mkswap /dev/xvdb\n",
             "  - swapon /dev/xvdb\n",
-            "  - yum install -y aws-cli nfs-utils\n",
+            "  - until yum install -y aws-cli nfs-utils; do echo \"Waiting for network\"; done;\n",
             "  - mkdir /volumes\n",
             { "Fn::If": [ "RegionHasEFS",
               { "Fn::Join": [ "", [


### PR DESCRIPTION
Second attempt at solving this problem after mixed results with https://github.com/convox/rack/pull/1628.

There were several recent user reports of installations with --private failing.

These seem to be happening because instances are booting before the private network stack is fully set up. That means there is no route to the Internet, so `yum` commands are failing in the instance boot script.

This change just calls the `yum` command in a loop until it works. The `yum` command itself has a 10-second timeout so this will loop every 10 seconds.

This is a much simpler solution than the previous attempt, will work for both public and private racks, and results in faster stack creation.