### PR TITLE
Fix `convox instances` showing 0% CPU usage

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -686,6 +686,7 @@
                       "autoscaling:TerminateInstanceInAutoScalingGroup",
                       "autoscaling:UpdateAutoScalingGroup",
                       "cloudformation:DescribeStacks",
+                      "cloudwatch:GetMetricStatistics",
                       "ec2:AllocateAddress",
                       "ec2:AssociateRouteTable",
                       "ec2:AuthorizeSecurityGroupIngress",


### PR DESCRIPTION
Without the `cloudwatch:GetMetricStatistics` permission, Racks had their GetMetricStatistics calls fail silently and the CPU usage value defaulted to 0.

```
❯ convox instances
ID                   AGENT  STATUS  STARTED     PS  CPU    MEM
i-0ec167aa2b0ea5158  on     active  1 week ago  0   0.00%  0.00%
i-0609ed1cca138fc22  on     active  1 week ago  3   0.00%  22.37%
i-0c00a267545c6d2f6  on     active  1 week ago  2   0.00%  19.17%
```