### PR TITLE
Unify usage string formatting; grammar tweaks

### DIFF
--- a/cmd/convox/api.go
+++ b/cmd/convox/api.go
@@ -11,21 +11,21 @@ import (
 func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "api",
-		Description: "api endpoint",
+		Description: "API endpoint",
 		Usage:       "",
 		Action:      cmdApi,
 		Flags:       []cli.Flag{rackFlag},
 		Subcommands: []cli.Command{
 			{
 				Name:        "get",
-				Description: "get an api endpoint",
+				Description: "Get an API endpoint",
 				Usage:       "<endpoint>",
 				Action:      cmdApiGet,
 				Flags:       []cli.Flag{rackFlag},
 			},
 			{
 				Name:        "delete",
-				Description: "delete an api endpoint",
+				Description: "Delete an API endpoint",
 				Usage:       "<endpoint>",
 				Action:      cmdApiDelete,
 				Flags:       []cli.Flag{rackFlag},

--- a/cmd/convox/apps.go
+++ b/cmd/convox/apps.go
@@ -19,14 +19,14 @@ func init() {
 		Subcommands: []cli.Command{
 			{
 				Name:        "cancel",
-				Description: "cancel an update",
+				Description: "Cancel an update",
 				Usage:       "",
 				Action:      cmdAppCancel,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
 				Name:        "create",
-				Description: "create a new application",
+				Description: "Create a new app",
 				Usage:       "<name>",
 				Action:      cmdAppCreate,
 				Flags: []cli.Flag{
@@ -34,34 +34,34 @@ func init() {
 					cli.BoolFlag{
 						Name:   "wait",
 						EnvVar: "CONVOX_WAIT",
-						Usage:  "wait for app to finish creating before returning",
+						Usage:  "Wait for app to finish creating before returning",
 					},
 				},
 			},
 			{
 				Name:        "delete",
-				Description: "delete an application",
+				Description: "Delete an app",
 				Usage:       "<name>",
 				Action:      cmdAppDelete,
 				Flags:       []cli.Flag{rackFlag},
 			},
 			{
 				Name:        "info",
-				Description: "see info about an app",
+				Description: "See info about an app",
 				Usage:       "[name]",
 				Action:      cmdAppInfo,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
 				Name:        "params",
-				Description: "list advanced parameters for an app",
+				Description: "List advanced parameters for an app",
 				Usage:       "[name]",
 				Action:      cmdAppParams,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 				Subcommands: []cli.Command{
 					{
 						Name:        "set",
-						Description: "update advanced parameters for an app",
+						Description: "Update advanced parameters for an app",
 						Usage:       "NAME=VALUE [NAME=VALUE]",
 						Action:      cmdAppParamsSet,
 						Flags:       []cli.Flag{appFlag, rackFlag},

--- a/cmd/convox/doctor.go
+++ b/cmd/convox/doctor.go
@@ -25,7 +25,7 @@ func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "doctor",
 		Action:      cmdDoctor,
-		Description: "Check your app for common Convox compatibility issues.",
+		Description: "check your app for common issues",
 	})
 }
 

--- a/cmd/convox/exec.go
+++ b/cmd/convox/exec.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "exec",
-		Description: "exec a command in a process in your Convox rack",
+		Description: "Execute a command in a process in your Convox rack",
 		Usage:       "[pid] [command]",
 		Action:      cmdExec,
 		Flags:       []cli.Flag{appFlag, rackFlag},

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -63,91 +63,91 @@ func init() {
 
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "install",
-		Description: "install convox into an aws account",
+		Description: "Install Convox into an AWS account",
 		Usage:       "[credentials.csv]",
 		Action:      cmdInstall,
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:   "email",
-				EnvVar: "CONVOX_EMAIL",
-				Usage:  "email address to receive project updates",
-			},
-			cli.StringFlag{
-				Name:   "password",
-				EnvVar: "PASSWORD",
-				Value:  "",
-				Usage:  "custom rack password",
-			},
-			cli.StringFlag{
 				Name:  "ami",
 				Value: "",
-				Usage: "custom AMI for rack instances",
+				Usage: "Custom AMI for Rack instances",
 			},
 			cli.BoolFlag{
 				Name:  "dedicated",
-				Usage: "create EC2 instances on dedicated hardware",
+				Usage: "Create EC2 instances on dedicated hardware",
+			},
+			cli.StringFlag{
+				Name:   "email",
+				EnvVar: "CONVOX_EMAIL",
+				Usage:  "Email address to receive project updates",
 			},
 			cli.StringFlag{
 				Name:  "existing-vpc",
 				Value: "",
-				Usage: "existing vpc id into which to install rack",
+				Usage: "Existing VPC ID into which to install Rack",
 			},
 			cli.IntFlag{
 				Name:  "instance-count",
 				Value: 3,
-				Usage: "number of instances in the rack",
+				Usage: "Number of instances in the Rack",
 			},
 			cli.StringFlag{
 				Name:  "instance-type",
 				Value: "t2.small",
-				Usage: "type of instances in the rack",
+				Usage: "Type of instances in the Rack",
 			},
 			cli.StringFlag{
 				Name:  "internet-gateway",
 				Value: "",
-				Usage: "internet gateway id to use in existing vpc",
+				Usage: "Internet gateway ID to use in existing VPC",
 			},
 			cli.BoolFlag{
 				Name:  "no-autoscale",
-				Usage: "use to disable autoscale during install (which is enabled by default)",
+				Usage: "Disable autoscale during install (autoscale is enabled by default)",
+			},
+			cli.StringFlag{
+				Name:   "password",
+				EnvVar: "RACK_PASSWORD,PASSWORD",
+				Value:  "",
+				Usage:  "Custom Rack password",
 			},
 			cli.BoolFlag{
 				Name:   "private",
-				Usage:  "use private subnets and NAT gateways to shield instances",
+				Usage:  "Use private subnets and NAT gateways to shield instances",
 				EnvVar: "RACK_PRIVATE",
 			},
 			cli.StringFlag{
 				Name:  "private-cidrs",
 				Value: "10.0.4.0/24,10.0.5.0/24,10.0.6.0/24",
-				Usage: "private subnet CIDRs",
+				Usage: "Private subnet CIDRs",
 			},
 			cli.StringFlag{
 				Name:   "region",
 				Value:  "us-east-1",
-				Usage:  "aws region",
+				Usage:  "AWS region",
 				EnvVar: "AWS_REGION,AWS_DEFAULT_REGION",
 			},
 			cli.StringFlag{
 				Name:   "stack-name",
 				EnvVar: "STACK_NAME",
 				Value:  "convox",
-				Usage:  "custom rack name",
+				Usage:  "Custom Rack name",
+			},
+			cli.StringFlag{
+				Name:  "subnet-cidrs",
+				Value: "10.0.1.0/24,10.0.2.0/24,10.0.3.0/24",
+				Usage: "Subnet CIDRs",
 			},
 			cli.StringFlag{
 				Name:   "version",
 				EnvVar: "VERSION",
 				Value:  "latest",
-				Usage:  "install a specific version",
+				Usage:  "Install a specific version of Convox",
 			},
 			cli.StringFlag{
 				Name:  "vpc-cidr",
 				Value: "10.0.0.0/16",
-				Usage: "custom VPC CIDR",
-			},
-			cli.StringFlag{
-				Name:  "subnet-cidrs",
-				Value: "10.0.1.0/24,10.0.2.0/24,10.0.3.0/24",
-				Usage: "subnet CIDRs",
+				Usage: "Custom VPC CIDR",
 			},
 		},
 	})

--- a/cmd/convox/instances.go
+++ b/cmd/convox/instances.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "instances",
-		Description: "list your Convox rack's instances",
+		Description: "List a Rack's EC2 instances",
 		Usage:       "",
 		Action:      cmdInstancesList,
 		Flags:       []cli.Flag{rackFlag},

--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -257,13 +257,13 @@ func currentLogin() (string, string, error) {
 	host, err := currentHost()
 
 	if err != nil {
-		return "", "", fmt.Errorf("must login first")
+		return "", "", fmt.Errorf("must log in first")
 	}
 
 	password, err := currentPassword()
 
 	if err != nil {
-		return "", "", fmt.Errorf("must login first")
+		return "", "", fmt.Errorf("must log in first")
 	}
 
 	return host, password, nil


### PR DESCRIPTION
This is only partially complete, but I'd like to get some feedback before continuing.

My suggestion for usage strings:
* Capitalize the beginning of the sentence
* Capitalize Convox and Rack
* No trailing periods (since usage strings are usually not complete sentences)

Basically following Docker style here.

Thoughts?