### PR TITLE
Paginate stack listing

### DIFF
--- a/provider/aws/apps.go
+++ b/provider/aws/apps.go
@@ -27,10 +27,7 @@ func (p *AWSProvider) AppCancel(name string) error {
 
 // AppGet gets an app
 func (p *AWSProvider) AppGet(name string) (*structs.App, error) {
-	var res *cloudformation.DescribeStacksOutput
-	var err error
-
-	res, err = p.describeStacks(&cloudformation.DescribeStacksInput{
+	stacks, err := p.describeStacks(&cloudformation.DescribeStacksInput{
 		StackName: aws.String(p.Rack + "-" + name),
 	})
 	if ae, ok := err.(awserr.Error); ok && ae.Code() == "ValidationError" {
@@ -39,11 +36,11 @@ func (p *AWSProvider) AppGet(name string) (*structs.App, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(res.Stacks) != 1 {
+	if len(stacks) != 1 {
 		return nil, fmt.Errorf("could not load stack for app: %s", name)
 	}
 
-	app := appFromStack(res.Stacks[0])
+	app := appFromStack(stacks[0])
 
 	if app.Tags["Rack"] != "" && app.Tags["Rack"] != p.Rack {
 		return nil, fmt.Errorf("no such app: %s", name)

--- a/provider/aws/system.go
+++ b/provider/aws/system.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (p *AWSProvider) SystemGet() (*structs.System, error) {
-	res, err := p.describeStacks(&cloudformation.DescribeStacksInput{
+	stacks, err := p.describeStacks(&cloudformation.DescribeStacksInput{
 		StackName: aws.String(p.Rack),
 	})
 	if ae, ok := err.(awserr.Error); ok && ae.Code() == "ValidationError" {
@@ -25,11 +25,11 @@ func (p *AWSProvider) SystemGet() (*structs.System, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(res.Stacks) != 1 {
+	if len(stacks) != 1 {
 		return nil, fmt.Errorf("could not load stack for app: %s", p.Rack)
 	}
 
-	stack := res.Stacks[0]
+	stack := stacks[0]
 	status := humanStatus(*stack.StackStatus)
 	params := stackParameters(stack)
 


### PR DESCRIPTION
Accounts with large amounts of CloudFormation stacks can see only partial results for `convox resources` or `convox apps`.

This change pages through the full listing of stacks to make sure the result is complete.