### PR TITLE
Prevent terminal from hanging on ssh error

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -67,7 +67,6 @@ func (c *Client) SSHInstance(id, cmd string, height, width int, isTerm bool, in 
 		headers["Terminal"] = "xterm"
 	}
 	err := c.Stream(fmt.Sprintf("/instances/%s/ssh", id), headers, in, w)
-
 	if err != nil {
 		return -1, err
 	}

--- a/client/processes.go
+++ b/client/processes.go
@@ -147,9 +147,14 @@ func copyWithExit(w io.Writer, r io.Reader, ch chan int) {
 		if err != nil {
 			break
 		}
+		if s := string(buf[0:n]); strings.Contains(s, StatusCodePrefix) {
+			rr := strings.Split(s, StatusCodePrefix)
 
-		if s := string(buf[0:n]); strings.HasPrefix(s, StatusCodePrefix) {
-			code, _ = strconv.Atoi(strings.TrimSpace(s[37:]))
+			if rr[0] != "" {
+				w.Write([]byte(strings.TrimSpace(rr[0]) + "\n"))
+			}
+
+			code, _ = strconv.Atoi(strings.TrimSpace(rr[1]))
 			return
 		}
 


### PR DESCRIPTION
When trying to SSH into an instance that doesn't exist or no ssh key, the terminal would hang. This change injects the status code prefix in the error so the client can parse and act accordingly.