### PR TITLE
Add "Accept: application/json" header to client requests (blocked by console #794)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -433,6 +433,7 @@ func (c *Client) Request(method, path string, body io.Reader) (*http.Request, er
 	req.SetBasicAuth("convox", string(c.Password))
 
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Version", c.Version)
 
 	if c.Rack != "" {


### PR DESCRIPTION
- Add "Accept: application/json" header to client requests
- Add test for nonexistent API endpoints (blocked by console #794)

P.S. Hardcoding the expected reply in `TestApiGet404` felt like it defeated the purpose, so I did it the hard way, by making an actual request for a nonexistent page (which is why the test will fail until console #794 is merged). There must be an easier way to validate responses from Console. Unfortunately, I don't know what it is yet.