### PR TITLE
Make instance tenancy refer to Tenancy instead of being hardcoded to default

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -956,7 +956,7 @@
         "CidrBlock": { "Ref": "VPCCIDR" },
         "EnableDnsSupport": "true",
         "EnableDnsHostnames": "true",
-        "InstanceTenancy": "default",
+        "InstanceTenancy": { "Ref": "Tenancy" },
         "Tags": [
           { "Key": "Name", "Value": { "Ref": "AWS::StackName" } }
         ]


### PR DESCRIPTION
Tested this again (after closing https://github.com/convox/rack/pull/1934) and it seems to be working fine (I was testing with a local Rack instead of uploading rack.json to CF web interface; maybe that was the problem?).

Tested manually with:

### Standard

```
Ami	
ApiCpu	128
ApiMemory	128
Autoscale	Yes
BuildCpu	0
BuildImage	
BuildInstance	
BuildMemory	1024
ClientId	dev@convox.com
ContainerDisk	10
* CustomTopicRuntime	nodejs4.3
Development	No
Encryption	Yes
ExistingVpc	
InstanceBootCommand	
InstanceCount	3
InstanceRunCommand	
* InstanceType	m4.large
InstanceUpdateBatchSize	1
Internal	No
InternetGateway	
Key	
* Password	****
Private	No
PrivateApi	No
Subnet0CIDR	10.0.1.0/24
Subnet1CIDR	10.0.2.0/24
Subnet2CIDR	10.0.3.0/24
SubnetPrivate0CIDR	10.0.4.0/24
SubnetPrivate1CIDR	10.0.5.0/24
SubnetPrivate2CIDR	10.0.6.0/24
SwapSize	5
* Tenancy	dedicated
* Version	20170216230221
VolumeSize	50
VPCCIDR	10.0.0.0/16
```

### Internal

```
Ami	
ApiCpu	128
ApiMemory	128
Autoscale	Yes
BuildCpu	0
BuildImage	
BuildInstance	
BuildMemory	1024
ClientId	dev@convox.com
ContainerDisk	10
* CustomTopicRuntime	nodejs4.3
Development	No
Encryption	Yes
ExistingVpc	
InstanceBootCommand	
InstanceCount	3
InstanceRunCommand	
* InstanceType	m4.large
InstanceUpdateBatchSize	1
* Internal	Yes
InternetGateway	
Key	
* Password	****
Private	No
PrivateApi	No
Subnet0CIDR	10.0.1.0/24
Subnet1CIDR	10.0.2.0/24
Subnet2CIDR	10.0.3.0/24
SubnetPrivate0CIDR	10.0.4.0/24
SubnetPrivate1CIDR	10.0.5.0/24
SubnetPrivate2CIDR	10.0.6.0/24
SwapSize	5
* Tenancy	dedicated
* Version	20170216230221
VolumeSize	50
VPCCIDR	10.0.0.0/16
```

### Existing VPC

TODO

### Private

```
Ami	
ApiCpu	128
ApiMemory	128
Autoscale	Yes
BuildCpu	0
BuildImage	
BuildInstance	
BuildMemory	1024
ClientId	dev@convox.com
ContainerDisk	10
* CustomTopicRuntime	nodejs4.3
Development	No
Encryption	Yes
ExistingVpc	
InstanceBootCommand	
InstanceCount	3
InstanceRunCommand	
* InstanceType	m4.large
InstanceUpdateBatchSize	1
Internal	No
InternetGateway	
Key	
* Password	****
Private	Yes
PrivateApi	No
Subnet0CIDR	10.0.1.0/24
Subnet1CIDR	10.0.2.0/24
Subnet2CIDR	10.0.3.0/24
SubnetPrivate0CIDR	10.0.4.0/24
SubnetPrivate1CIDR	10.0.5.0/24
SubnetPrivate2CIDR	10.0.6.0/24
SwapSize	5
* Tenancy	dedicated
* Version	20170216230221
VolumeSize	50
VPCCIDR	10.0.0.0/16
```