### PR TITLE
Allow DOCKER_BIN to specify location of docker binary

### DIFF
--- a/cmd/convox/convox.go
+++ b/cmd/convox/convox.go
@@ -1,6 +1,11 @@
 package main
 
-import "github.com/convox/rack/cmd/convox/stdcli"
+import (
+	"github.com/convox/rack/cmd/convox/helpers"
+	"github.com/convox/rack/cmd/convox/stdcli"
+)
+
+var dockerBin = helpers.DetectDocker()
 
 func init() {
 	stdcli.DefaultWriter.Tags["app"] = stdcli.RenderAttributes(39)

--- a/cmd/convox/doctor.go
+++ b/cmd/convox/doctor.go
@@ -221,9 +221,8 @@ func cmdDoctor(c *cli.Context) error {
 
 func checkDockerRunning() error {
 	startCheck("Docker running")
-	d := stdcli.Docker()
 
-	dockerTest := exec.Command(d, "images")
+	dockerTest := exec.Command(dockerBin, "images")
 	err := dockerTest.Run()
 	if err != nil {
 		diagnose(Diagnosis{
@@ -234,7 +233,7 @@ func checkDockerRunning() error {
 		})
 		return nil
 	} else {
-		dv, _ := exec.Command(d, "-v").Output()
+		dv, _ := exec.Command(dockerBin, "-v").Output()
 		v := strings.Split(string(dv), "\n")[0]
 		diagnose(Diagnosis{
 			Title: fmt.Sprintf("Docker running (%s)", v),

--- a/cmd/convox/doctor.go
+++ b/cmd/convox/doctor.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -227,7 +226,6 @@ func checkDockerRunning() error {
 	dockerTest := exec.Command(d, "images")
 	err := dockerTest.Run()
 	if err != nil {
-		log.Panic(err)
 		diagnose(Diagnosis{
 			Title:       "Docker running",
 			Description: "<fail>Could not connect to the Docker daemon, is it installed and running?</fail>",

--- a/cmd/convox/doctor.go
+++ b/cmd/convox/doctor.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -221,10 +222,12 @@ func cmdDoctor(c *cli.Context) error {
 
 func checkDockerRunning() error {
 	startCheck("Docker running")
+	d := stdcli.Docker()
 
-	dockerTest := exec.Command("docker", "images")
+	dockerTest := exec.Command(d, "images")
 	err := dockerTest.Run()
 	if err != nil {
+		log.Panic(err)
 		diagnose(Diagnosis{
 			Title:       "Docker running",
 			Description: "<fail>Could not connect to the Docker daemon, is it installed and running?</fail>",
@@ -233,8 +236,10 @@ func checkDockerRunning() error {
 		})
 		return nil
 	} else {
+		dv, _ := exec.Command(d, "-v").Output()
+		v := strings.Split(string(dv), "\n")[0]
 		diagnose(Diagnosis{
-			Title: "Docker running",
+			Title: fmt.Sprintf("Docker running (%s)", v),
 			Kind:  "success",
 		})
 	}
@@ -262,14 +267,14 @@ func checkDockerVersion() error {
 
 	if !(currentVersion.GreaterThanOrEqualTo(minDockerVersion)) {
 		diagnose(Diagnosis{
-			Title:       "Docker up to date",
+			Title:       "Docker up to date ",
 			Description: "<fail>Docker engine is out of date (min: 1.9)</fail>",
 			DocsLink:    "https://docs.docker.com/engine/installation/",
 			Kind:        "fail",
 		})
 	} else {
 		diagnose(Diagnosis{
-			Title: "Docker up to date",
+			Title: fmt.Sprintf("Docker up to date (%s)", currentVersion),
 			Kind:  "success",
 		})
 	}

--- a/cmd/convox/helpers/helpers.go
+++ b/cmd/convox/helpers/helpers.go
@@ -61,3 +61,11 @@ func DetectApplication(dir string) string {
 
 	return "unknown"
 }
+
+func DetectDocker() string {
+	osd := os.Getenv("DOCKER_BIN")
+	if osd != "" {
+		return osd
+	}
+	return "docker"
+}

--- a/cmd/convox/helpers/helpers.go
+++ b/cmd/convox/helpers/helpers.go
@@ -62,6 +62,7 @@ func DetectApplication(dir string) string {
 	return "unknown"
 }
 
+// DetectDocker checks for a fully-qualified path to a Docker binary in $DOCKER_BIN. If not present, returns the one in the host path.
 func DetectDocker() string {
 	osd := os.Getenv("DOCKER_BIN")
 	if osd != "" {

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -25,6 +25,7 @@ var (
 	Querier    func(bin string, args ...string) ([]byte, error)
 	Spinner    *spinner.Spinner
 	Tagger     func() string
+	Docker     func() string
 )
 
 func init() {
@@ -35,6 +36,7 @@ func init() {
 	Runner = runExecCommand
 	Spinner = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	Tagger = tagTimeUnix
+	Docker = getDockerBin
 
 	cli.AppHelpTemplate = `{{.Name}}: {{.Usage}}
 
@@ -262,6 +264,19 @@ func runExecCommand(bin string, args ...string) error {
 
 func queryExecCommand(bin string, args ...string) ([]byte, error) {
 	return exec.Command(bin, args...).CombinedOutput()
+}
+
+func getDockerBin() string {
+	osd := os.Getenv("DOCKER_BIN")
+	if osd != "" {
+		return osd
+	}
+	wd, err := exec.Command("which", "docker").Output()
+	whichDocker := strings.Split(string(wd), "\n")[0]
+	if err != nil {
+		return err.Error()
+	}
+	return whichDocker
 }
 
 func tagTimeUnix() string {

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -12,7 +12,6 @@ import (
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/briandowns/spinner"
-	"github.com/convox/rack/cmd/convox/helpers"
 	"github.com/segmentio/analytics-go"
 	"github.com/stvp/rollbar"
 )
@@ -26,7 +25,6 @@ var (
 	Querier    func(bin string, args ...string) ([]byte, error)
 	Spinner    *spinner.Spinner
 	Tagger     func() string
-	Docker     func() string
 )
 
 func init() {
@@ -37,7 +35,6 @@ func init() {
 	Runner = runExecCommand
 	Spinner = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	Tagger = tagTimeUnix
-	Docker = helpers.DetectDocker
 
 	cli.AppHelpTemplate = `{{.Name}}: {{.Usage}}
 

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/briandowns/spinner"
+	"github.com/convox/rack/cmd/convox/helpers"
 	"github.com/segmentio/analytics-go"
 	"github.com/stvp/rollbar"
 )
@@ -36,7 +37,7 @@ func init() {
 	Runner = runExecCommand
 	Spinner = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	Tagger = tagTimeUnix
-	Docker = getDockerBin
+	Docker = helpers.DetectDocker
 
 	cli.AppHelpTemplate = `{{.Name}}: {{.Usage}}
 
@@ -264,14 +265,6 @@ func runExecCommand(bin string, args ...string) error {
 
 func queryExecCommand(bin string, args ...string) ([]byte, error) {
 	return exec.Command(bin, args...).CombinedOutput()
-}
-
-func getDockerBin() string {
-	osd := os.Getenv("DOCKER_BIN")
-	if osd != "" {
-		return osd
-	}
-	return "docker"
 }
 
 func tagTimeUnix() string {

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -271,12 +271,7 @@ func getDockerBin() string {
 	if osd != "" {
 		return osd
 	}
-	wd, err := exec.Command("which", "docker").Output()
-	whichDocker := strings.Split(string(wd), "\n")[0]
-	if err != nil {
-		return err.Error()
-	}
-	return whichDocker
+	return "docker"
 }
 
 func tagTimeUnix() string {


### PR DESCRIPTION
This is a minimal implementation to demonstrate making the CLI use a `DOCKER_BIN` environment variable instead of just `docker`.

Currently, at various places in the code, the CLI grabs the output of `docker` commands.

If accepted (in a less hypothetical form), this PR would allow a user to set `CONVOX_ENV` to a fully-qualified path, e.g. `/usr/bin/docker12`, in order to easily switch between Docker versions. If not set, the output of `which docker` is used.

This is probably pretty pointless and unnecessary since the user can just alias `docker` to whatever binary they want. But I'm throwing it out there anyway, if only to raise the issue of the fact that **at some places in the code, a "different docker" is being used (namely, `github.com/fsouza/go-dockerclient`), which can cause unexpected contradictions, especially during tests.** Different versions of docker use different api endpoints (e.g. `/v1.24/auth` vs `/v1.25/auth`) and make extra calls (notably `/_ping` comes up in docker 1.13). But our docker stubs can only support one series of calls at a time, which vary from 1.12 to 1.13 (see https://github.com/convox/rack/pull/1601).

