### PR TITLE
Print a warning when custom values aren't passed to --vpc-cidr or --subnet-cidrs when installing into an existing VPC

### DIFF
--- a/cmd/convox/install_test.go
+++ b/cmd/convox/install_test.go
@@ -282,6 +282,17 @@ func TestReadCredentialsFromFile(t *testing.T) {
 	assert.EqualError(t, err, "credentials file is of unknown length")
 }
 
+func TestRequiredFlagsWhenInstallingIntoExistingVPC(t *testing.T) {
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox install --existing-vpc foo",
+			Exit:    1,
+			Stdout:  "WARNING: [existing vpc] using default subnet cidrs (10.0.1.0/24,10.0.2.0/24,10.0.3.0/24); if this is incorrect, pass a custom value to --subnet-cidrs\nWARNING: [existing vpc] using default vpc cidr (10.0.0.0/16); if this is incorrect, pass a custom value to --vpc-cidr\n",
+			Stderr:  "ERROR: must specify --internet-gateway for existing VPC\n",
+		},
+	)
+}
+
 /* TestUrls checks that each URL returns HTTP status code 200.
 These URLs are printed in user-facing messages and have been gathered manually.
 Sources (mostly): cmd/convox/doctor.go, cmd/convox/install.go


### PR DESCRIPTION
Since the CLI fills in a default value for `--vpc-cidr` and `--subnet-cidrs`, I don't think it's possible to tell when a user hasn't passed those flags.

If this PR is accepted, the CLI will display a warning if the user has passed `--existing-vpc` and the value of either `--vpc-cidr` or `--subnet-cidrs` corresponds to the default:

![vpc-cidr](https://cloud.githubusercontent.com/assets/1585815/23237190/e3467ce2-f921-11e6-8dee-8fa0573014b5.png)
