### PR TITLE
Help tests

### DIFF
--- a/cmd/convox/api_test.go
+++ b/cmd/convox/api_test.go
@@ -37,12 +37,12 @@ Usage:
 Subcommands: (convox api help <subcommand>)
   get		get an api endpoint
   delete	delete an api endpoint
-  help, h
-
+  help, h	
+  
 Options:
   --rack value	rack name
   --help, -h	show help
-
+  
 `
 
 var apiGetHelp = `convox api get: get an api endpoint
@@ -52,7 +52,7 @@ Usage:
 
 Options:
    --rack value	rack name
-
+   
 `
 
 var commandStrings = []string{

--- a/cmd/convox/api_test.go
+++ b/cmd/convox/api_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/convox/rack/client"
+	"github.com/convox/rack/cmd/convox/stdcli"
 	"github.com/convox/rack/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,6 +24,141 @@ func TestApiGet(t *testing.T) {
 			Stdout:  "\"bar\"\n",
 		},
 	)
+}
+
+/* HELP CHECKS */
+// http://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html
+
+var apiHelp = `convox api: api endpoint
+
+Usage:
+  convox api <command> [args...]
+
+Subcommands: (convox api help <subcommand>)
+  get		get an api endpoint
+  delete	delete an api endpoint
+  help, h
+
+Options:
+  --rack value	rack name
+  --help, -h	show help
+
+`
+
+var apiGetHelp = `convox api get: get an api endpoint
+
+Usage:
+  convox api get <endpoint>
+
+Options:
+   --rack value	rack name
+
+`
+
+var commandStrings = []string{
+	"convox %s api",
+	"convox api %s",
+}
+
+var commandGetStrings = []string{
+	"convox %s api get",
+	"convox %s api get /foo",
+	"convox api %s get",
+	"convox api %s get /foo",
+	"convox api get %s",
+	"convox api get %s /foo",
+}
+
+// TODO: These commands don't behave as expected
+var skipCommands = []string{
+	"convox api --help",          // treats '--help' as an argument
+	"convox api get help",        // treats 'help' as an argument
+	"convox api get help /foo",   // treats 'help' as an argument
+	"convox api get h",           // treats 'h' as an argument
+	"convox api get h /foo",      // treats 'h' as an argument
+	"convox api --help get",      // executes command, ignores --help
+	"convox api --help get /foo", // executes command, ignores --help
+	"convox api -h",              // executes command, ignores -h
+	"convox api -h get",          // executes command, ignores -h
+	"convox api -h get /foo",     // executes command, ignores -h
+	"convox help api",            // /!\ different output from 'convox api --help'
+	"convox help api get",        // outputs 'convox api' help
+	"convox help api get /foo",   // outputs 'convox api' help
+	"convox --help api get /foo", // Outputs 'convox' help
+	"convox -h api get /foo",     // outputs 'convox' help
+	"convox -h api get",          // outputs 'convox' help
+	"convox -h api",              // outputs 'convox' help
+	"convox h api",               // /!\ different output from 'convox api --help'
+	"convox h api get",           // outputs 'convox api' help
+	"convox h api get /foo",      // outputs 'convox api' help
+	"convox --help api get",      // outputs 'convox' help
+	"convox --help api",          // outputs 'convox' help
+}
+
+func shouldSkip(c string, skipCommands []string) bool {
+	// skip permutations that don't work as expected yet
+	for _, skipC := range skipCommands {
+		if c == skipC {
+			return true
+		}
+	}
+	return false
+}
+
+func TestApiHelpFlag(t *testing.T) {
+	ts := testServer(t,
+		test.Http{
+			Method:   "GET",
+			Path:     "/foo",
+			Code:     200,
+			Response: "bar",
+			Headers:  map[string]string{"Rack": "myorg/staging"},
+		},
+	)
+	defer ts.Close()
+
+	// base 'api' command (without subcommands)
+	// these commands should output a help screen about 'convox api'
+	for _, cmd := range commandStrings {
+		for _, hf := range stdcli.HelpFlags {
+			c := fmt.Sprintf(cmd, hf)
+
+			if shouldSkip(c, skipCommands) {
+				fmt.Println("SKIPPED: ", c)
+				continue
+			}
+			test.Runs(t,
+				test.ExecRun{
+					Command: c,
+					Exit:    0,
+					Stdout:  apiHelp,
+				},
+			)
+		}
+	}
+
+	assert.Equal(t, stdcli.HelpFlags, []string{"--help", "-h", "h", "help"})
+
+	// 'api get' subcommand
+	// these commands should output a help screen about 'convox api get'
+	for _, cmd := range commandGetStrings {
+		for _, hf := range stdcli.HelpFlags {
+			c := fmt.Sprintf(cmd, hf)
+
+			if shouldSkip(c, skipCommands) {
+				fmt.Println("SKIPPED: ", c)
+				continue
+			}
+
+			test.Runs(t,
+				test.ExecRun{
+					Command: c,
+					Exit:    0,
+					Stdout:  apiGetHelp,
+				},
+			)
+		}
+	}
 }
 
 func TestRackFlag(t *testing.T) {
@@ -117,6 +253,25 @@ func TestApiGet404(t *testing.T) {
 			Command: "convox api get /nonexistent",
 			Exit:    1,
 			Stderr:  "ERROR: A wild 404 appears!",
+		},
+	)
+}
+
+// TestApiGetNoArg should ensure help text is displayed when user runs 'api get' without an endpoint.
+func TestApiGetNoArg(t *testing.T) {
+	ts := testServer(t,
+		test.Http{
+			Method: "GET",
+			Code:   129,
+		},
+	)
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox api get",
+			Exit:    129,
+			Stdout:  apiGetHelp,
 		},
 	)
 }

--- a/cmd/convox/flags_test.go
+++ b/cmd/convox/flags_test.go
@@ -45,14 +45,14 @@ Subcommands: (convox help <subcommand>)
   switch		switch to another Convox rack
   uninstall		uninstall a convox rack
   update		update the cli
-  help, h
-
+  help, h		
+  
 Options:
   --app value, -a value	app name inferred from current directory if not specified
   --rack value		rack name
   --help, -h		show help
   --version, -v		print the version
-
+  
 `
 
 func TestHelpFlag(t *testing.T) {

--- a/cmd/convox/flags_test.go
+++ b/cmd/convox/flags_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/convox/rack/cmd/convox/stdcli"
+	"github.com/convox/rack/test"
+)
+
+/* HELP CHECKS */
+// http://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html
+
+var convoxHelp = `convox: command-line application management
+
+Usage:
+  convox <command> [args...]
+
+Subcommands: (convox help <subcommand>)
+  api			api endpoint
+  apps			list deployed apps
+  build			create a new build
+  builds		manage an app's builds
+  certs			list certificates
+  deploy		deploy an app to AWS
+  doctor		check your app for common Convox compatibility issues
+  env			manage an app's environment variables
+  exec			exec a command in a process in your Convox rack
+  init			initialize an app for local development
+  install		install convox into an aws account
+  instances		list your Convox rack's instances
+  login			log into your convox rack
+  logs			stream the logs for an application
+  proxy			proxy local ports into a rack
+  ps			list an app's processes
+  rack			manage your Convox rack
+  racks			list your Convox racks
+  registries		manage private registries
+  releases		list an app's releases
+  run			run a one-off command in your Convox rack
+  scale			scale an app's processes
+  resources, services	manage external resources [prev. services]
+  ssl			manage ssl certificates
+  start			start an app for local development
+  switch		switch to another Convox rack
+  uninstall		uninstall a convox rack
+  update		update the cli
+  help, h
+
+Options:
+  --app value, -a value	app name inferred from current directory if not specified
+  --rack value		rack name
+  --help, -h		show help
+  --version, -v		print the version
+
+`
+
+func TestHelpFlag(t *testing.T) {
+	ts := testServer(t,
+		test.Http{
+			Method: "GET",
+			Path:   "/",
+			Code:   200,
+		},
+	)
+
+	defer ts.Close()
+	for _, hf := range stdcli.HelpFlags {
+		c := fmt.Sprintf("convox %s", hf)
+		test.Runs(t,
+			test.ExecRun{
+				Command: c,
+				Exit:    0,
+				Stdout:  convoxHelp,
+			},
+		)
+	}
+}

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -16,6 +16,9 @@ import (
 	"github.com/stvp/rollbar"
 )
 
+// HelpFlags is a slice of all the strings that should be treated as help flags by the CLI
+var HelpFlags = []string{"--help", "-h", "h", "help"}
+
 var (
 	Binary     string
 	Commands   []cli.Command

--- a/test/exec.go
+++ b/test/exec.go
@@ -32,17 +32,17 @@ func (er ExecRun) Test(t *testing.T) {
 	}
 
 	assert.NoError(t, err)
-	assert.Equal(t, er.Exit, code, "exit code should be equal")
+	assert.Equal(t, er.Exit, code, fmt.Sprintf("exit code should be equal 🢂  %s", er.Command))
 	if er.Stdout != "" {
-		assert.Equal(t, er.Stdout, stdout, "stdout should be equal")
+		assert.Equal(t, er.Stdout, stdout, fmt.Sprintf("stdout should be equal 🢂  %s", er.Command))
 	}
 	if er.OutMatch != "" {
 		assert.Contains(t, stdout, er.OutMatch,
-			fmt.Sprintf("stdout %q should contain %q", stdout, er.OutMatch))
+			fmt.Sprintf("stdout %q should contain %q\n 🢂  %s", stdout, er.OutMatch, er.Command))
 	}
 	if er.Stderr != "" {
 		assert.Contains(t, stderr, er.Stderr,
-			fmt.Sprintf("stderr %q should contain %q", stderr, er.Stderr))
+			fmt.Sprintf("stderr %q should contain %q\n 🢂  %s", stderr, er.Stderr, er.Command))
 	}
 }
 


### PR DESCRIPTION
Help flags in the CLI don't behave consistently:

```
$ convox ps help
convox ps: list an app's processes

Usage:
  convox ps <command> [args...]

Subcommands: (convox ps help <subcommand>)
  info		show info for a process
  stop		stop a process
  help, h	
  
Options:
  --app value, -a value	app name inferred from current directory if not specified
  --rack value		rack name
  --stats		display process cpu/memory stats
  --help, -h		show help
  
$ convox ps --help
ERROR: Rack not found. Try one of:
convox/demo
[...]
```

This PR adds a test to `cmd/convox/api_test.go` to check all permutations of all help flag forms for the `convox api` and `convox api get` commands.

Since the majority of the permutations don't behave as expected yet, I included a list of permutations to skip. Those should be fixed in a separate PR to actually correct the help flag parsing behavior.

If this test format is acceptable, it can be added to the other `convox` command test files.

This PR also adds additional output to show the content of the failed command in `test/exec.go`.