### PR TITLE
Improve Release Failed Webhook Messages

### DIFF
--- a/api/models/release.go
+++ b/api/models/release.go
@@ -690,13 +690,12 @@ func waitForPromotion(r *Release) {
 			err = CloudFormation().WaitUntilStackUpdateComplete(&cloudformation.DescribeStacksInput{
 				StackName: aws.String(stackName),
 			})
-			if err == nil {
-				//signal stack update has completed
-				waitch <- err
-				return
+			if err != nil {
+				if err.Error() == "exceeded 120 wait attempts" {
+					continue
+				}
 			}
-			fmt.Println(fmt.Errorf("unable to wait for promotion: %s", err))
-			//stack has not updated after an hour try again
+			break
 		}
 		waitch <- err
 	}()
@@ -704,9 +703,15 @@ func waitForPromotion(r *Release) {
 	for {
 		select {
 		case err := <-waitch:
-			if err != nil {
-				Provider().EventSend(event, fmt.Errorf("unable to wait for promotion: %s", err))
-				fmt.Println(fmt.Errorf("unable to wait for promotion: %s", err))
+			if err == nil {
+				event.Status = "success"
+				Provider().EventSend(event, nil)
+				return
+			}
+
+			if err != nil && err.Error() == "exceeded 120 wait attempts" {
+				Provider().EventSend(event, fmt.Errorf("couldn't determine promotion status, timed out"))
+				fmt.Println(fmt.Errorf("couldn't determine promotion status, timed out"))
 				return
 			}
 
@@ -726,40 +731,32 @@ func waitForPromotion(r *Release) {
 			}
 
 			stack := resp.Stacks[0]
-			switch *stack.StackStatus {
 
-			case "UPDATE_COMPLETE":
-				event.Status = "success"
-				Provider().EventSend(event, nil)
-
-			case "UPDATE_ROLLBACK_FAILED", "UPDATE_ROLLBACK_COMPLETE", "UPDATE_FAILED":
-				se, err := CloudFormation().DescribeStackEvents(&cloudformation.DescribeStackEventsInput{
-					StackName: aws.String(stackName),
-				})
-				if err != nil {
-					Provider().EventSend(event, fmt.Errorf("unable to check stack events: %s", err))
-					fmt.Println(fmt.Errorf("unable to check stack events: %s", err))
-					return
-				}
-
-				var lastEvent *cloudformation.StackEvent
-
-				for _, e := range se.StackEvents {
-					switch *e.ResourceStatus {
-					case "UPDATE_FAILED", "DELETE_FAILED", "CREATE_FAILED":
-						lastEvent = e
-						break
-					}
-				}
-
-				ee := fmt.Errorf("unable to determine release error")
-				if lastEvent != nil {
-					ee = fmt.Errorf("%s: %s", *lastEvent.ResourceStatus, *lastEvent.ResourceStatusReason)
-				}
-
-				Provider().EventSend(event, fmt.Errorf("release failed: %s", r.Id, ee))
+			se, err := CloudFormation().DescribeStackEvents(&cloudformation.DescribeStackEventsInput{
+				StackName: aws.String(stackName),
+			})
+			if err != nil {
+				Provider().EventSend(event, fmt.Errorf("unable to check stack events: %s", err))
+				fmt.Println(fmt.Errorf("unable to check stack events: %s", err))
+				return
 			}
-			return
+
+			var lastEvent *cloudformation.StackEvent
+
+			for _, e := range se.StackEvents {
+				switch *e.ResourceStatus {
+				case "UPDATE_FAILED", "DELETE_FAILED", "CREATE_FAILED":
+					lastEvent = e
+					break
+				}
+			}
+
+			ee := fmt.Errorf("unable to determine release error")
+			if lastEvent != nil {
+				ee = fmt.Errorf("%s: %s", *lastEvent.ResourceStatus, *lastEvent.ResourceStatusReason)
+			}
+
+			Provider().EventSend(event, fmt.Errorf("release failed: %s", r.Id, ee))
 		}
 	}
 }

--- a/api/models/release.go
+++ b/api/models/release.go
@@ -751,10 +751,16 @@ func waitForPromotion(r *Release) {
 
 			ee := fmt.Errorf("unable to determine release error")
 			if lastEvent != nil {
-				ee = fmt.Errorf("%s: %s", *lastEvent.ResourceStatus, *lastEvent.ResourceStatusReason)
+				ee = fmt.Errorf(
+					"[%s:%s] [%s]: %s",
+					*lastEvent.ResourceType,
+					*lastEvent.LogicalResourceId,
+					*lastEvent.ResourceStatus,
+					*lastEvent.ResourceStatusReason,
+				)
 			}
 
-			Provider().EventSend(event, fmt.Errorf("release failed: %s", r.Id, ee))
+			Provider().EventSend(event, fmt.Errorf("release %s failed - %s", r.Id, ee.Error()))
 		}
 	}
 }

--- a/api/models/release.go
+++ b/api/models/release.go
@@ -730,8 +730,6 @@ func waitForPromotion(r *Release) {
 				return
 			}
 
-			stack := resp.Stacks[0]
-
 			se, err := CloudFormation().DescribeStackEvents(&cloudformation.DescribeStackEventsInput{
 				StackName: aws.String(stackName),
 			})


### PR DESCRIPTION
We are incorrectly sending release failed webhooks with a message that says `unable to wait for promotion: ResourceNotReady: exceeded 120 wait attempts`.

Looking at the aws `Waiter` source code it returns an error when the stack is in an update failed state, we were not handling this properly and always outputting this error.

This PR

* Increases the waiter 3x to cover observations that a stack can take more than an hour to rollback
* Changes the message include "UPDATE_FAILED", "UPDATE_ROLLBACK_FAILED", "UPDATE_ROLLBACK_COMPLETE" and event status correctly
* adds more info to the error message: `message": "release RYSPOEAUOVY failed - [AWS::ECS::Service:ServiceWeb] [UPDATE_FAILED]: Resource update cancelled",`