### PR TITLE
Export client.Request and add TestApiGetRequest

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -43,7 +43,7 @@ func New(host, password, version string) *Client {
 }
 
 func (c *Client) Get(path string, out interface{}) error {
-	req, err := c.request("GET", path, nil)
+	req, err := c.Request("GET", path, nil)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (c *Client) PostBody(path string, body io.Reader, out interface{}) error {
 }
 
 func (c *Client) PostBodyResponse(path string, body io.Reader, out interface{}) (*http.Response, error) {
-	req, err := c.request("POST", path, body)
+	req, err := c.Request("POST", path, body)
 
 	if err != nil {
 		return nil, err
@@ -202,7 +202,7 @@ func (c *Client) PostMultipart(path string, opts PostMultipartOptions, out inter
 		e = nil
 	}()
 
-	req, err := c.request("POST", path, pr)
+	req, err := c.Request("POST", path, pr)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func (c *Client) Put(path string, params Params, out interface{}) error {
 }
 
 func (c *Client) PutBody(path string, body io.Reader, out interface{}) error {
-	req, err := c.request("PUT", path, body)
+	req, err := c.Request("PUT", path, body)
 
 	if err != nil {
 		return err
@@ -286,7 +286,7 @@ func (c *Client) Delete(path string, out interface{}) error {
 }
 
 func (c *Client) DeleteResponse(path string, out interface{}) (*http.Response, error) {
-	req, err := c.request("DELETE", path, nil)
+	req, err := c.Request("DELETE", path, nil)
 
 	if err != nil {
 		return nil, nil
@@ -422,7 +422,8 @@ func copyAsync(dst io.Writer, src io.Reader, wg *sync.WaitGroup) {
 	io.Copy(dst, src)
 }
 
-func (c *Client) request(method, path string, body io.Reader) (*http.Request, error) {
+// Request wraps http.Request and sets some Convox-specific headers
+func (c *Client) Request(method, path string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, fmt.Sprintf("https://%s%s", c.Host, path), body)
 
 	if err != nil {

--- a/cmd/convox/api_test.go
+++ b/cmd/convox/api_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"encoding/base64"
+	"fmt"
 	"testing"
 
+	"github.com/convox/rack/client"
 	"github.com/convox/rack/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestApiGet(t *testing.T) {
@@ -19,4 +23,17 @@ func TestApiGet(t *testing.T) {
 			Stdout:  "\"bar\"\n",
 		},
 	)
+}
+
+// TestApiGetRequest should ensure Content-Type header is set to application/json during 'convox api get'
+func TestApiGetRequest(t *testing.T) {
+	host, err := currentHost()
+	assert.NoError(t, err)
+	c := client.New(host, "testPassword", "testVersion")
+	req, err := c.Request("GET", "/nonexistent", nil)
+	assert.NoError(t, err)
+	b64pw := base64.StdEncoding.EncodeToString([]byte("convox:testPassword"))
+	assert.Equal(t, req.Header.Get("Authorization"), fmt.Sprintf("Basic %s", b64pw))
+	assert.Equal(t, req.Header.Get("Content-Type"), "application/json")
+	assert.Equal(t, req.Header.Get("Version"), "testVersion")
 }


### PR DESCRIPTION
Add test TestApiGetRequest to ensure Content-Type header is set to application/json during 'convox api get'.