### PR TITLE
configure login transport to allow for proxies

### DIFF
--- a/api/controllers/auth.go
+++ b/api/controllers/auth.go
@@ -8,6 +8,6 @@ import (
 
 func Auth(w http.ResponseWriter, r *http.Request) *httperr.Error {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte('{"success":true}'))
+	w.Write([]byte(`{"success":true}`))
 	return nil
 }

--- a/api/controllers/auth.go
+++ b/api/controllers/auth.go
@@ -7,6 +7,7 @@ import (
 )
 
 func Auth(w http.ResponseWriter, r *http.Request) *httperr.Error {
-	w.Write([]byte("OK\n"))
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte('{"success":true}'))
 	return nil
 }

--- a/client/auth.go
+++ b/client/auth.go
@@ -7,6 +7,9 @@ import (
 	"net/http"
 )
 
+//Auth is a request that simply checks whether the password is valid
+//in the case of console the users id will be returned, a rack will
+//return an empty string
 func (c *Client) Auth() (string, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/auth", c.Host), nil)
 	if err != nil {
@@ -35,7 +38,8 @@ func (c *Client) Auth() (string, error) {
 
 	err = json.Unmarshal(body, &data)
 	if err == nil {
-		//if bad JSON is returned it is probably a legacy app
+		//if bad JSON is returned it is probably a legacy rack
+		//which used to return the plain text string 'OK'
 		id = data["id"]
 	}
 

--- a/client/auth.go
+++ b/client/auth.go
@@ -1,29 +1,43 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 )
 
-func (c *Client) Auth() error {
+func (c *Client) Auth() (string, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/auth", c.Host), nil)
-
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	req.SetBasicAuth("convox", string(c.Password))
 
 	resp, err := c.client().Do(req)
-
 	if err != nil {
-		return err
+		return "", err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("invalid login\nHave you created an account at https://convox.com/signup?")
+		return "", fmt.Errorf("invalid login\nHave you created an account at https://convox.com/signup?")
 	}
 
-	resp.Body.Close()
-	return nil
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var id string
+	var data map[string]string
+
+	err = json.Unmarshal(body, &data)
+	if err == nil {
+		//if bad JSON is returned it is probably a legacy app
+		id = data["id"]
+	}
+
+	return id, nil
 }

--- a/client/auth.go
+++ b/client/auth.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 )
 
+//Auth is used to transfer the id of the authenticating user when authing against the console API.
+//When authing against a rack the id will be blank as user ids are a console concept
 type Auth struct {
 	ID string `json:"id"`
 }

--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -81,7 +81,6 @@ func cmdLogin(c *cli.Context) error {
 	}
 
 	password := os.Getenv("CONVOX_PASSWORD")
-
 	if password == "" {
 		password = c.String("password")
 	}
@@ -95,7 +94,6 @@ func cmdLogin(c *cli.Context) error {
 		// first try current login
 		password, err = getLogin(host)
 		userID, err = testLogin(host, password, c.App.Version)
-
 		// then prompt for password
 		if err != nil {
 			password = promptForPassword()
@@ -351,15 +349,7 @@ func updateID(id string) error {
 }
 
 func testLogin(host, password, version string) (string, error) {
-	cl := client.New(host, password, version)
-	id, err := cl.Auth()
-	if err != nil {
-		pw := promptForPassword()
-		cl := client.New(host, pw, version)
-		return cl.Auth()
-	}
-
-	return id, nil
+	return client.New(host, password, version).Auth()
 }
 
 func promptForPassword() string {

--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -354,8 +354,21 @@ func updateID(id string) error {
 
 func testLogin(host, password, version string) (bool, string, error) {
 	//Attempt a console login
+	var config *tls.Config
+
+	if host == "console.convox.com" {
+		config = &tls.Config{
+			ServerName: host,
+		}
+	} else {
+		config = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: config,
 	}
 
 	u := url.URL{}

--- a/cmd/convox/login_test.go
+++ b/cmd/convox/login_test.go
@@ -58,8 +58,7 @@ func TestLoginRack(t *testing.T) {
 	temp, _ := ioutil.TempDir("", "convox-test")
 
 	ts := testServer(t,
-		test.Http{Method: "GET", Path: "/auth", Code: 404, Response: client.Apps{}},
-		test.Http{Method: "GET", Path: "/apps", Code: 200, Response: client.Apps{}},
+		test.Http{Method: "GET", Path: "/auth", Code: 200, Response: client.Apps{}},
 	)
 
 	defer ts.Close()

--- a/cmd/convox/login_test.go
+++ b/cmd/convox/login_test.go
@@ -58,7 +58,7 @@ func TestLoginRack(t *testing.T) {
 	temp, _ := ioutil.TempDir("", "convox-test")
 
 	ts := testServer(t,
-		test.Http{Method: "GET", Path: "/auth", Code: 200, Response: client.Apps{}},
+		test.Http{Method: "GET", Path: "/auth", Code: 200, Response: client.Auth{}},
 	)
 
 	defer ts.Close()


### PR DESCRIPTION
The implementation of retrieving the console user id in the login function broke the login command for users using proxies.

This should fix that.
