### PR TITLE
Validate manifest file when deploying

### DIFF
--- a/cmd/convox/deploy.go
+++ b/cmd/convox/deploy.go
@@ -61,8 +61,17 @@ func cmdDeploy(c *cli.Context) error {
 	}
 
 	// validate docker-compose
-	if _, err := manifest.LoadFile(c.String("file")); err != nil {
+	m, err := manifest.LoadFile(c.String("file"))
+	if err != nil {
 		return stdcli.Error(fmt.Errorf("invalid %s: %s", c.String("file"), strings.TrimSpace(err.Error())))
+	}
+
+	errs := m.Validate()
+	if len(errs) > 0 {
+		for _, e := range errs[1:] {
+			stdcli.Error(e)
+		}
+		return stdcli.Error(errs[0])
 	}
 
 	output := os.Stdout

--- a/cmd/convox/deploy_test.go
+++ b/cmd/convox/deploy_test.go
@@ -39,3 +39,20 @@ func TestDeployNoManifestFound(t *testing.T) {
 		},
 	)
 }
+
+func TestDeployInvalidCronInManifest(t *testing.T) {
+	ts := testServer(t,
+		test.Http{Method: "GET", Path: "/apps/foo", Code: 200, Response: client.App{Name: "foo", Status: "running"}},
+	)
+
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox deploy --file docker-compose.invalid-cron-label.yml --app foo",
+			Dir:     "../../manifest/fixtures",
+			Exit:    1,
+			Stderr:  "ERROR: Cron task my_job is not valid (cron names can contain only alphanumeric characters, dashes and must be between 4 and 30 characters)\n",
+		},
+	)
+}

--- a/cmd/convox/start_test.go
+++ b/cmd/convox/start_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/convox/rack/client"
+	"github.com/convox/rack/test"
+)
+
+func TestStartInvalidManifest(t *testing.T) {
+	ts := testServer(t,
+		test.Http{Method: "GET", Path: "/apps/foo", Code: 200, Response: client.App{Name: "foo", Status: "running"}},
+	)
+
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox start --file docker-compose.invalid-cron-label.yml",
+			Dir:     "../../manifest/fixtures",
+			Exit:    1,
+			Stderr:  "ERROR: Cron task my_job is not valid (cron names can contain only alphanumeric characters, dashes and must be between 4 and 30 characters)\n",
+		},
+	)
+}

--- a/manifest/fixtures/docker-compose.invalid-cron-label.yml
+++ b/manifest/fixtures/docker-compose.invalid-cron-label.yml
@@ -1,0 +1,9 @@
+version: "2"
+services:
+  counter:
+    build: .
+    ports:
+      - "80:5000"
+    command: ["bin/counter"]
+    labels:
+      - convox.cron.my_job=* * * * ? bin/myjob


### PR DESCRIPTION
Before:

```
$ convox start
ERROR: Cron task my_job is not valid (cron names can contain only alphanumeric characters, dashes and must be between 4 and 30 characters)

$ convox deploy
Deploying flask
Creating tarball... OK
[...]
```

After:

```
$ convox start
ERROR: Cron task my_job is not valid (cron names can contain only alphanumeric characters, dashes and must be between 4 and 30 characters)

$ convox deploy
ERROR: Cron task my_job is not valid (cron names can contain only alphanumeric characters, dashes and must be between 4 and 30 characters)
```

Ref: As discussed in https://github.com/convox/rack/pull/1920#issuecomment-279531409