### PR TITLE
build cache

### DIFF
--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -222,15 +223,49 @@ func build(dir string) error {
 
 	defer close(s)
 
-	env, err := currentProvider.EnvironmentGet(flagApp)
+	tmp, err := ioutil.TempDir("", "")
 	if err != nil {
 		return err
+	}
+
+	cacheKey := fmt.Sprintf("apps/%s/cache.tgz", flagApp)
+	cacheDir := filepath.Join(tmp, "cache")
+	cacheArchive := filepath.Join(tmp, "cache.tgz")
+
+	if err := os.Mkdir(cacheDir, 0755); err != nil {
+		return err
+	}
+
+	if currentProvider.ObjectExists(cacheKey) {
+		r, err := currentProvider.ObjectFetch(cacheKey)
+		if err != nil {
+			return err
+		}
+
+		fd, err := os.Create(cacheArchive)
+		if err != nil {
+			return err
+		}
+
+		defer fd.Close()
+
+		if _, err := io.Copy(fd, r); err != nil {
+			return err
+		}
+
+		if err := fd.Close(); err != nil {
+			return err
+		}
+
+		if err := exec.Command("tar", "xzf", cacheArchive, "-C", cacheDir).Run(); err != nil {
+			return err
+		}
 	}
 
 	err = m.Build(dir, flagApp, s, manifest.BuildOptions{
 		Environment: env,
 		Cache:       flagCache == "true",
-		Verbose:     false,
+		CacheDir:    cacheDir,
 	})
 	if err != nil {
 		return err
@@ -240,7 +275,27 @@ func build(dir string) error {
 		return err
 	}
 
+	if err := exec.Command("tar", "czf", cacheArchive, "-C", cacheDir, ".").Run(); err != nil {
+		return err
+	}
+
+	fd, err := os.Open(cacheArchive)
+	if err != nil {
+		return err
+	}
+
+	if _, err := currentProvider.ObjectStore(cacheKey, fd, structs.ObjectOptions{}); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+type ChanWriter chan string
+
+func (cw ChanWriter) Write(data []byte) (int, error) {
+	cw <- string(data)
+	return len(data), nil
 }
 
 func success() error {

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -291,13 +291,6 @@ func build(dir string) error {
 	return nil
 }
 
-type ChanWriter chan string
-
-func (cw ChanWriter) Write(data []byte) (int, error) {
-	cw <- string(data)
-	return len(data), nil
-}
-
 func success() error {
 	_, err := currentProvider.BuildRelease(currentBuild)
 	if err != nil {

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -223,6 +223,11 @@ func build(dir string) error {
 
 	defer close(s)
 
+	env, err := currentProvider.EnvironmentGet(flagApp)
+	if err != nil {
+		return err
+	}
+
 	tmp, err := ioutil.TempDir("", "")
 	if err != nil {
 		return err

--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -271,6 +271,7 @@ func build(dir string) error {
 		Environment: env,
 		Cache:       flagCache == "true",
 		CacheDir:    cacheDir,
+		Verbose:     false,
 	})
 	if err != nil {
 		return err

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -150,8 +150,6 @@ func cmdStart(c *cli.Context) error {
 		os.MkdirAll(cacheDir, 0755)
 	}
 
-	fmt.Printf("cacheDir = %+v\n", cacheDir)
-
 	r := m.Run(dir, app, manifest.RunOptions{
 		Build:    !c.Bool("no-build"),
 		Cache:    !c.Bool("no-cache"),

--- a/manifest/build.go
+++ b/manifest/build.go
@@ -76,9 +76,6 @@ func (m *Manifest) Build(dir, appName string, s Stream, opts BuildOptions) error
 				s <- fmt.Sprintf("cache error: %s", err)
 			}
 
-			fmt.Printf("lcd = %+v\n", lcd)
-			fmt.Printf("hash = %+v\n", hash)
-
 			exec.Command("rm", "-rf", lcd).Run()
 			exec.Command("cp", "-a", filepath.Join(opts.CacheDir, hash), lcd).Run()
 			exec.Command("mkdir", "-p", lcd).Run()

--- a/manifest/run.go
+++ b/manifest/run.go
@@ -28,12 +28,13 @@ type Run struct {
 }
 
 type RunOptions struct {
-	Service string
-	Command []string
-	Build   bool
-	Cache   bool
-	Quiet   bool
-	Sync    bool
+	Service  string
+	Command  []string
+	Build    bool
+	Cache    bool
+	CacheDir string
+	Quiet    bool
+	Sync     bool
 }
 
 // NewRun Default constructor method for a Run object
@@ -139,6 +140,7 @@ func (r *Run) Start() error {
 		err = r.manifest.Build(r.Dir, r.App, r.Output.Stream("build"), BuildOptions{
 			Environment: env,
 			Cache:       r.Opts.Cache,
+			CacheDir:    r.Opts.CacheDir,
 			Service:     r.Opts.Service,
 		})
 		if err != nil {

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -96,9 +97,11 @@ func (b *Build) Hash() string {
 	for i, key := range argKeys {
 		hashParts[i] = fmt.Sprintf("%s=%s", key, b.Args[key])
 	}
-	argsHash := strings.Join(hashParts, "@@@@@")
+	argsHash := strings.Join(hashParts, "-----")
 
-	return fmt.Sprintf("%+v|||||%+v|||||%+v", b.Context, b.Dockerfile, argsHash)
+	hash := fmt.Sprintf("%+v_____%+v_____%+v", b.Context, b.Dockerfile, argsHash)
+
+	return fmt.Sprintf("%x", sha1.Sum([]byte(hash)))
 }
 
 func (s *Service) Process(app string, m Manifest) Process {


### PR DESCRIPTION
This change allows you to persist certain artifacts between docker builds. This is useful for speeding up things like `bundle install`.

The new behavior:

* Any files residing in `/var/cache/build` in your image will be extracted after your build is complete and stored at the application level.
* Future builds will see the contents of this cached directory injected into `.cache/build` during the build process.

An example of how to use this with `bundle install`:

````
# bundle install
COPY Gemfile      /app/Gemfile
COPY Gemfile.lock /app/Gemfile.lock
COPY .cache/build/gems /var/cache/build/gems
RUN bundle install --path /var/cache/build/gems
````

The next time you need to touch your Gemfile.lock you won't need to completely rebuild your entire Gemfile as the local artifacts will already be present.