### PR TITLE
Handle case where terminal doesn't enter raw mode

### DIFF
--- a/client/processes.go
+++ b/client/processes.go
@@ -136,7 +136,9 @@ func copyWithExit(w io.Writer, r io.Reader, ch chan int) {
 	state, _ := terminal.MakeRaw(int(os.Stdin.Fd()))
 
 	defer func() {
-		terminal.Restore(int(os.Stdin.Fd()), state)
+		if state != nil {
+			terminal.Restore(int(os.Stdin.Fd()), state)
+		}
 		ch <- code
 	}()
 

--- a/client/processes.go
+++ b/client/processes.go
@@ -68,6 +68,9 @@ func (c *Client) ExecProcessAttached(app, pid, command string, in io.Reader, out
 	}
 
 	err := c.Stream(fmt.Sprintf("/apps/%s/processes/%s/exec", app, pid), headers, in, w)
+
+	w.Close()
+
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
In some cases when `terminal.MakeRaw` is called the terminal will not go into raw mode and `nil` will be returned as the state. If `terminal.Restore` is later called with a nil state the CLI will panic. This change checks for a nil state and does not call `terminal.Restore`.

This also adds back a call to close a PipeWriter in the case of validation errors, etc so that it doesn't hang open.