### PR TITLE
Fix errant capitalization and trailing periods in usage strings and error messages

### DIFF
--- a/cmd/convox/doctor.go
+++ b/cmd/convox/doctor.go
@@ -25,7 +25,7 @@ func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "doctor",
 		Action:      cmdDoctor,
-		Description: "Check your app for common Convox compatibility issues.",
+		Description: "check your app for common Convox compatibility issues",
 	})
 }
 

--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -180,7 +180,7 @@ func cmdInstall(c *cli.Context) error {
 		match := len(matchedStr) == len(stackName)
 
 		if !match {
-			msg := fmt.Errorf("Stack name '%s' is invalid, must match [a-z0-9-]*", stackName)
+			msg := fmt.Errorf("stack name '%s' is invalid, must match [a-z0-9-]*", stackName)
 			stdcli.QOSEventSend("cli-install", distinctID, stdcli.QOSEventProperties{ValidationError: msg})
 			return stdcli.Error(msg)
 		}

--- a/cmd/convox/install_test.go
+++ b/cmd/convox/install_test.go
@@ -186,7 +186,7 @@ func TestConvoxInstallValidateStackName(t *testing.T) {
 			Exit:    1,
 			Env:     map[string]string{"AWS_ENDPOINT_URL": s.URL, "AWS_REGION": "test"},
 			Stdin:   `{"Credentials":{"AccessKeyId":"FOO","SecretAccessKey":"BAR","Expiration":"2015-09-17T14:09:41Z"}}`,
-			Stderr:  `ERROR: Stack name 'Invalid' is invalid, must match [a-z0-9-]*`,
+			Stderr:  `ERROR: stack name 'Invalid' is invalid, must match [a-z0-9-]*`,
 		},
 
 		test.ExecRun{
@@ -194,7 +194,7 @@ func TestConvoxInstallValidateStackName(t *testing.T) {
 			Exit:    1,
 			Env:     map[string]string{"AWS_ENDPOINT_URL": s.URL, "AWS_REGION": "test"},
 			Stdin:   `{"Credentials":{"AccessKeyId":"FOO","SecretAccessKey":"BAR","Expiration":"2015-09-17T14:09:41Z"}}`,
-			Stderr:  `ERROR: Stack name 'in_valid' is invalid, must match [a-z0-9-]*`,
+			Stderr:  `ERROR: stack name 'in_valid' is invalid, must match [a-z0-9-]*`,
 		},
 	)
 }

--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -257,13 +257,13 @@ func currentLogin() (string, string, error) {
 	host, err := currentHost()
 
 	if err != nil {
-		return "", "", fmt.Errorf("must login first")
+		return "", "", fmt.Errorf("must log in first")
 	}
 
 	password, err := currentPassword()
 
 	if err != nil {
-		return "", "", fmt.Errorf("must login first")
+		return "", "", fmt.Errorf("must log in first")
 	}
 
 	return host, password, nil

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -77,7 +77,7 @@ func init() {
 		Subcommands: []cli.Command{
 			{
 				Name:            "create",
-				Description:     "create a new resource.",
+				Description:     "create a new resource",
 				Usage:           "<type> [--name=value] [--option-name=value]\n\n" + usage,
 				Action:          cmdResourceCreate,
 				Flags:           []cli.Flag{rackFlag},
@@ -92,7 +92,7 @@ func init() {
 			},
 			{
 				Name:            "update",
-				Description:     "update a resource.\n\nWARNING: updates may cause resource downtime.",
+				Description:     "update a resource\n\nWARNING: updates may cause resource downtime.",
 				Usage:           "<name> --option-name=value [--option-name=value]\n\n" + usage,
 				Action:          cmdResourceUpdate,
 				Flags:           []cli.Flag{rackFlag},
@@ -100,21 +100,21 @@ func init() {
 			},
 			{
 				Name:        "info",
-				Description: "info about a resource.",
+				Description: "info about a resource",
 				Usage:       "<name>",
 				Action:      cmdResourceInfo,
 				Flags:       []cli.Flag{rackFlag},
 			},
 			{
 				Name:        "link",
-				Description: "create a link between a resource and an app.",
+				Description: "create a link between a resource and an app",
 				Usage:       "<name>",
 				Action:      cmdLinkCreate,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
 				Name:        "unlink",
-				Description: "delete a link between a resource and an app.",
+				Description: "delete a link between a resource and an app",
 				Usage:       "<name>",
 				Action:      cmdLinkDelete,
 				Flags:       []cli.Flag{appFlag, rackFlag},

--- a/cmd/convox/uninstall.go
+++ b/cmd/convox/uninstall.go
@@ -91,7 +91,7 @@ func cmdUninstall(c *cli.Context) error {
 
 	// verify that rack was detected
 	if len(stacks.Rack) == 0 || stacks.Rack[0].StackName != rackName {
-		return stdcli.Error(fmt.Errorf("Can not find rack named %s.", rackName))
+		return stdcli.Error(fmt.Errorf("can not find rack named %s", rackName))
 	}
 
 	fmt.Println("Resources to delete:\n")

--- a/provider/aws/resource.go
+++ b/provider/aws/resource.go
@@ -298,7 +298,7 @@ func (p *AWSProvider) ResourceLink(name, app, process string) (*structs.Resource
 	// already linked
 	for _, linkedApp := range s.Apps {
 		if a.Name == linkedApp.Name {
-			return nil, fmt.Errorf("Resource %s is already linked to app %s", s.Name, a.Name)
+			return nil, fmt.Errorf("resource %s is already linked to app %s", s.Name, a.Name)
 		}
 	}
 
@@ -307,7 +307,7 @@ func (p *AWSProvider) ResourceLink(name, app, process string) (*structs.Resource
 	case "fluentd", "syslog":
 		err = p.linkResource(a, s) // Update resource to know about App
 	default:
-		err = fmt.Errorf("Resource type %s does not have a link strategy", s.Type)
+		err = fmt.Errorf("resource type %s does not have a link strategy", s.Type)
 	}
 
 	return s, err
@@ -335,7 +335,7 @@ func (p *AWSProvider) ResourceUnlink(name, app, process string) (*structs.Resour
 	}
 
 	if !linked {
-		return nil, fmt.Errorf("Resource %s is not linked to app %s", s.Name, a.Name)
+		return nil, fmt.Errorf("resource %s is not linked to app %s", s.Name, a.Name)
 	}
 
 	// Update Resource and/or App stacks
@@ -343,7 +343,7 @@ func (p *AWSProvider) ResourceUnlink(name, app, process string) (*structs.Resour
 	case "fluentd", "syslog":
 		err = p.unlinkResource(a, s) // Update resource to forget about App
 	default:
-		err = fmt.Errorf("Resource type %s does not have an unlink strategy", s.Type)
+		err = fmt.Errorf("resource type %s does not have an unlink strategy", s.Type)
 	}
 
 	return s, err
@@ -393,7 +393,7 @@ func (p *AWSProvider) createResource(s *structs.Resource) (*cloudformation.Creat
 
 func (p *AWSProvider) createResourceURL(s *structs.Resource, allowedProtocols ...string) (*cloudformation.CreateStackInput, error) {
 	if s.Parameters["Url"] == "" {
-		return nil, fmt.Errorf("Must specify a URL")
+		return nil, fmt.Errorf("must specify a URL")
 	}
 
 	u, err := url.Parse(s.Parameters["Url"])
@@ -411,7 +411,7 @@ func (p *AWSProvider) createResourceURL(s *structs.Resource, allowedProtocols ..
 	}
 
 	if !valid {
-		return nil, fmt.Errorf("Invalid URL scheme: %s. Allowed schemes are: %s", u.Scheme, strings.Join(allowedProtocols, ", "))
+		return nil, fmt.Errorf("invalid URL scheme: %s. Allowed schemes are: %s", u.Scheme, strings.Join(allowedProtocols, ", "))
 	}
 
 	return p.createResource(s)


### PR DESCRIPTION
Before: most command descriptions start with a lowercase letter and lack a trailing period
After: _all_ command descriptions start with a lowercase letter and lack a trailing period