### PR TITLE
NAT DependsOn KernelUser

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -961,7 +961,7 @@
     },
     "Nat0": {
       "Condition": "Private",
-      "DependsOn": "KernelUser",
+      "DependsOn": "KernelAccess",
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
         "AllocationId": { "Fn::GetAtt": [ "NatAddress0", "AllocationId" ] },
@@ -970,7 +970,7 @@
     },
     "Nat1": {
       "Condition": "Private",
-      "DependsOn": "KernelUser",
+      "DependsOn": "KernelAccess",
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
         "AllocationId": { "Fn::GetAtt": [ "NatAddress1", "AllocationId" ] },
@@ -979,7 +979,7 @@
     },
     "Nat2": {
       "Condition": "PrivateAndThirdAvailabilityZone",
-      "DependsOn": "KernelUser",
+      "DependsOn": "KernelAccess",
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
         "AllocationId": { "Fn::GetAtt": [ "NatAddress2", "AllocationId" ] },

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -742,6 +742,7 @@
                       "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
                       "events:DescribeRule",
                       "iam:DeleteServerCertificate",
+                      "iam:GetPolicy",
                       "iam:GetServerCertificate",
                       "iam:ListServerCertificates",
                       "iam:PassRole",
@@ -960,6 +961,7 @@
     },
     "Nat0": {
       "Condition": "Private",
+      "DependsOn": "KernelUser",
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
         "AllocationId": { "Fn::GetAtt": [ "NatAddress0", "AllocationId" ] },
@@ -968,6 +970,7 @@
     },
     "Nat1": {
       "Condition": "Private",
+      "DependsOn": "KernelUser",
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
         "AllocationId": { "Fn::GetAtt": [ "NatAddress1", "AllocationId" ] },
@@ -976,6 +979,7 @@
     },
     "Nat2": {
       "Condition": "PrivateAndThirdAvailabilityZone",
+      "DependsOn": "KernelUser",
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
         "AllocationId": { "Fn::GetAtt": [ "NatAddress2", "AllocationId" ] },


### PR DESCRIPTION
A CloudFormation stack update can fail if the NATs are updated before the KernelUserGeneralPolicy is created.

![screen shot 2017-01-31 at 8 54 54 pm](https://cloud.githubusercontent.com/assets/44615/22513879/8becd084-e86b-11e6-99e2-bdc622ec1d26.png)

This PR makes the NAT resources depend on the KernelUser (which depends on all its policies) to avoid this timing issue.