### PR TITLE
Break out general KernelUser policy

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -634,18 +634,24 @@
       "Type": "AWS::IAM::User",
       "Properties": {
         "Path": "/convox/",
-        "ManagedPolicyArns": [ { "Ref": "KernelUserPolicy" }, { "Ref": "KernelUserIAMPolicy" } ]
+        "ManagedPolicyArns": [
+          { "Ref": "KernelUserPolicy" },
+          { "Ref": "KernelUserIAMPolicy" },
+          { "Ref": "KernelUserGeneralPolicy" }
+        ]
       }
     },
-    "KernelUserPolicy": {
+    "KernelUserGeneralPolicy": {
       "Type" : "AWS::IAM::ManagedPolicy",
       "Properties" : {
         "Path": "/convox/",
-        "Description" : "Policy used by the KernelUser",
+        "Description" : "Limited general policy used by the KernelUser",
         "PolicyDocument" : {
             "Version": "2012-10-17",
             "Statement": [
                 {
+                    "Sid": "LimitedGeneralPermissions",
+                    "Effect": "Allow",
                     "Action": [
                       "acm:DescribeCertificate",
                       "acm:ListCertificates",
@@ -773,9 +779,21 @@
                       "sqs:GetQueueAttributes",
                       "sqs:SetQueueAttributes"
                     ],
-                    "Effect": "Allow",
                     "Resource": "*"
-                }, {
+                }
+            ]
+        }
+      }
+    },
+    "KernelUserPolicy": {
+      "Type" : "AWS::IAM::ManagedPolicy",
+      "Properties" : {
+        "Path": "/convox/",
+        "Description" : "Policy used by the KernelUser",
+        "PolicyDocument" : {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
                   "Sid": "LimitedDynamoDBAccess",
                   "Action": "dynamodb:*",
                   "Effect": "Allow",

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -630,7 +630,7 @@
       }
     },
     "KernelUser": {
-      "DependsOn": [ "KernelUserPolicy", "KernelUserIAMPolicy" ],
+      "DependsOn": [ "KernelUserPolicy", "KernelUserIAMPolicy", "KernelUserGeneralPolicy" ],
       "Type": "AWS::IAM::User",
       "Properties": {
         "Path": "/convox/",


### PR DESCRIPTION
**Note**: this might cause another ECS Service replacement. We should test for that and take appropriate actions to mitigate update issues if so.

Break out general KernelUser policy to avoid AWS character limits.

Over time we will move more of these into "locked down" policy documents.