### PR TITLE
Fix forks failing to build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ go:
   - 1.7
 
 before_install:
+  - source ./ci/correct-path.sh
+
   # upgrade docker-engine to specific version
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
   - docker version

--- a/ci/correct-path.sh
+++ b/ci/correct-path.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ "$TRAVIS_REPO_SLUG" != "convox/rack" ]]; then
+    cd ../..
+    mkdir -p convox
+    mv $TRAVIS_REPO_SLUG convox/rack
+
+    export TRAVIS_BUILD_DIR="$PWD/convox/rack"
+    cd $TRAVIS_BUILD_DIR
+fi


### PR DESCRIPTION
Due to an unfortunate combination of Golang's packaging system, vendoring support, and people being able to fork projects so they can submit PRs, Rack failed to build on Travis when not in `$GOPATH/src/github.com/convox/rack`. This fixes the issue simply by moving the project to the correct path.

Before: https://travis-ci.org/spencerhakim/rack/builds/199657369
After: https://travis-ci.org/spencerhakim/rack/builds/199658999