### PR TITLE
Allow running a single test with 'make test'/'TESTRUN'

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -277,6 +277,12 @@ $ ci/cleanup.sh
 
 This generally uses a specific version number (e.g. 20160323164322) that has been released but not published. Passing integration tests offer confidence that the release can be published.
 
+## Testing
+
+* To run the test suite locally, run `make test`
+* To run a subset of tests, provide `TEST`, e.g. `make test TEST=github.com/convox/rack/cmd/convox`
+* To run a single test, provide `TEST` and `TESTRUN`, e.g. `make test TEST=github.com/convox/rack/cmd/convox TESTRUN=TestRequiredFlagsWhenInstallingIntoExistingVPC`
+
 ## Gotchas
 
 We compile some templates into `.go` files using `go-bindata`. If you make any changes to template files you will often need to run `make templates` to propagate your changes to the `.go` files. If it seems like your template changes aren't doing anything, try running `make templates.

--- a/bin/test
+++ b/bin/test
@@ -7,6 +7,12 @@ go get -t ./...
 rm -f coverage.txt
 
 if [ ! -z ${TEST} ]; then
+    if [ ! -z ${TESTRUN} ]; then
+        echo "Running single test $TESTRUN"
+        go test -coverprofile=profile.out -covermode=atomic "$TEST" -test.run "$TESTRUN"
+        exit
+    fi
+
     go test -coverprofile=profile.out -covermode=atomic "$TEST"
     exit
 fi

--- a/bin/test
+++ b/bin/test
@@ -6,14 +6,14 @@ go get -t ./...
 
 rm -f coverage.txt
 
-if [ ! -z ${TEST} ]; then
-    if [ ! -z ${TESTRUN} ]; then
-        echo "Running single test $TESTRUN"
-        go test -coverprofile=profile.out -covermode=atomic "$TEST" -test.run "$TESTRUN"
+if [ ! -z ${PKG} ]; then
+    if [ ! -z ${TEST} ]; then
+        echo "Running single test $TEST"
+        go test -coverprofile=profile.out -covermode=atomic "$PKG" -test.run "$TEST"
         exit
     fi
 
-    go test -coverprofile=profile.out -covermode=atomic "$TEST"
+    go test -coverprofile=profile.out -covermode=atomic "$PKG"
     exit
 fi
 

--- a/bin/test
+++ b/bin/test
@@ -8,20 +8,19 @@ rm -f coverage.txt
 
 if [ ! -z ${PKG} ]; then
     if [ ! -z ${TEST} ]; then
-        echo "Running single test $TEST"
-        go test -coverprofile=profile.out -covermode=atomic "$PKG" -test.run "$TEST"
-        exit
+        echo "Running tests matching '$TEST' from package $PKG"
+        go test -coverprofile=profile.out -covermode=atomic "$PKG" -run "$TEST"
+    else
+        echo "Running tests on package $PKG"
+        go test -coverprofile=profile.out -covermode=atomic "$PKG"
     fi
+else
+    for d in $(find . -not \( -name vendor -prune \) -name '*.go' -exec dirname {} \; | sort -u); do
+        go test -coverprofile=profile.out -covermode=atomic $d
 
-    go test -coverprofile=profile.out -covermode=atomic "$PKG"
-    exit
+        if [ -f profile.out ]; then
+            cat profile.out >> coverage.txt
+            rm profile.out
+        fi
+    done
 fi
-
-for d in $(find . -not \( -name vendor -prune \) -name '*.go' -exec dirname {} \; | sort -u); do
-  go test -coverprofile=profile.out -covermode=atomic $d
-
-  if [ -f profile.out ]; then
-    cat profile.out >> coverage.txt
-    rm profile.out
-  fi
-done


### PR DESCRIPTION
```
$ make test TEST=github.com/convox/rack/cmd/convox TESTRUN=TestRequiredFlagsWhenInstallingIntoExistingVPC
env PROVIDER=test CONVOX_WAIT= bin/test
Running single test TestRequiredFlagsWhenInstallingIntoExistingVPC
ok  	github.com/convox/rack/cmd/convox	0.010s	coverage: 1.7% of statements
```

Accepting this PR will enable behavior similar to `go test -test.run` but with `make test`.