### PR TITLE
Build Environment Limit Fix

### DIFF
--- a/api/cmd/build/main.go
+++ b/api/cmd/build/main.go
@@ -22,7 +22,6 @@ var (
 	flagApp    string
 	flagAuth   string
 	flagCache  string
-	flagEnv    string
 	flagID     string
 	flagConfig string
 	flagMethod string
@@ -53,7 +52,6 @@ func main() {
 	fs.StringVar(&flagAuth, "auth", "", "docker auth data (json)")
 	fs.StringVar(&flagCache, "cache", "true", "use docker cache")
 	fs.StringVar(&flagConfig, "config", "docker-compose.yml", "path to app config")
-	fs.StringVar(&flagEnv, "env", "", "build env (json)")
 	fs.StringVar(&flagID, "id", "latest", "build id")
 	fs.StringVar(&flagMethod, "method", "", "source method")
 	fs.StringVar(&flagPush, "push", "", "push to registry")
@@ -73,10 +71,6 @@ func main() {
 
 	if v := os.Getenv("BUILD_CONFIG"); v != "" {
 		flagConfig = v
-	}
-
-	if v := os.Getenv("BUILD_ENV"); v != "" {
-		flagEnv = v
 	}
 
 	if v := os.Getenv("BUILD_ID"); v != "" {
@@ -218,12 +212,6 @@ func build(dir string) error {
 		return errs[0]
 	}
 
-	env := map[string]string{}
-
-	if err := json.Unmarshal([]byte(flagEnv), &env); err != nil {
-		return err
-	}
-
 	s := make(chan string)
 
 	go func() {
@@ -233,6 +221,11 @@ func build(dir string) error {
 	}()
 
 	defer close(s)
+
+	env, err := currentProvider.EnvironmentGet(flagApp)
+	if err != nil {
+		return err
+	}
 
 	err = m.Build(dir, flagApp, s, manifest.BuildOptions{
 		Environment: env,

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -768,16 +768,6 @@ func (p *AWSProvider) runBuild(build *structs.Build, method, url string, opts st
 		return err
 	}
 
-	env, err := p.EnvironmentGet(build.App)
-	if err != nil {
-		return err
-	}
-
-	envb, err := json.Marshal(env)
-	if err != nil {
-		return err
-	}
-
 	push := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:{service}.{build}", a.Outputs["RegistryId"], p.Region, a.Outputs["RegistryRepository"])
 
 	req := &ecs.RunTaskInput{
@@ -806,10 +796,6 @@ func (p *AWSProvider) runBuild(build *structs.Build, method, url string, opts st
 						{
 							Name:  aws.String("BUILD_CONFIG"),
 							Value: aws.String(opts.Config),
-						},
-						{
-							Name:  aws.String("BUILD_ENV"),
-							Value: aws.String(string(envb)),
 						},
 						{
 							Name:  aws.String("BUILD_ID"),

--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -60,8 +60,6 @@ func TestBuildCreate(t *testing.T) {
 		cycleRegistryDecrypt,
 		cycleBuildDescribeStacks,
 		cycleBuildGetAuthorizationTokenPrivate1,
-		cycleBuildDescribeStacks,
-		cycleEnvironmentGet,
 		cycleBuildRunTask,
 		cycleBuildGetItem,
 		cycleBuildDescribeStacks,
@@ -69,7 +67,8 @@ func TestBuildCreate(t *testing.T) {
 		cycleBuildDescribeTasks,
 		cycleBuildDescribeContainerInstances,
 		cycleBuildDescribeInstances,
-		cycleBuildNotificationPublish,
+		cycleBuildDescribeStacks,
+		cycleBuildQuery,
 	)
 	defer provider.Close()
 
@@ -130,6 +129,9 @@ func TestBuildExport(t *testing.T) {
 	defer provider.Close()
 
 	d := stubDocker(
+		cycleBuildDockerLogin,
+		cycleBuildDockerPull,
+		cycleBuildDockerSave,
 		cycleBuildDockerPing,
 		cycleBuildDockerInfo,
 		cycleBuildDockerLogin,
@@ -191,14 +193,9 @@ func TestBuildImport(t *testing.T) {
 	defer provider.Close()
 
 	d := stubDocker(
-		cycleBuildDockerPing,
-		cycleBuildDockerInfo,
 		cycleBuildDockerLogin,
-		cycleBuildDockerPing,
 		cycleBuildDockerLoad,
-		cycleBuildDockerPing,
 		cycleBuildDockerTag,
-		cycleBuildDockerPing,
 		cycleBuildDockerPush,
 	)
 	defer d.Close()
@@ -279,7 +276,7 @@ func TestBuildList(t *testing.T) {
 	)
 	defer provider.Close()
 
-	b, err := provider.BuildList("httpd", 20)
+	b, err := provider.BuildList("httpd", 150)
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, structs.Builds{
@@ -1010,7 +1007,7 @@ var cycleBuildQuery = awsutil.Cycle{
 	Request: awsutil.Request{
 		RequestURI: "/",
 		Operation:  "DynamoDB_20120810.Query",
-		Body:       `{"IndexName":"app.created","KeyConditions":{"app":{"AttributeValueList":[{"S":"httpd"}],"ComparisonOperator":"EQ"}},"Limit":20,"ScanIndexForward":false,"TableName":"convox-builds"}`,
+		Body:       `{"IndexName":"app.created","KeyConditions":{"app":{"AttributeValueList":[{"S":"httpd"}],"ComparisonOperator":"EQ"}},"Limit":150,"ScanIndexForward":false,"TableName":"convox-builds"}`,
 	},
 	Response: awsutil.Response{
 		StatusCode: 200,
@@ -1103,10 +1100,6 @@ var cycleBuildRunTask = awsutil.Cycle{
 							{
 								"name": "BUILD_CONFIG",
 								"value": ""
-							},
-							{
-								"name": "BUILD_ENV",
-								"value": "{\"BAZ\":\"qux\",\"FOO\":\"bar\"}"
 							},
 							{
 								"name": "BUILD_ID",

--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -129,9 +129,6 @@ func TestBuildExport(t *testing.T) {
 	defer provider.Close()
 
 	d := stubDocker(
-		cycleBuildDockerLogin,
-		cycleBuildDockerPull,
-		cycleBuildDockerSave,
 		cycleBuildDockerPing,
 		cycleBuildDockerInfo,
 		cycleBuildDockerLogin,
@@ -193,9 +190,14 @@ func TestBuildImport(t *testing.T) {
 	defer provider.Close()
 
 	d := stubDocker(
+		cycleBuildDockerPing,
+		cycleBuildDockerInfo,
 		cycleBuildDockerLogin,
+		cycleBuildDockerPing,
 		cycleBuildDockerLoad,
+		cycleBuildDockerPing,
 		cycleBuildDockerTag,
+		cycleBuildDockerPing,
 		cycleBuildDockerPush,
 	)
 	defer d.Close()


### PR DESCRIPTION
Fixes the error:

```
Starting build... ERROR: InvalidParameterException: Container Overrides length must be at most 8192
	status code: 400, request id: 533613f0-ee61-11e6-89af-09d09715c24a
```

by pulling the app environment within the build container instead of passing it as a Container Override.