### PR TITLE
autoscaling:DeleteLifecycleHook permission

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -658,6 +658,7 @@
                       "acm:RequestCertificate",
                       "autoscaling:CreateLaunchConfiguration",
                       "autoscaling:DeleteLaunchConfiguration",
+                      "autoscaling:DeleteLifecycleHook",
                       "autoscaling:DescribeAutoScalingGroups",
                       "autoscaling:DescribeAutoScalingInstances",
                       "autoscaling:DescribeLaunchConfigurations",


### PR DESCRIPTION
Needed for updates from some older racks.