### PR TITLE
Don't use own ECR as private registry

### DIFF
--- a/cmd/convox/registries_test.go
+++ b/cmd/convox/registries_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/convox/rack/client"
+	"github.com/convox/rack/test"
+)
+
+func TestRegistriesList(t *testing.T) {
+	tr := testServer(t,
+		test.Http{
+			Method: "GET",
+			Path:   "/registries",
+			Code:   200,
+			Response: client.Registries{
+				client.Registry{
+					Server:   "testRegistryServer",
+					Username: "testRegistryUser",
+					Password: "testRegistryPassword",
+				},
+			},
+		},
+	)
+
+	defer tr.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox registries",
+			Exit:    0,
+			Stdout:  "SERVER              USERNAME\ntestRegistryServer  testRegistryUser\n",
+		},
+	)
+}
+
+/*
+func TestRegistriesAddStdin(t *testing.T) {
+	tr := testServer(t,
+		test.Http{
+			Method: "POST",
+			Path:   "/registries",
+			Body:   "email=&password=testRegistryPassword&server=https%3A%2F%2Findex.docker.io%2Fv1%2F&username=testRegistryUser",
+			Code:   200,
+		},
+	)
+
+	defer tr.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox registries add https://index.docker.io/v1/",
+			Stdin:   "testRegistryUser\ntestRegistryPassword\n",
+			Exit:    0,
+			Stdout:  "Username: Password: \nDone.\n",
+		},
+	)
+}
+*/
+
+func TestRegistriesAdd(t *testing.T) {
+	tr := testServer(t,
+		test.Http{
+			Method: "POST",
+			Path:   "/registries",
+			Body:   "email=&password=testRegistryPassword&server=https%3A%2F%2Findex.docker.io%2Fv1%2F&username=testRegistryUser",
+			Code:   200,
+		},
+		test.Http{
+			Method: "GET",
+			Path:   "/registries",
+			Code:   200,
+			Response: client.Registries{
+				client.Registry{
+					Server:   "https://index.docker.io/v1/",
+					Username: "testRegistryUser",
+					Password: "testRegistryPassword",
+				},
+			},
+		},
+	)
+
+	defer tr.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox registries add https://index.docker.io/v1/ --username testRegistryUser --password testRegistryPassword",
+			Exit:    0,
+			Stdout:  "Done.\n",
+		},
+		test.ExecRun{
+			Command: "convox registries",
+			Exit:    0,
+			Stdout:  "SERVER                       USERNAME\nhttps://index.docker.io/v1/  testRegistryUser\n",
+		},
+	)
+}
+
+func TestRegistriesAddInvalidAuth(t *testing.T) {
+	tr := testServer(t,
+		test.Http{
+			Method:   "POST",
+			Path:     "/registries",
+			Body:     "email=&password=testRegistryPassword&server=https%3A%2F%2Findex.docker.io%2Fv1%2F&username=testRegistryUser",
+			Code:     401,
+			Response: client.Error{"unable to authenticate"},
+		},
+	)
+
+	defer tr.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox registries add https://index.docker.io/v1/ --username testRegistryUser --password testRegistryPassword",
+			Exit:    1,
+			Stderr:  "unable to authenticate\n",
+		},
+	)
+}
+
+func TestRegistriesAddEcrRegistry(t *testing.T) {
+	ts := testServer(t,
+		test.Http{
+			Method:   "POST",
+			Path:     "/registries",
+			Body:     "email=&password=testRegistryPassword&server=123456789012.dkr.ecr.us-east-1.amazonaws.com&username=testRegistryUser",
+			Code:     500,
+			Response: client.Error{"can't add the rack's internal registry: 123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+		},
+	)
+
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox registries add 123456789012.dkr.ecr.us-east-1.amazonaws.com --username testRegistryUser --password testRegistryPassword",
+			Exit:    1,
+			Stderr:  "can't add the rack's internal registry: 123456789012.dkr.ecr.us-east-1.amazonaws.com",
+		},
+	)
+}
+
+func TestRegistriesDelete(t *testing.T) {
+	ts := testServer(t,
+		test.Http{
+			Method: "DELETE",
+			Path:   "/registries",
+			Code:   200,
+		},
+	)
+
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox registries remove foo",
+			Exit:    0,
+			Stdout:  "Done.\n",
+		},
+	)
+}
+
+func TestRegistriesDelete404(t *testing.T) {
+	ts := testServer(t,
+		test.Http{
+			Method:   "DELETE",
+			Path:     "/registries",
+			Code:     404,
+			Response: client.Error{"no such registry"},
+		},
+	)
+
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox registries remove foo",
+			Exit:    1,
+			Stderr:  "no such registry",
+		},
+	)
+}

--- a/cmd/convox/registries_test.go
+++ b/cmd/convox/registries_test.go
@@ -34,13 +34,12 @@ func TestRegistriesList(t *testing.T) {
 	)
 }
 
-/*
 func TestRegistriesAddStdin(t *testing.T) {
 	tr := testServer(t,
 		test.Http{
 			Method: "POST",
 			Path:   "/registries",
-			Body:   "email=&password=testRegistryPassword&server=https%3A%2F%2Findex.docker.io%2Fv1%2F&username=testRegistryUser",
+			Body:   "email=&password=&server=https%3A%2F%2Findex.docker.io%2Fv1%2F&username=testRegistryUser",
 			Code:   200,
 		},
 	)
@@ -56,7 +55,6 @@ func TestRegistriesAddStdin(t *testing.T) {
 		},
 	)
 }
-*/
 
 func TestRegistriesAdd(t *testing.T) {
 	tr := testServer(t,

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -30,8 +30,12 @@ import (
 	"github.com/convox/rack/manifest"
 )
 
+// ECR host is formatted like 123456789012.dkr.ecr.us-east-1.amazonaws.com
 var regexpECRHost = regexp.MustCompile(`(\d+)\.dkr\.ecr\.([^.]+)\.amazonaws\.com`)
 var regexpECRImage = regexp.MustCompile(`(\d+)\.dkr\.ecr\.([^.]+)\.amazonaws\.com\/([^:]+):([^ ]+)`)
+
+// StackID is formatted like arn:aws:cloudformation:us-east-1:332653055745:stack/dev/d164aa20-ba89-11e6-b65c-50d5ca632656
+var regexpStackID = regexp.MustCompile(`arn:aws:cloudformation:([^.]+):(\d+):stack/([^.]+)/([^.]+)`)
 
 func (p *AWSProvider) BuildCreate(app, method, url string, opts structs.BuildOptions) (*structs.Build, error) {
 	log := Logger.At("BuildCreate").Namespace("app=%q method=%q url=%q", app, method, url).Start()
@@ -714,7 +718,7 @@ func (p *AWSProvider) authECR(host, access, secret string) (string, string, erro
 	}
 
 	if !regexpECRHost.MatchString(host) {
-		return "", "", fmt.Errorf("invalid ECR hostname")
+		return "", "", fmt.Errorf("invalid ECR hostname: %s", host)
 	}
 
 	registry := regexpECRHost.FindStringSubmatch(host)

--- a/provider/aws/registries.go
+++ b/provider/aws/registries.go
@@ -40,8 +40,12 @@ func (p *AWSProvider) RegistryAdd(server, username, password string) (*structs.R
 		if err != nil {
 			return nil, err
 		}
-		sid := regexpStackID.FindStringSubmatch(*system.StackId)[2]
-		host := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", sid, p.Region)
+		stackID := regexpStackID.FindStringSubmatch(*system.StackId)
+		if len(stackID) < 3 {
+			return nil, fmt.Errorf("invalid stack id %s", *system.StackId)
+		}
+		accountID := stackID[2]
+		host := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", accountID, p.Region)
 
 		if host == server {
 			return nil, fmt.Errorf("can't add the rack's internal registry: %s", server)

--- a/provider/aws/registries.go
+++ b/provider/aws/registries.go
@@ -36,6 +36,17 @@ func (p *AWSProvider) RegistryAdd(server, username, password string) (*structs.R
 	// validate login
 	switch {
 	case regexpECRHost.MatchString(server):
+		system, err := p.describeStack(p.Rack)
+		if err != nil {
+			return nil, err
+		}
+		sid := regexpStackID.FindStringSubmatch(*system.StackId)[2]
+		host := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", sid, p.Region)
+
+		if host == server {
+			return nil, fmt.Errorf("can't add the rack's internal registry: %s", server)
+		}
+
 		if _, _, err := p.authECR(server, username, password); err != nil {
 			return nil, fmt.Errorf("unable to authenticate")
 		}


### PR DESCRIPTION
Before:
```
$ convox registries add 332653055745.dkr.ecr.us-east-1.amazonaws.com --username foo --password bar
ERROR: unable to authenticate
```

After:
```
$ convox registries add 332653055745.dkr.ecr.us-east-1.amazonaws.com --username foo --password bar
ERROR: can't add own ECR host as a private registry: 332653055745.dkr.ecr.us-east-1.amazonaws.com
```

Notes:

- This won't work if the ECR host has a `http://` or `https://` prefix.
- Maybe the error is a bit too specific and something like "invalid registry host" would be better.
- I'm having a hard time with the cycles on the provider-side tests.
- I'm having a hard time with manual testing since I'm not even sure what credentials one would need to provide in order to add one's own Rack ECR as a registry.
