### PR TITLE
Error when duplicate cron labels are present.

### DIFF
--- a/cmd/convox/deploy_test.go
+++ b/cmd/convox/deploy_test.go
@@ -56,3 +56,20 @@ func TestDeployInvalidCronInManifest(t *testing.T) {
 		},
 	)
 }
+
+func TestDeployDuplicateCronInManifest(t *testing.T) {
+	ts := testServer(t,
+		test.Http{Method: "GET", Path: "/apps/foo", Code: 200, Response: client.App{Name: "foo", Status: "running"}},
+	)
+
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox deploy --file docker-compose.duplicate-cron-label.yml --app foo",
+			Dir:     "../../manifest/fixtures",
+			Exit:    1,
+			Stderr:  "ERROR: invalid docker-compose.duplicate-cron-label.yml: error loading manifest: duplicate cron label convox.cron.myjob\n",
+		},
+	)
+}

--- a/cmd/convox/start_test.go
+++ b/cmd/convox/start_test.go
@@ -23,3 +23,19 @@ func TestStartInvalidManifest(t *testing.T) {
 		},
 	)
 }
+func TestStartDuplicateCronInManifest(t *testing.T) {
+	ts := testServer(t,
+		test.Http{Method: "GET", Path: "/apps/foo", Code: 200, Response: client.App{Name: "foo", Status: "running"}},
+	)
+
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox start --file docker-compose.duplicate-cron-label.yml",
+			Dir:     "../../manifest/fixtures",
+			Exit:    1,
+			Stderr:  "ERROR: error loading manifest: duplicate cron label convox.cron.myjob\n",
+		},
+	)
+}

--- a/manifest/fixtures/docker-compose.duplicate-cron-label.yml
+++ b/manifest/fixtures/docker-compose.duplicate-cron-label.yml
@@ -1,0 +1,10 @@
+version: "2"
+services:
+  counter:
+    build: .
+    ports:
+      - "80:5000"
+    command: ["bin/counter"]
+    labels:
+      - convox.cron.myjob=* * * * ? bin/myjob1
+      - convox.cron.myjob=* * * * ? bin/myjob2

--- a/manifest/yaml.go
+++ b/manifest/yaml.go
@@ -280,6 +280,9 @@ func (l *Labels) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 			switch len(parts) {
 			case 2:
+				if _, ok := (*l)[parts[0]]; ok {
+					return fmt.Errorf("duplicate cron label %v", parts[0])
+				}
 				(*l)[parts[0]] = parts[1]
 			default:
 				return fmt.Errorf("cannot parse label: %v", t)


### PR DESCRIPTION
The warning isn't easily visible in (and doesn't match the formatting of) the output of `convox start`. Is there a helper for printing warnings?