### PR TITLE
Recover --rack from os.Args if urfave/cli has dropped it

### DIFF
--- a/api/controllers/apps_test.go
+++ b/api/controllers/apps_test.go
@@ -24,7 +24,7 @@ func TestAppList(t *testing.T) {
 	aws := test.StubAws(test.DescribeStackCycleWithoutQuery("convox-test-bar"))
 	defer aws.Close()
 
-	body := test.HTTPBody("GET", "http://convox/apps", nil)
+	body := test.HTTPBody("GET", "http://convox/apps", nil, nil)
 
 	var resp []map[string]string
 	err := json.Unmarshal([]byte(body), &resp)
@@ -82,7 +82,7 @@ func TestAppCreate(t *testing.T) {
 	defer aws.Close()
 
 	val := url.Values{"name": []string{"application"}}
-	body := test.HTTPBody("POST", "http://convox/apps", val)
+	body := test.HTTPBody("POST", "http://convox/apps", val, nil)
 
 	if assert.NotEqual(t, "", body) {
 		var resp map[string]string
@@ -104,7 +104,7 @@ func TestAppCreateWithAlreadyExists(t *testing.T) {
 	defer aws.Close()
 
 	val := url.Values{"name": []string{"application"}}
-	body := test.AssertStatus(t, 403, "POST", "http://convox/apps", val)
+	body := test.AssertStatus(t, 403, "POST", "http://convox/apps", val, nil)
 	assert.Equal(t, "{\"error\":\"there is already an app named application (running)\"}", body)
 }
 
@@ -115,7 +115,7 @@ func TestAppCreateWithAlreadyExistsUnbound(t *testing.T) {
 	defer aws.Close()
 
 	val := url.Values{"name": []string{"application"}}
-	body := test.AssertStatus(t, 403, "POST", "http://convox/apps", val)
+	body := test.AssertStatus(t, 403, "POST", "http://convox/apps", val, nil)
 	assert.Equal(t, "{\"error\":\"there is already a legacy app named application (running). We recommend you delete this app and create it again.\"}", body)
 }
 
@@ -126,7 +126,7 @@ func TestAppCreateWithRackName(t *testing.T) {
 	defer aws.Close()
 
 	val := url.Values{"name": []string{"convox-test"}}
-	body := test.AssertStatus(t, 403, "POST", "http://convox/apps", val)
+	body := test.AssertStatus(t, 403, "POST", "http://convox/apps", val, nil)
 	assert.Equal(t, "{\"error\":\"application name cannot match rack name (convox-test). Please choose a different name for your app.\"}", body)
 }
 
@@ -144,7 +144,7 @@ func TestAppDelete(t *testing.T) {
 	// setup expectations on current provider
 	models.TestProvider.On("AppDelete", "bar").Return(nil)
 
-	body := test.HTTPBody("DELETE", "http://convox/apps/bar", nil)
+	body := test.HTTPBody("DELETE", "http://convox/apps/bar", nil, nil)
 
 	var resp map[string]bool
 	err := json.Unmarshal([]byte(body), &resp)
@@ -161,7 +161,7 @@ func TestAppDeleteWithAppNotFound(t *testing.T) {
 	)
 	defer aws.Close()
 
-	test.AssertStatus(t, 404, "DELETE", "http://convox/apps/bar", nil)
+	test.AssertStatus(t, 404, "DELETE", "http://convox/apps/bar", nil, nil)
 }
 
 func TestAppLogs(t *testing.T) {

--- a/cmd/convox/api_test.go
+++ b/cmd/convox/api_test.go
@@ -20,3 +20,42 @@ func TestApiGet(t *testing.T) {
 		},
 	)
 }
+
+func TestRackFlag(t *testing.T) {
+	ts := testServer(t,
+		test.Http{Method: "GET", Path: "/foo", Code: 200, Response: "bar", Headers: map[string]string{"Rack": "myorg/staging"}},
+	)
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command:  "convox --rack myorg/staging api get /foo",
+			Exit:     0,
+			OutMatch: "bar",
+		},
+	)
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox api --rack myorg/staging get /foo",
+			Exit:    0,
+			Stdout:  "bar",
+		},
+	)
+
+	test.Runs(t,
+		test.ExecRun{
+			Command:  "convox api get --rack myorg/staging /foo",
+			Exit:     0,
+			OutMatch: "bar",
+		},
+	)
+
+	test.Runs(t,
+		test.ExecRun{
+			Command:  "convox api get /foo --rack myorg/staging",
+			Exit:     0,
+			OutMatch: "bar",
+		},
+	)
+}

--- a/cmd/convox/api_test.go
+++ b/cmd/convox/api_test.go
@@ -23,7 +23,13 @@ func TestApiGet(t *testing.T) {
 
 func TestRackFlag(t *testing.T) {
 	ts := testServer(t,
-		test.Http{Method: "GET", Path: "/foo", Code: 200, Response: "bar", Headers: map[string]string{"Rack": "myorg/staging"}},
+		test.Http{
+			Method:   "GET",
+			Path:     "/foo",
+			Code:     200,
+			Response: "bar",
+			Headers:  map[string]string{"Rack": "myorg/staging"},
+		},
 	)
 	defer ts.Close()
 

--- a/cmd/convox/api_test.go
+++ b/cmd/convox/api_test.go
@@ -37,9 +37,9 @@ func TestRackFlag(t *testing.T) {
 
 	test.Runs(t,
 		test.ExecRun{
-			Command: "convox api --rack myorg/staging get /foo",
-			Exit:    0,
-			Stdout:  "bar",
+			Command:  "convox api --rack myorg/staging get /foo",
+			Exit:     0,
+			OutMatch: "bar",
 		},
 	)
 

--- a/cmd/convox/main.go
+++ b/cmd/convox/main.go
@@ -98,18 +98,15 @@ func coalesce(ss ...string) string {
 // if --rack is missing from c.String(), recover it here by checking os.Args
 func getRackFlag(c *cli.Context) string {
 	rackFlag := c.String("rack")
-	if rackFlag == "" {
-		osArgs := os.Args
-
-		// set rackFlag to everything after --rack
-		pArgs := stdcli.ParseOpts(osArgs)
-		rackFlag = pArgs["rack"]
-
-		// stdcli.ParseOpts() includes everything after --rack, so discard everything after the first space
-		rackFlagSplit := strings.Split(rackFlag, " ")
-		rackFlag = rackFlagSplit[0]
+	if rackFlag != "" {
+		return rackFlag
 	}
-	return rackFlag
+
+	// set rackFlag to everything after --rack
+	rackFlag = stdcli.ParseOpts(os.Args)["rack"]
+
+	// stdcli.ParseOpts() includes everything after --rack, so discard everything after the first space
+	return strings.Split(rackFlag, " ")[0]
 }
 
 func currentRack(c *cli.Context) string {

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -84,6 +84,17 @@ func New() *cli.App {
 	app.Name = Binary
 	app.Commands = Commands
 
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "app, a",
+			Usage: "app name inferred from current directory if not specified",
+		},
+		cli.StringFlag{
+			Name:  "rack",
+			Usage: "rack name",
+		},
+	}
+
 	app.CommandNotFound = func(c *cli.Context, cmd string) {
 		fmt.Fprintf(os.Stderr, "No such command \"%s\". Try `%s help`\n", cmd, Binary)
 		os.Exit(1)

--- a/test/http.go
+++ b/test/http.go
@@ -15,14 +15,15 @@ type Http struct {
 	Path     string
 	Code     int
 	Body     string
+	Headers  map[string]string
 	Response interface{}
 }
 
 var HandlerFunc http.HandlerFunc
 
-func AssertStatus(t *testing.T, status int, method, url string, values url.Values) string {
+func AssertStatus(t *testing.T, status int, method, url string, values url.Values, headers map[string]string) string {
 	w := httptest.NewRecorder()
-	req, err := buildRequest(method, url, values)
+	req, err := buildRequest(method, url, values, headers)
 
 	if err != nil {
 		t.Error(err)
@@ -34,9 +35,9 @@ func AssertStatus(t *testing.T, status int, method, url string, values url.Value
 	return w.Body.String()
 }
 
-func HTTPBody(method, url string, values url.Values) string {
+func HTTPBody(method, url string, values url.Values, headers map[string]string) string {
 	w := httptest.NewRecorder()
-	req, err := buildRequest(method, url, values)
+	req, err := buildRequest(method, url, values, headers)
 
 	if err != nil {
 		return ""
@@ -46,7 +47,7 @@ func HTTPBody(method, url string, values url.Values) string {
 	return w.Body.String()
 }
 
-func buildRequest(method, url string, values url.Values) (req *http.Request, err error) {
+func buildRequest(method, url string, values url.Values, headers map[string]string) (req *http.Request, err error) {
 
 	if method == "POST" {
 		postBody := strings.NewReader(values.Encode())
@@ -57,6 +58,10 @@ func buildRequest(method, url string, values url.Values) (req *http.Request, err
 	}
 
 	req.Header.Set("Version", "dev")
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 
 	return
 }

--- a/test/http.go
+++ b/test/http.go
@@ -21,6 +21,7 @@ type Http struct {
 
 var HandlerFunc http.HandlerFunc
 
+// AssertStatus fails a test if the response status doesn't match the expected status
 func AssertStatus(t *testing.T, status int, method, url string, values url.Values, headers map[string]string) string {
 	w := httptest.NewRecorder()
 	req, err := buildRequest(method, url, values, headers)
@@ -35,6 +36,7 @@ func AssertStatus(t *testing.T, status int, method, url string, values url.Value
 	return w.Body.String()
 }
 
+// HTTPBody reads the HTTP response body as a string
 func HTTPBody(method, url string, values url.Values, headers map[string]string) string {
 	w := httptest.NewRecorder()
 	req, err := buildRequest(method, url, values, headers)

--- a/test/server.go
+++ b/test/server.go
@@ -17,7 +17,15 @@ func Server(t *testing.T, stubs ...Http) *httptest.Server {
 		found := false
 
 		for _, stub := range stubs {
-			if stub.Method == r.Method && stub.Path == r.URL.Path {
+			headersMatch := true
+			for k, v := range stub.Headers {
+				if r.Header.Get(k) != v {
+					headersMatch = false
+					break
+				}
+			}
+
+			if stub.Method == r.Method && stub.Path == r.URL.Path && headersMatch {
 				data, err := json.Marshal(stub.Response)
 
 				if err != nil {


### PR DESCRIPTION
## Flag handling changes

**Current behavior**: If `--rack` is passed in position 0, convox (via urfave/cli) ignores it. 
**PR behavior:** When coalescing the active rack, if urfave/cli thinks the rack flag is empty, we double-check in the os.args via `getRackFlag()`.

@noah added `rack` and `app` app.Flags at the CLI level.
(There might therefore be some redundancy in `getRackFlag()`; need to check.) 

## Testing changes

To test this, we needed to add a `rack` header to the testServer. That wasn't possible before, so @noah added `Headers` to the `Http` struct in `test/http.go`. (I think we could have accomplished this via the `CONVOX_RACK` env var, but being able to manipulate headers is useful anyway.)

Resolves:
* #1107
* #1202
* #1520 
* https://github.com/convox/console/issues/513