### PR TITLE
Avoid AWS rate limits for apps with lots of processes

### DIFF
--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -230,6 +230,7 @@ func (p *AWSProvider) stackTasks(stack string) ([]string, error) {
 				for _, arn := range page.TaskArns {
 					tasks = append(tasks, *arn)
 				}
+				time.Sleep(100 * time.Millisecond)
 				return true
 			},
 		)


### PR DESCRIPTION
Add a short delay between pages to prevent AWS rate limiting.

Fixes #1990 