### PR TITLE
Check for help on every command

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,6 +6,9 @@ go get -t ./...
 
 rm -f coverage.txt
 
+# Print urfave/cli template parsing errors
+export CLI_TEMPLATE_ERROR_DEBUG=true
+
 if [ ! -z ${PKG} ]; then
     if [ ! -z ${TEST} ]; then
         echo "Running single test $TEST"

--- a/cmd/convox/api.go
+++ b/cmd/convox/api.go
@@ -2,32 +2,57 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/convox/rack/cmd/convox/stdcli"
 	"gopkg.in/urfave/cli.v1"
 )
 
+var endpoints = []string{
+	"/apps",
+	"/apps/<app-name>",
+	"/auth",
+	"/certificates",
+	"/index",
+	"/instances",
+	"/racks",
+	"/registries",
+	"/resources",
+	"/switch",
+	"/system",
+}
+
+var apiHelp = fmt.Sprintf(`Valid endpoints:
+  %s
+
+For more information, see https://convox.com/api`,
+	strings.Join(endpoints, "\n  "))
+
 func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "api",
-		Description: "api endpoint",
-		Usage:       "",
+		Description: "make a rest api call to a convox endpoint",
+		Usage:       "<command> <endpoint> [options]",
+		ArgsUsage:   "<command> <endpoint>",
 		Action:      cmdApi,
 		Flags:       []cli.Flag{rackFlag},
 		Subcommands: []cli.Command{
 			{
 				Name:        "get",
-				Description: "get an api endpoint",
-				Usage:       "<endpoint>",
+				Description: "make a GET request to an api endpoint",
+				Usage:       "<endpoint> [options]",
+				UsageText:   apiHelp,
+				ArgsUsage:   "<endpoint>",
 				Action:      cmdApiGet,
 				Flags:       []cli.Flag{rackFlag},
 			},
 			{
 				Name:        "delete",
-				Description: "delete an api endpoint",
-				Usage:       "<endpoint>",
+				Description: "make a DELETE request to an api endpoint",
+				Usage:       "delete an api endpoint",
+				UsageText:   apiHelp,
+				ArgsUsage:   "<endpoint>",
 				Action:      cmdApiDelete,
 				Flags:       []cli.Flag{rackFlag},
 			},
@@ -36,21 +61,21 @@ func init() {
 }
 
 func cmdApi(c *cli.Context) error {
-	if len(c.Args()) > 0 {
-		return stdcli.Error(
-			errors.New("ERROR: `convox api` does not take arguments. Perhaps you meant `convox api get`?"),
-		)
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
 
-	stdcli.Usage(c, "")
+	// If we're here, it means the user has run 'convox api' without any subcommand or help flag
+	stdcli.Errorf("Missing expected subcommand")
+	cli.ShowCommandHelp(c, c.Command.Name)
+
+	// Also print the list of endpoints for good measure
+	fmt.Printf("\n%s\n", apiHelp)
 	return nil
 }
 
 func cmdApiGet(c *cli.Context) error {
-	if len(c.Args()) < 1 {
-		stdcli.Usage(c, "get")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	path := c.Args()[0]
 
@@ -71,10 +96,8 @@ func cmdApiGet(c *cli.Context) error {
 }
 
 func cmdApiDelete(c *cli.Context) error {
-	if len(c.Args()) < 1 {
-		stdcli.Usage(c, "delete")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	path := c.Args()[0]
 

--- a/cmd/convox/apps.go
+++ b/cmd/convox/apps.go
@@ -20,14 +20,16 @@ func init() {
 			{
 				Name:        "cancel",
 				Description: "cancel an update",
-				Usage:       "",
+				Usage:       "[options]",
+				ArgsUsage:   "",
 				Action:      cmdAppCancel,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
 				Name:        "create",
 				Description: "create a new application",
-				Usage:       "<name>",
+				Usage:       "[name] [options]",
+				ArgsUsage:   "[name] (inferred from current directory if not specified)",
 				Action:      cmdAppCreate,
 				Flags: []cli.Flag{
 					rackFlag,
@@ -56,13 +58,15 @@ func init() {
 				Name:        "params",
 				Description: "list advanced parameters for an app",
 				Usage:       "[name]",
+				ArgsUsage:   "",
 				Action:      cmdAppParams,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 				Subcommands: []cli.Command{
 					{
 						Name:        "set",
 						Description: "update advanced parameters for an app",
-						Usage:       "NAME=VALUE [NAME=VALUE]",
+						Usage:       "NAME=VALUE [NAME=VALUE] ... [options]",
+						ArgsUsage:   "NAME=VALUE",
 						Action:      cmdAppParamsSet,
 						Flags:       []cli.Flag{appFlag, rackFlag},
 					},
@@ -73,14 +77,8 @@ func init() {
 }
 
 func cmdApps(c *cli.Context) error {
-	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox apps` does not take arguments. Perhaps you meant `convox apps create`?"))
-	}
-
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
 
 	apps, err := rackClient(c).GetApps()
 	if err != nil {
@@ -98,6 +96,9 @@ func cmdApps(c *cli.Context) error {
 }
 
 func cmdAppCancel(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
@@ -119,12 +120,16 @@ func cmdAppCancel(c *cli.Context) error {
 }
 
 func cmdAppCreate(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
 	}
 
 	if len(c.Args()) > 0 {
+		// accept no more than 1 argument
+		stdcli.NeedArg(c, 1)
 		app = c.Args()[0]
 	}
 
@@ -155,10 +160,8 @@ func cmdAppCreate(c *cli.Context) error {
 }
 
 func cmdAppDelete(c *cli.Context) error {
-	if len(c.Args()) < 1 {
-		stdcli.Usage(c, "delete")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	app := c.Args()[0]
 
@@ -175,12 +178,16 @@ func cmdAppDelete(c *cli.Context) error {
 }
 
 func cmdAppInfo(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
 	}
 
+	// FIXME: we should accept only --app (i.e. as a flag) to be consistent with other commands
 	if len(c.Args()) > 0 {
+		stdcli.NeedArg(c, 1)
 		app = c.Args()[0]
 	}
 
@@ -221,6 +228,9 @@ func cmdAppInfo(c *cli.Context) error {
 }
 
 func cmdAppParams(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
@@ -250,6 +260,10 @@ func cmdAppParams(c *cli.Context) error {
 }
 
 func cmdAppParamsSet(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	// need at least one argument
+	stdcli.NeedArg(c, -1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)

--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -59,28 +59,30 @@ func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "build",
 		Description: "create a new build",
-		Usage:       "",
+		Usage:       "[directory] [options]",
 		Action:      cmdBuildsCreate,
 		Flags:       buildCreateFlags,
 	})
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "builds",
 		Description: "manage an app's builds",
-		Usage:       "",
+		Usage:       "[subcommand] [options] [args...]",
 		Action:      cmdBuilds,
 		Flags:       []cli.Flag{appFlag, rackFlag},
 		Subcommands: []cli.Command{
 			{
 				Name:        "create",
 				Description: "create a new build",
-				Usage:       "",
+				Usage:       "[directory] [options]",
+				ArgsUsage:   "[directory]",
 				Action:      cmdBuildsCreate,
 				Flags:       buildCreateFlags,
 			},
 			{
 				Name:        "delete",
 				Description: "archive a build and its artifacts",
-				Usage:       "<id>",
+				Usage:       "<build id>",
+				ArgsUsage:   "<build id>",
 				Action:      cmdBuildsDelete,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
@@ -101,14 +103,15 @@ func init() {
 			{
 				Name:        "logs",
 				Description: "get logs for a build",
-				Usage:       "<id>",
+				Usage:       "<build id>",
+				ArgsUsage:   "<build id>",
 				Action:      cmdBuildsLogs,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
 				Name:        "import",
 				Description: "import a build artifact from stdin",
-				Usage:       "",
+				Usage:       "[options]",
 				Action:      cmdBuildsImport,
 				Flags: []cli.Flag{
 					appFlag,
@@ -126,7 +129,8 @@ func init() {
 			{
 				Name:        "info",
 				Description: "print output for a build",
-				Usage:       "<id>",
+				Usage:       "<build id>",
+				ArgsUsage:   "<build id>",
 				Action:      cmdBuildsInfo,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
@@ -135,18 +139,12 @@ func init() {
 }
 
 func cmdBuilds(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox builds` does not take arguments. Perhaps you meant `convox builds create`?"))
-	}
-
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
 	}
 
 	builds, err := rackClient(c).GetBuilds(app)
@@ -172,9 +170,11 @@ func cmdBuilds(c *cli.Context) error {
 }
 
 func cmdBuildsCreate(c *cli.Context) error {
+	stdcli.NeedHelp(c)
 	wd := "."
 
 	if len(c.Args()) > 0 {
+		stdcli.NeedArg(c, 1)
 		wd = c.Args()[0]
 	}
 
@@ -222,14 +222,12 @@ func cmdBuildsCreate(c *cli.Context) error {
 }
 
 func cmdBuildsDelete(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "delete")
-		return nil
 	}
 
 	build := c.Args()[0]
@@ -244,14 +242,12 @@ func cmdBuildsDelete(c *cli.Context) error {
 }
 
 func cmdBuildsInfo(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "info")
-		return nil
 	}
 
 	build := c.Args()[0]
@@ -272,6 +268,9 @@ func cmdBuildsInfo(c *cli.Context) error {
 }
 
 func cmdBuildsExport(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
@@ -279,11 +278,6 @@ func cmdBuildsExport(c *cli.Context) error {
 
 	if stdcli.IsTerminal(os.Stdout) && c.String("file") == "" {
 		return stdcli.Error(fmt.Errorf("please pipe the output of this command to a file or specify -f"))
-	}
-
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "export")
-		return nil
 	}
 
 	build := c.Args()[0]
@@ -311,6 +305,7 @@ func cmdBuildsExport(c *cli.Context) error {
 }
 
 func cmdBuildsImport(c *cli.Context) error {
+	stdcli.NeedHelp(c)
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
@@ -352,14 +347,12 @@ func cmdBuildsImport(c *cli.Context) error {
 }
 
 func cmdBuildsLogs(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "info")
-		return nil
 	}
 
 	build := c.Args()[0]
@@ -774,7 +767,7 @@ func warnUnignoredEnv(dir string) error {
 		}
 	}
 	if warn {
-		fmt.Fprintf(os.Stderr, "WARNING: You have a .env file that is not in your .dockerignore, you may be leaking secrets\n")
+		stdcli.Warn("You have a .env file that is not in your .dockerignore, you may be leaking secrets")
 	}
 	return nil
 }

--- a/cmd/convox/certs.go
+++ b/cmd/convox/certs.go
@@ -20,6 +20,7 @@ func init() {
 				Name:        "create",
 				Description: "upload a certificate",
 				Usage:       "<cert.pub> <cert.key>",
+				ArgsUsage:   "<cert.pub> <cert.key>",
 				Action:      cmdCertsCreate,
 				Flags: []cli.Flag{
 					rackFlag,
@@ -32,7 +33,8 @@ func init() {
 			{
 				Name:        "delete",
 				Description: "delete a certificate",
-				Usage:       "<id>",
+				Usage:       "<cert id>",
+				ArgsUsage:   "<cert id>",
 				Action:      cmdCertsDelete,
 				Flags:       []cli.Flag{rackFlag},
 			},
@@ -40,6 +42,7 @@ func init() {
 				Name:        "generate",
 				Description: "generate a certificate",
 				Usage:       "<domain> [domain...]",
+				ArgsUsage:   "<domain> [domain...]",
 				Action:      cmdCertsGenerate,
 				Flags:       []cli.Flag{rackFlag},
 			},
@@ -48,14 +51,8 @@ func init() {
 }
 
 func cmdCertsList(c *cli.Context) error {
-	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox certs` does not take arguments. Perhaps you meant `convox certs generate`?"))
-	}
-
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
 
 	certs, err := rackClient(c).ListCertificates()
 	if err != nil {
@@ -73,10 +70,8 @@ func cmdCertsList(c *cli.Context) error {
 }
 
 func cmdCertsCreate(c *cli.Context) error {
-	if len(c.Args()) < 2 {
-		stdcli.Usage(c, "create")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 2)
 
 	pub, err := ioutil.ReadFile(c.Args()[0])
 	if err != nil {
@@ -111,10 +106,8 @@ func cmdCertsCreate(c *cli.Context) error {
 }
 
 func cmdCertsDelete(c *cli.Context) error {
-	if len(c.Args()) < 1 {
-		stdcli.Usage(c, "delete")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	fmt.Printf("Removing certificate... ")
 
@@ -128,10 +121,8 @@ func cmdCertsDelete(c *cli.Context) error {
 }
 
 func cmdCertsGenerate(c *cli.Context) error {
-	if len(c.Args()) < 1 {
-		stdcli.Usage(c, "generate")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	fmt.Printf("Requesting certificate... ")
 

--- a/cmd/convox/deploy.go
+++ b/cmd/convox/deploy.go
@@ -30,9 +30,11 @@ func init() {
 }
 
 func cmdDeploy(c *cli.Context) error {
+	stdcli.NeedHelp(c)
 	wd := "."
 
 	if len(c.Args()) > 0 {
+		stdcli.NeedArg(c, 1)
 		wd = c.Args()[0]
 	}
 

--- a/cmd/convox/doctor.go
+++ b/cmd/convox/doctor.go
@@ -775,8 +775,8 @@ func checkMissingDockerFiles(m *manifest.Manifest) error {
 
 	for _, s := range m.Services {
 		if s.Image == "" {
-			dockerFile := coalesce(s.Dockerfile, "Dockerfile")
-			dockerFile = coalesce(s.Build.Dockerfile, dockerFile)
+			dockerFile := helpers.Coalesce(s.Dockerfile, "Dockerfile")
+			dockerFile = helpers.Coalesce(s.Build.Dockerfile, dockerFile)
 			if !helpers.Exists(fmt.Sprintf("%s/%s", s.Build.Context, dockerFile)) {
 				diagnose(Diagnosis{
 					Title:       title,

--- a/cmd/convox/env.go
+++ b/cmd/convox/env.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -25,14 +24,16 @@ func init() {
 			{
 				Name:        "get",
 				Description: "get an environment variable",
-				Usage:       "VARIABLE",
+				Usage:       "VARIABLE [options]",
+				ArgsUsage:   "VARIABLE",
 				Action:      cmdEnvGet,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
 				Name:        "set",
 				Description: "set an environment variable",
-				Usage:       "VARIABLE=VALUE",
+				Usage:       "VARIABLE=VALUE [VARIABLE=VALUE ...] [options]",
+				ArgsUsage:   "VARIABLE=VALUE",
 				Action:      cmdEnvSet,
 				Flags: []cli.Flag{
 					appFlag,
@@ -55,7 +56,8 @@ func init() {
 			{
 				Name:        "unset",
 				Description: "delete an environment varible",
-				Usage:       "VARIABLE",
+				Usage:       "VARIABLE [options]",
+				ArgsUsage:   "VARIABLE",
 				Action:      cmdEnvUnset,
 				Flags: []cli.Flag{
 					appFlag,
@@ -80,18 +82,12 @@ func init() {
 }
 
 func cmdEnvList(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox env` does not take arguments. Perhaps you meant `convox env set`?"))
-	}
-
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
 	}
 
 	env, err := rackClient(c).GetEnvironment(app)
@@ -115,17 +111,12 @@ func cmdEnvList(c *cli.Context) error {
 }
 
 func cmdEnvGet(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) == 0 {
-		return stdcli.Error(errors.New("No variable specified"))
-	}
-
-	if len(c.Args()) > 1 {
-		return stdcli.Error(errors.New("Only 1 variable can be retrieved at a time"))
 	}
 
 	variable := c.Args()[0]
@@ -140,6 +131,8 @@ func cmdEnvGet(c *cli.Context) error {
 }
 
 func cmdEnvSet(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
@@ -222,17 +215,12 @@ func cmdEnvSet(c *cli.Context) error {
 }
 
 func cmdEnvUnset(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) == 0 {
-		return stdcli.Error(errors.New("No variable specified"))
-	}
-
-	if len(c.Args()) > 1 {
-		return stdcli.Error(errors.New("Only 1 variable can be unset at a time"))
 	}
 
 	key := c.Args()[0]

--- a/cmd/convox/env_test.go
+++ b/cmd/convox/env_test.go
@@ -73,8 +73,8 @@ func TestGetEnvNoVariableSpecified(t *testing.T) {
 	test.Runs(t,
 		test.ExecRun{
 			Command: "convox env get",
-			Exit:    1,
-			Stderr:  "No variable specified",
+			Exit:    129,
+			Stderr:  "ERROR: 1 argument is required: VARIABLE",
 		},
 	)
 }

--- a/cmd/convox/exec.go
+++ b/cmd/convox/exec.go
@@ -14,7 +14,8 @@ func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "exec",
 		Description: "exec a command in a process in your Convox rack",
-		Usage:       "[pid] [command]",
+		Usage:       "<pid> <command> [options]",
+		ArgsUsage:   "<pid> <command>",
 		Action:      cmdExec,
 		Flags:       []cli.Flag{appFlag, rackFlag},
 	})
@@ -44,10 +45,8 @@ func cmdExec(c *cli.Context) error {
 		return stdcli.Error(err)
 	}
 
-	if len(c.Args()) < 2 {
-		stdcli.Usage(c, "exec")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, -2)
 
 	ps := c.Args()[0]
 

--- a/cmd/convox/flags_test.go
+++ b/cmd/convox/flags_test.go
@@ -6,18 +6,22 @@ import (
 
 	"github.com/convox/rack/cmd/convox/stdcli"
 	"github.com/convox/rack/test"
+	"github.com/stretchr/testify/assert"
 )
 
 /* HELP CHECKS */
 // http://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html
 
-var convoxHelp = `convox: command-line application management
+// Note: when --help precedes a subcommand, it shows Convox help, not the subcommand help
+// This is a known issue: https://github.com/urfave/cli/issues/318
+
+var convoxUsage = `convox: command-line application management
 
 Usage:
-  convox <command> [args...]
+  convox <command> [subcommand] [options...] [args...]
 
-Subcommands: (convox help <subcommand>)
-  api                  api endpoint
+Commands: (convox <command> --help)
+  api                  make a rest api call to a convox endpoint
   apps                 list deployed apps
   build                create a new build
   builds               manage an app's builds
@@ -52,10 +56,11 @@ Options:
   --rack value           rack name
   --help, -h             show help
   --version, -v          print the version
-  
-`
+  `
 
 func TestHelpFlag(t *testing.T) {
+	assert.Equal(t, stdcli.HelpFlags, []string{"--help", "-h", "h", "help"})
+
 	ts := testServer(t,
 		test.Http{
 			Method: "GET",
@@ -71,7 +76,7 @@ func TestHelpFlag(t *testing.T) {
 			test.ExecRun{
 				Command: c,
 				Exit:    0,
-				Stdout:  convoxHelp,
+				Stdout:  convoxUsage,
 			},
 		)
 	}

--- a/cmd/convox/helpers/helpers.go
+++ b/cmd/convox/helpers/helpers.go
@@ -8,6 +8,17 @@ import (
 	"github.com/dustin/go-humanize"
 )
 
+// Coalesce returns the first non-empty string in a slice of strings
+func Coalesce(ss ...string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+
+	return ""
+}
+
 // DetectComposeFile checks for COMPOSE_FILE envvar; falls back to docker-compose.yml
 func DetectComposeFile() string {
 	dcm := "docker-compose.yml"
@@ -69,4 +80,14 @@ func DetectDocker() string {
 		return osd
 	}
 	return "docker"
+}
+
+// In checks if a string is present in a slice of strings
+func In(item string, s []string) bool {
+	for _, sliceItem := range s {
+		if sliceItem == item {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/convox/helpers/helpers_test.go
+++ b/cmd/convox/helpers/helpers_test.go
@@ -1,0 +1,47 @@
+package helpers
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoalesce(t *testing.T) {
+	result := Coalesce("", "b", "c")
+	assert.Equal(t, result, "b")
+}
+
+func TestDetectComposeFile(t *testing.T) {
+	cf := DetectComposeFile()
+	assert.Equal(t, cf, "docker-compose.yml")
+
+	os.Setenv("COMPOSE_FILE", "foo")
+	cf = DetectComposeFile()
+	assert.Equal(t, cf, "foo")
+}
+
+func TestExists(t *testing.T) {
+	result := Exists("helpers_test.go")
+	assert.Equal(t, result, true)
+
+	result = Exists("nonexistent")
+	assert.Equal(t, result, false)
+}
+
+func TestHumanizeTime(t *testing.T) {
+	now := time.Now()
+	result := HumanizeTime(now)
+	assert.Equal(t, result, "now")
+
+	zero := time.Time{}
+	result = HumanizeTime(zero)
+	assert.Equal(t, result, "")
+}
+
+func TestIn(t *testing.T) {
+	words := []string{"I", "am", "a", "traveler", "of", "both", "time", "and", "space,", "to", "be", "where", "I", "have", "been"}
+	assert.Equal(t, In("traveler", words), true)
+	assert.Equal(t, In("kashmir", words), false)
+}

--- a/cmd/convox/instances.go
+++ b/cmd/convox/instances.go
@@ -17,21 +17,24 @@ func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "instances",
 		Description: "list your Convox rack's instances",
-		Usage:       "",
+		Usage:       "[subcommand] [args] [options]",
+		ArgsUsage:   "",
 		Action:      cmdInstancesList,
 		Flags:       []cli.Flag{rackFlag},
 		Subcommands: []cli.Command{
 			{
 				Name:        "keyroll",
 				Description: "generate and replace the ec2 keypair used for SSH",
-				Usage:       "",
+				Usage:       "[options]",
+				ArgsUsage:   "",
 				Action:      cmdInstancesKeyroll,
 				Flags:       []cli.Flag{rackFlag},
 			},
 			{
 				Name:            "ssh",
 				Description:     "establish secure shell with EC2 instance",
-				Usage:           "<id> [command]",
+				Usage:           "<instance id> [command] [options]",
+				ArgsUsage:       "<intance id>",
 				Action:          cmdInstancesSSH,
 				Flags:           []cli.Flag{rackFlag},
 				SkipFlagParsing: true,
@@ -39,7 +42,8 @@ func init() {
 			{
 				Name:        "terminate",
 				Description: "terminate an EC2 instance",
-				Usage:       "<id>",
+				Usage:       "<instance id> [options]",
+				ArgsUsage:   "<instance id>",
 				Flags:       []cli.Flag{rackFlag},
 				Action:      cmdInstancesTerminate,
 			},
@@ -48,14 +52,8 @@ func init() {
 }
 
 func cmdInstancesList(c *cli.Context) error {
-	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox instances` does not take arguments. Perhaps you meant `convox instances ssh`?"))
-	}
-
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
 
 	instances, err := rackClient(c).GetInstances()
 	if err != nil {
@@ -82,6 +80,9 @@ func cmdInstancesList(c *cli.Context) error {
 }
 
 func cmdInstancesKeyroll(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	fmt.Print("Rolling SSH keys... ")
 
 	err := rackClient(c).InstanceKeyroll()
@@ -95,10 +96,8 @@ func cmdInstancesKeyroll(c *cli.Context) error {
 }
 
 func cmdInstancesTerminate(c *cli.Context) error {
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "terminate")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	id := c.Args()[0]
 
@@ -114,10 +113,8 @@ func cmdInstancesTerminate(c *cli.Context) error {
 }
 
 func cmdInstancesSSH(c *cli.Context) error {
-	if len(c.Args()) < 1 {
-		stdcli.Usage(c, "ssh")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, -1)
 
 	id := c.Args()[0]
 	cmd := strings.Join(c.Args()[1:], " ")

--- a/cmd/convox/main.go
+++ b/cmd/convox/main.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/convox/rack/client"
+	"github.com/convox/rack/cmd/convox/helpers"
 	"github.com/convox/rack/cmd/convox/stdcli"
 )
 
@@ -40,10 +41,31 @@ func init() {
 	})
 }
 
+/*
+	## Command syntax ##
+
+		Usage:
+			no more than one line
+
+		UsageText:
+			may be multiple lines, but isn't usually displayed
+
+		ArgsUsage:
+			no more than one line
+			denotes required arguments
+			used in output of stdcli.NeedArg as placeholder when argument is missing or unexpected
+
+		Description:
+			no more than one line
+			used in:
+				* 'convox <command> --help' under 'Usage:'
+				* output of 'convox -h' and 'convox h'
+*/
+
 func main() {
 	app := stdcli.New()
+	app.Flags = []cli.Flag{appFlag, rackFlag}
 	app.Version = Version
-	app.Usage = "command-line application management"
 
 	err := app.Run(os.Args)
 
@@ -88,16 +110,6 @@ func main() {
 	}
 }
 
-func coalesce(ss ...string) string {
-	for _, s := range ss {
-		if s != "" {
-			return s
-		}
-	}
-
-	return ""
-}
-
 func currentRack(c *cli.Context) string {
 	cr, err := ioutil.ReadFile(filepath.Join(ConfigRoot, "rack"))
 	if err != nil && !os.IsNotExist(err) {
@@ -106,7 +118,7 @@ func currentRack(c *cli.Context) string {
 
 	rackFlag := stdcli.RecoverFlag(c, "rack")
 
-	return coalesce(rackFlag, os.Getenv("CONVOX_RACK"), stdcli.ReadSetting("rack"), strings.TrimSpace(string(cr)))
+	return helpers.Coalesce(rackFlag, os.Getenv("CONVOX_RACK"), stdcli.ReadSetting("rack"), strings.TrimSpace(string(cr)))
 }
 
 func rackClient(c *cli.Context) *client.Client {

--- a/cmd/convox/main_test.go
+++ b/cmd/convox/main_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/convox/rack/client"
 	"github.com/convox/rack/test"
+	"github.com/stretchr/testify/assert"
 )
 
 var configlessEnv = map[string]string{
@@ -17,6 +18,8 @@ var configlessEnv = map[string]string{
 	"AWS_ACCESS_KEY_ID":     "",
 	"CONVOX_HOST":           "",
 }
+var DebuglessEnv = map[string]string{"CONVOX_DEBUG": ""}
+var DebugfulEnv = map[string]string{"CONVOX_DEBUG": "true"}
 
 func testServer(t *testing.T, stubs ...test.Http) *httptest.Server {
 	stubs = append(stubs, test.Http{Method: "GET", Path: "/system", Code: 200, Response: client.System{
@@ -42,4 +45,6 @@ func TestVersion(t *testing.T) {
 		Stdout:  "client: dev\n",
 		Stderr:  "ERROR: no host config found, try `convox login`\n",
 	})
+	v := Version
+	assert.Equal(t, v, "dev")
 }

--- a/cmd/convox/proxy.go
+++ b/cmd/convox/proxy.go
@@ -16,16 +16,15 @@ func init() {
 		Name:        "proxy",
 		Description: "proxy local ports into a rack",
 		Usage:       "<[port:]host:hostport> [[port:]host:hostport]...",
+		ArgsUsage:   "<[port:]host:hostport>",
 		Action:      cmdProxy,
 		Flags:       []cli.Flag{rackFlag},
 	})
 }
 
 func cmdProxy(c *cli.Context) error {
-	if len(c.Args()) == 0 {
-		stdcli.Usage(c, "proxy")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, -1)
 
 	for _, arg := range c.Args() {
 		parts := strings.SplitN(arg, ":", 3)

--- a/cmd/convox/ps.go
+++ b/cmd/convox/ps.go
@@ -14,8 +14,9 @@ func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "ps",
 		Description: "list an app's processes",
-		Usage:       "",
 		Action:      cmdPs,
+		Usage:       "[subcommand] [args] [options]",
+		ArgsUsage:   "[subcommand]",
 		Flags: []cli.Flag{
 			appFlag,
 			rackFlag,
@@ -28,14 +29,18 @@ func init() {
 			{
 				Name:        "info",
 				Description: "show info for a process",
-				Usage:       "<id>",
+				Usage:       "<process id> [options]",
+				UsageText:   "process id (from `convox ps`)",
+				ArgsUsage:   "<process id>",
 				Action:      cmdPsInfo,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
 				Name:        "stop",
-				Description: "stop a process",
-				Usage:       "<id>",
+				Description: "stop a process by its id",
+				Usage:       "<process id> [options]",
+				UsageText:   "process id (from `convox ps`)",
+				ArgsUsage:   "<process id>",
 				Action:      cmdPsStop,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
@@ -44,6 +49,9 @@ func init() {
 }
 
 func cmdPs(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
@@ -134,14 +142,12 @@ func displayProcessesStats(ps []client.Process, fm client.Formation, showApp boo
 }
 
 func cmdPsInfo(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "info")
-		return nil
 	}
 
 	id := c.Args()[0]
@@ -163,14 +169,12 @@ func cmdPsInfo(c *cli.Context) error {
 }
 
 func cmdPsStop(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "stop")
-		return nil
 	}
 
 	id := c.Args()[0]

--- a/cmd/convox/ps_test.go
+++ b/cmd/convox/ps_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/convox/rack/client"
+	"github.com/convox/rack/cmd/convox/stdcli"
+	"github.com/convox/rack/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPs(t *testing.T) {
+	tr := testServer(t,
+		test.Http{
+			Method: "GET",
+			Path:   "/apps/myapp/processes",
+			Code:   200,
+			Response: client.Processes{
+				client.Process{
+					Id:      "fooID",
+					App:     "fooApp",
+					Command: "fooCommand",
+					Host:    "fooHost",
+					Image:   "fooImage",
+					Name:    "fooName",
+					Ports:   []string{"fooPorts"},
+					Release: "fooRelease",
+					Cpu:     256,
+					Memory:  256,
+					Started: time.Date(1984, 05, 20, 0, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+	)
+
+	defer tr.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox ps --app myapp",
+			Exit:    0,
+			Stdout:  "ID     NAME     RELEASE     STARTED       COMMAND\nfooID  fooName  fooRelease  33 years ago  fooCommand\n",
+		},
+	)
+}
+
+/* HELP-USAGE CHECKS */
+
+var psUsageWithoutHelpFlag = `convox ps: list an app's processes
+
+Usage:
+  convox ps [subcommand] [args] [options]
+
+Subcommands: (convox ps <subcommand> --help)
+  info  show info for a process
+  stop  stop a process by its id
+
+Options:
+  --app value, -a value  app name inferred from current directory if not specified
+  --rack value           rack name
+  --stats                display process cpu/memory stats
+  `
+
+var psUsage = `convox ps: list an app's processes`
+
+var psInfoUsage = `convox ps info: show info for a process`
+
+var psStopUsage = `convox ps stop: stop a process by its id`
+
+var psMissingProcessID = `ERROR: 1 argument is required: <process id>`
+
+func TestPsHelpFlag(t *testing.T) {
+	tests := []test.ExecRun{
+		test.ExecRun{
+			Command:  "convox ps h",
+			OutMatch: psUsage,
+			Env:      DebuglessEnv,
+		},
+		test.ExecRun{
+			Command:  "convox ps help",
+			OutMatch: psUsage,
+			Env:      DebuglessEnv,
+		},
+		test.ExecRun{
+			Command:  "convox ps -h",
+			OutMatch: psUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps --help",
+			OutMatch: psUsage,
+		},
+		test.ExecRun{
+			Command:  "convox h ps",
+			OutMatch: psUsageWithoutHelpFlag,
+		},
+		test.ExecRun{
+			Command:  "convox help ps",
+			OutMatch: psUsageWithoutHelpFlag,
+		},
+
+		// ps stop
+		test.ExecRun{
+			Command:  "convox ps stop",
+			Exit:     129,
+			Stderr:   psMissingProcessID,
+			OutMatch: psStopUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps stop -h",
+			OutMatch: psStopUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps stop --help",
+			OutMatch: psStopUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps stop h",
+			OutMatch: psStopUsage,
+			Env:      DebuglessEnv,
+		},
+		test.ExecRun{
+			Command:  "convox ps stop help",
+			OutMatch: psStopUsage,
+			Env:      DebuglessEnv,
+		},
+		test.ExecRun{
+			Command:  "convox ps h stop",
+			OutMatch: psStopUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps help stop",
+			OutMatch: psStopUsage,
+			Env:      DebuglessEnv,
+		},
+
+		// ps info
+		test.ExecRun{
+			Command:  "convox ps info",
+			Exit:     129,
+			Stderr:   psMissingProcessID,
+			OutMatch: psInfoUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps info -h",
+			OutMatch: psInfoUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps info --help",
+			OutMatch: psInfoUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps -h info",
+			OutMatch: psUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps --help info",
+			OutMatch: psUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps h info",
+			OutMatch: psInfoUsage,
+		},
+		test.ExecRun{
+			Command:  "convox ps help info",
+			OutMatch: psInfoUsage,
+		},
+	}
+
+	assert.Equal(t, stdcli.HelpFlags, []string{"--help", "-h", "h", "help"})
+
+	ts := testServer(t,
+		test.Http{
+			Method:   "GET",
+			Path:     "/apps/myapp/processes",
+			Code:     200,
+			Response: "bar",
+			Headers:  map[string]string{"Rack": "myorg/staging"},
+		},
+	)
+	defer ts.Close()
+
+	for _, myTest := range tests {
+		test.Runs(t, myTest)
+	}
+
+}
+
+func TestPsInfoMissingArg(t *testing.T) {
+	ts := testServer(t,
+		test.Http{
+			Method:   "GET",
+			Path:     "/apps/myapp/processes",
+			Code:     200,
+			Response: "bar",
+			Headers:  map[string]string{"Rack": "myorg/staging"},
+		},
+	)
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command:  "convox ps info",
+			Env:      DebugfulEnv,
+			Exit:     129,
+			OutMatch: psInfoUsage,
+			Stderr:   psMissingProcessID,
+		},
+		test.ExecRun{
+			Command:  "convox ps info",
+			Env:      DebuglessEnv,
+			Exit:     129,
+			OutMatch: psInfoUsage,
+		},
+	)
+}

--- a/cmd/convox/ps_test.go
+++ b/cmd/convox/ps_test.go
@@ -47,20 +47,7 @@ func TestPs(t *testing.T) {
 
 /* HELP-USAGE CHECKS */
 
-var psUsageWithoutHelpFlag = `convox ps: list an app's processes
-
-Usage:
-  convox ps [subcommand] [args] [options]
-
-Subcommands: (convox ps <subcommand> --help)
-  info  show info for a process
-  stop  stop a process by its id
-
-Options:
-  --app value, -a value  app name inferred from current directory if not specified
-  --rack value           rack name
-  --stats                display process cpu/memory stats
-  `
+var psUsageWithoutHelpFlag = `convox ps: list an app's processes`
 
 var psUsage = `convox ps: list an app's processes`
 

--- a/cmd/convox/rack.go
+++ b/cmd/convox/rack.go
@@ -18,14 +18,16 @@ func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "rack",
 		Description: "manage your Convox rack",
-		Usage:       "",
+		Usage:       "[options]",
+		ArgsUsage:   "[subcommand]",
 		Action:      cmdRack,
 		Flags:       []cli.Flag{rackFlag},
 		Subcommands: []cli.Command{
 			{
 				Name:        "logs",
 				Description: "stream the rack logs",
-				Usage:       "",
+				Usage:       "[options]",
+				ArgsUsage:   "",
 				Action:      cmdRackLogs,
 				Flags: []cli.Flag{
 					rackFlag,
@@ -47,14 +49,16 @@ func init() {
 			{
 				Name:        "params",
 				Description: "list advanced rack parameters",
-				Usage:       "",
+				Usage:       "[options]",
+				ArgsUsage:   "[<subcommand>]",
 				Action:      cmdRackParams,
 				Flags:       []cli.Flag{rackFlag},
 				Subcommands: []cli.Command{
 					{
 						Name:        "set",
 						Description: "update advanced rack parameters",
-						Usage:       "NAME=VALUE [NAME=VALUE]",
+						Usage:       "NAME=VALUE [NAME=VALUE] ...",
+						ArgsUsage:   "NAME=VALUE",
 						Action:      cmdRackParamsSet,
 						Flags:       []cli.Flag{rackFlag},
 					},
@@ -63,7 +67,8 @@ func init() {
 			{
 				Name:        "ps",
 				Description: "list rack processes",
-				Usage:       "",
+				Usage:       "[options]",
+				ArgsUsage:   "",
 				Action:      cmdRackPs,
 				Flags: []cli.Flag{
 					rackFlag,
@@ -80,7 +85,8 @@ func init() {
 			{
 				Name:        "scale",
 				Description: "scale the rack capacity",
-				Usage:       "",
+				Usage:       "[options]",
+				ArgsUsage:   "",
 				Action:      cmdRackScale,
 				Flags: []cli.Flag{
 					rackFlag,
@@ -97,7 +103,8 @@ func init() {
 			{
 				Name:        "update",
 				Description: "update rack to the given version",
-				Usage:       "[version]",
+				Usage:       "[version] [options]",
+				ArgsUsage:   "[version]",
 				Action:      cmdRackUpdate,
 				Flags: []cli.Flag{
 					rackFlag,
@@ -112,6 +119,7 @@ func init() {
 				Name:        "releases",
 				Description: "list a Rack's version history",
 				Usage:       "",
+				ArgsUsage:   "",
 				Action:      cmdRackReleases,
 				Flags: []cli.Flag{
 					rackFlag,
@@ -126,14 +134,8 @@ func init() {
 }
 
 func cmdRack(c *cli.Context) error {
-	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox rack` does not take arguments. Perhaps you meant `convox rack update`?"))
-	}
-
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
 
 	system, err := rackClient(c).GetSystem()
 	if err != nil {
@@ -150,6 +152,9 @@ func cmdRack(c *cli.Context) error {
 }
 
 func cmdRackLogs(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	err := rackClient(c).StreamRackLogs(c.String("filter"), c.BoolT("follow"), c.Duration("since"), os.Stdout)
 	if err != nil {
 		return stdcli.Error(err)
@@ -159,6 +164,9 @@ func cmdRackLogs(c *cli.Context) error {
 }
 
 func cmdRackParams(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	system, err := rackClient(c).GetSystem()
 	if err != nil {
 		return stdcli.Error(err)
@@ -188,6 +196,9 @@ func cmdRackParams(c *cli.Context) error {
 }
 
 func cmdRackParamsSet(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, -1)
+
 	system, err := rackClient(c).GetSystem()
 	if err != nil {
 		return stdcli.Error(err)
@@ -220,6 +231,9 @@ func cmdRackParamsSet(c *cli.Context) error {
 }
 
 func cmdRackPs(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	system, err := rackClient(c).GetSystem()
 	if err != nil {
 		return stdcli.Error(err)
@@ -248,6 +262,8 @@ func cmdRackPs(c *cli.Context) error {
 }
 
 func cmdRackUpdate(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+
 	// Retrieve list of all versions
 	vs, err := version.All()
 	if err != nil {
@@ -262,6 +278,7 @@ func cmdRackUpdate(c *cli.Context) error {
 
 	// if user has provided a version number as an argument, use that instead
 	if len(c.Args()) > 0 {
+		stdcli.NeedArg(c, 1) // accept no more than one argument
 		t, err := vs.Find(c.Args()[0])
 		if err != nil {
 			return stdcli.Error(err)
@@ -318,6 +335,9 @@ func cmdRackUpdate(c *cli.Context) error {
 }
 
 func cmdRackScale(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	// initialize to invalid values that indicate no change
 	count := -1
 	typ := ""
@@ -330,16 +350,8 @@ func cmdRackScale(c *cli.Context) error {
 		typ = c.String("type")
 	}
 
-	// validate no argument
-	switch len(c.Args()) {
-	case 0:
-		if count == -1 && typ == "" {
-			displaySystem(c)
-			return nil
-		}
-		// fall through to scale API call
-	default:
-		stdcli.Usage(c, "scale")
+	if count == -1 && typ == "" {
+		displaySystem(c)
 		return nil
 	}
 
@@ -353,6 +365,9 @@ func cmdRackScale(c *cli.Context) error {
 }
 
 func cmdRackReleases(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	system, err := rackClient(c).GetSystem()
 	if err != nil {
 		return stdcli.Error(err)

--- a/cmd/convox/registries.go
+++ b/cmd/convox/registries.go
@@ -12,34 +12,41 @@ func init() {
 		Name:        "registries",
 		Action:      cmdRegistryList,
 		Description: "manage private registries",
+		UsageText:   "(add|remove)",
+		Usage:       "(add|remove) <registry> [--username USERNAME] [--password PASSWORD]",
+		ArgsUsage:   "<subcommand>",
 		Flags:       []cli.Flag{rackFlag},
 		Subcommands: []cli.Command{
 			{
 				Name:        "add",
 				Description: "add a new registry",
-				Usage:       "[server]",
+				Usage:       "<server> [--username USERNAME] [--password PASSWORD]",
+				ArgsUsage:   "<server>",
+				UsageText:   "<server> [--username USERNAME] [--password PASSWORD]",
 				Action:      cmdRegistryAdd,
 				Flags: []cli.Flag{
 					rackFlag,
 					cli.StringFlag{
 						Name:  "email, e",
-						Usage: "Email for registry auth.",
+						Usage: "email for registry auth",
 					},
 					cli.StringFlag{
 						Name:  "username, u",
-						Usage: "Username for auth. If not specified, prompt for username.",
+						Usage: "username for auth. If not specified, prompt for username.",
 					},
 					cli.StringFlag{
 						EnvVar: "PASSWORD",
 						Name:   "password, p",
-						Usage:  "Password for auth. If not specified, prompt for password.",
+						Usage:  "password for auth. If not specified, prompt for password.",
 					},
 				},
 			},
 			{
 				Name:        "remove",
 				Description: "remove a registry",
-				Usage:       "[server]",
+				Usage:       "<server>",
+				ArgsUsage:   "<server>",
+				UsageText:   "<server> (see `convox registries`)",
 				Action:      cmdRegistryRemove,
 				Flags:       []cli.Flag{rackFlag},
 			},
@@ -48,10 +55,8 @@ func init() {
 }
 
 func cmdRegistryAdd(c *cli.Context) error {
-	if len(c.Args()) < 1 {
-		stdcli.Usage(c, "add")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	server := c.Args()[0]
 	username := c.String("username")
@@ -76,14 +81,8 @@ func cmdRegistryAdd(c *cli.Context) error {
 }
 
 func cmdRegistryList(c *cli.Context) error {
-	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox registries` does not take arguments. Perhaps you meant `convox registries add`?"))
-	}
-
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
 
 	registries, err := rackClient(c).ListRegistries()
 	if err != nil {
@@ -101,10 +100,8 @@ func cmdRegistryList(c *cli.Context) error {
 }
 
 func cmdRegistryRemove(c *cli.Context) error {
-	if len(c.Args()) < 1 {
-		stdcli.Usage(c, "remove")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	server := c.Args()[0]
 

--- a/cmd/convox/releases.go
+++ b/cmd/convox/releases.go
@@ -15,14 +15,15 @@ func init() {
 	stdcli.RegisterCommand(cli.Command{
 		Name:        "releases",
 		Description: "list an app's releases",
-		Usage:       "",
+		Usage:       "[subcommand] [options]",
+		ArgsUsage:   "[subcommand]",
 		Action:      cmdReleases,
 		Flags: []cli.Flag{
 			appFlag,
 			rackFlag,
 			cli.IntFlag{
 				Name:  "limit",
-				Usage: "Number of releases to list.",
+				Usage: "number of releases to list",
 				Value: 20,
 			},
 		},
@@ -37,7 +38,8 @@ func init() {
 			{
 				Name:        "promote",
 				Description: "promote a release",
-				Usage:       "<release id>",
+				Usage:       "<release id> [options]",
+				ArgsUsage:   "<release id>",
 				Action:      cmdReleasePromote,
 				Flags: []cli.Flag{
 					appFlag,
@@ -54,18 +56,12 @@ func init() {
 }
 
 func cmdReleases(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox releases` does not take arguments. Perhaps you meant `convox releases help`?"))
-	}
-
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
 	}
 
 	a, err := rackClient(c).GetApp(app)
@@ -100,10 +96,8 @@ func cmdReleases(c *cli.Context) error {
 }
 
 func cmdReleaseInfo(c *cli.Context) error {
-	if len(c.Args()) < 1 {
-		stdcli.Usage(c, "release info")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	release := c.Args()[0]
 
@@ -127,10 +121,8 @@ func cmdReleaseInfo(c *cli.Context) error {
 }
 
 func cmdReleasePromote(c *cli.Context) error {
-	if len(c.Args()) < 1 {
-		stdcli.Usage(c, "releases promote")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	release := c.Args()[0]
 

--- a/cmd/convox/scale.go
+++ b/cmd/convox/scale.go
@@ -62,7 +62,7 @@ func cmdScale(c *cli.Context) error {
 	switch len(c.Args()) {
 	case 0:
 		if opts.Memory != "" || opts.CPU != "" || opts.Count != "" {
-			return stdcli.Error(fmt.Errorf("missing process name"))
+			return stdcli.Errorf("missing process name")
 		}
 
 		return displayFormation(c, app)
@@ -72,7 +72,7 @@ func cmdScale(c *cli.Context) error {
 		}
 		// fall through to scale API call
 	default:
-		stdcli.Usage(c, "scale")
+		stdcli.Usage(c)
 		return nil
 	}
 

--- a/cmd/convox/scale_test.go
+++ b/cmd/convox/scale_test.go
@@ -39,10 +39,9 @@ func TestScaleCmd(t *testing.T) {
 			Stderr:  "ERROR: no host config found, try `convox login`\n",
 		},
 		test.ExecRun{
-			Command:  "convox scale --foo",
-			OutMatch: "Incorrect Usage: flag provided but not defined: -foo\n\n" + scaleUsage,
-			Stderr:   "ERROR: flag provided but not defined: -foo\n",
-			Exit:     1,
+			Command:  "convox scale foo bar",
+			OutMatch: scaleUsage,
+			Exit:     129,
 		},
 		test.ExecRun{
 			Command:  "convox scale --foo",

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -18,52 +18,53 @@ type ResourceType struct {
 	name, args string
 }
 
+var resourceTypes = []ResourceType{
+	{
+		"fluentd",
+		"--url=tcp://fluentd-collector.example.com:24224",
+	},
+	{
+		"memcached",
+		"[--instance-type=db.t2.micro] [--num-cache-nodes=1] [--private]",
+	},
+	{
+		"mysql",
+		"[--allocated-storage=10] [--database=db-name] [--instance-type=db.t2.micro] [--multi-az] [--password=example] [--private] [--username=example]",
+	},
+	{
+		"postgres",
+		"[--allocated-storage=10] [--database=db-name] [--instance-type=db.t2.micro] [--max-connections={DBInstanceClassMemory/15000000}] [--multi-az] [--password=example] [--private] [--username=example] [--version=9.5.2]",
+	},
+	{
+		"redis",
+		"[--automatic-failover-enabled] [--database=db-name] [--instance-type=cache.t2.micro] [--num-cache-clusters=1] [--private]",
+	},
+	{
+		"s3",
+		"[--topic=sns-topic-name] [--versioning]",
+	},
+	{
+		"sns",
+		"[--queue=sqs-queue-name]",
+	},
+	{
+		"sqs",
+		"[--message-retention-period=345600] [--receive-message-wait-time=0] [--visibility-timeout=30]",
+	},
+	{
+		"syslog",
+		"--url=tcp+tls://logs1.papertrailapp.com:11235 [--private]",
+	},
+	{
+		"webhook",
+		"--url=https://console.convox.com/webhooks/1234",
+	},
+}
+
 func init() {
-	types := []ResourceType{
-		{
-			"memcached",
-			"[--instance-type=db.t2.micro] [--num-cache-nodes=1] [--private]",
-		},
-		{
-			"mysql",
-			"[--allocated-storage=10] [--database=db-name] [--instance-type=db.t2.micro] [--multi-az] [--password=example] [--private] [--username=example]",
-		},
-		{
-			"postgres",
-			"[--allocated-storage=10] [--database=db-name] [--instance-type=db.t2.micro] [--max-connections={DBInstanceClassMemory/15000000}] [--multi-az] [--password=example] [--private] [--username=example] [--version=9.5.2]",
-		},
-		{
-			"redis",
-			"[--automatic-failover-enabled] [--database=db-name] [--instance-type=cache.t2.micro] [--num-cache-clusters=1] [--private]",
-		},
-		{
-			"s3",
-			"[--topic=sns-topic-name] [--versioning]",
-		},
-		{
-			"sns",
-			"[--queue=sqs-queue-name]",
-		},
-		{
-			"sqs",
-			"[--message-retention-period=345600] [--receive-message-wait-time=0] [--visibility-timeout=30]",
-		},
-		{
-			"syslog",
-			"--url=tcp+tls://logs1.papertrailapp.com:11235 [--private]",
-		},
-		{
-			"fluentd",
-			"--url=tcp://fluentd-collector.example.com:24224",
-		},
-		{
-			"webhook",
-			"--url=https://console.convox.com/webhooks/1234",
-		},
-	}
 
 	usage := "Supported types / options:"
-	for _, t := range types {
+	for _, t := range resourceTypes {
 		usage += fmt.Sprintf("\n  %-10s  %s", t.name, t.args)
 	}
 
@@ -71,14 +72,16 @@ func init() {
 		Name:        "resources",
 		Aliases:     []string{"services"},
 		Description: "manage external resources [prev. services]",
-		Usage:       "",
+		Usage:       "<command> [subcommand] [options] [arguments]",
+		ArgsUsage:   "<command>",
 		Action:      cmdResources,
 		Flags:       []cli.Flag{rackFlag},
 		Subcommands: []cli.Command{
 			{
 				Name:            "create",
 				Description:     "create a new resource",
-				Usage:           "<type> [--name=value] [--option-name=value]\n\n" + usage,
+				Usage:           "<type> [--name=value] [--option-name=value] [options]\n\n" + usage,
+				ArgsUsage:       "<type>",
 				Action:          cmdResourceCreate,
 				Flags:           []cli.Flag{rackFlag},
 				SkipFlagParsing: true,
@@ -86,14 +89,17 @@ func init() {
 			{
 				Name:        "delete",
 				Description: "delete a resource",
-				Usage:       "<name>",
+				Usage:       "<name> [options]",
+				ArgsUsage:   "<name>",
 				Action:      cmdResourceDelete,
 				Flags:       []cli.Flag{rackFlag},
 			},
 			{
 				Name:            "update",
-				Description:     "update a resource\n\nWARNING: updates may cause resource downtime.",
+				Description:     "update a resource (may cause resource downtime)",
+				UsageText:       "update a resource\n\nWARNING: updates may cause resource downtime.",
 				Usage:           "<name> --option-name=value [--option-name=value]\n\n" + usage,
+				ArgsUsage:       "<name>",
 				Action:          cmdResourceUpdate,
 				Flags:           []cli.Flag{rackFlag},
 				SkipFlagParsing: true,
@@ -101,28 +107,32 @@ func init() {
 			{
 				Name:        "info",
 				Description: "info about a resource",
-				Usage:       "<name>",
+				Usage:       "<name> [options]",
+				ArgsUsage:   "<name>",
 				Action:      cmdResourceInfo,
 				Flags:       []cli.Flag{rackFlag},
 			},
 			{
 				Name:        "link",
 				Description: "create a link between a resource and an app",
-				Usage:       "<name>",
+				Usage:       "<name> [options]",
+				ArgsUsage:   "<name>",
 				Action:      cmdLinkCreate,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
 				Name:        "unlink",
 				Description: "delete a link between a resource and an app",
-				Usage:       "<name>",
+				Usage:       "<name> [options]",
+				ArgsUsage:   "<name>",
 				Action:      cmdLinkDelete,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
 			{
 				Name:        "url",
 				Description: "return url for the given resource",
-				Usage:       "<name>",
+				Usage:       "<name> [options]",
+				ArgsUsage:   "<name>",
 				Action:      cmdResourceURL,
 				Flags:       []cli.Flag{appFlag, rackFlag},
 			},
@@ -145,14 +155,8 @@ func init() {
 }
 
 func cmdResources(c *cli.Context) error {
-	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox resources` does not take arguments. Perhaps you meant `convox resources create`?"))
-	}
-
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
 
 	resources, err := rackClient(c).GetResources()
 	if err != nil {
@@ -169,32 +173,28 @@ func cmdResources(c *cli.Context) error {
 	return nil
 }
 
-func cmdResourceCreate(c *cli.Context) error {
-	// ensure type included
-	if !(len(c.Args()) > 0) {
-		stdcli.Usage(c, "create")
-		return nil
-	}
-
-	// ensure everything after type is a flag
-	if len(c.Args()) > 1 && !strings.HasPrefix(c.Args()[1], "--") {
-		stdcli.Usage(c, "create")
-		return nil
-	}
-
-	t := c.Args()[0]
-
-	if t == "help" || t == "--help" || t == "-h" {
-		stdcli.Usage(c, "create")
-		return nil
-	}
-
-	options := stdcli.ParseOpts(c.Args()[1:])
-	for key, value := range options {
-		if value == "" {
-			options[key] = "true"
+func checkResourceType(t string) (string, error) {
+	for _, resourceType := range resourceTypes {
+		if resourceType.name == t {
+			return t, nil
 		}
 	}
+	return "", stdcli.Errorf("unsupported resource type %s; see 'convox resources create --help'", t)
+}
+
+func cmdResourceCreate(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, -1)
+
+	t, err := checkResourceType(c.Args()[0])
+	if err != nil {
+		return stdcli.Error(err)
+	}
+	args := c.Args()[1:]
+
+	// ensure everything after type is a flag
+	stdcli.EnsureOnlyFlags(c, args)
+	options := stdcli.FlagsToOptions(c, args)
 
 	var optionsList []string
 	for key, val := range options {
@@ -222,7 +222,7 @@ func cmdResourceCreate(c *cli.Context) error {
 	}
 	fmt.Printf(")... ")
 
-	_, err := rackClient(c).CreateResource(t, options)
+	_, err = rackClient(c).CreateResource(t, options)
 	if err != nil {
 		return stdcli.Error(err)
 	}
@@ -232,26 +232,15 @@ func cmdResourceCreate(c *cli.Context) error {
 }
 
 func cmdResourceUpdate(c *cli.Context) error {
-	// ensure name included
-	if !(len(c.Args()) > 0) {
-		stdcli.Usage(c, "update")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, -1)
 
 	name := c.Args()[0]
+	args := c.Args()[1:]
 
-	// ensure everything after type is a flag
-	if len(c.Args()) > 1 && !strings.HasPrefix(c.Args()[1], "--") {
-		stdcli.Usage(c, "update")
-		return nil
-	}
+	stdcli.EnsureOnlyFlags(c, args)
 
-	options := stdcli.ParseOpts(c.Args()[1:])
-	for key, value := range options {
-		if value == "" {
-			options[key] = "true"
-		}
-	}
+	options := stdcli.FlagsToOptions(c, args)
 
 	var optionsList []string
 	for key, val := range options {
@@ -259,7 +248,7 @@ func cmdResourceUpdate(c *cli.Context) error {
 	}
 
 	if len(optionsList) == 0 {
-		stdcli.Usage(c, "update")
+		stdcli.Usage(c)
 		return nil
 	}
 
@@ -275,10 +264,8 @@ func cmdResourceUpdate(c *cli.Context) error {
 }
 
 func cmdResourceDelete(c *cli.Context) error {
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "delete")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	name := c.Args()[0]
 
@@ -294,10 +281,8 @@ func cmdResourceDelete(c *cli.Context) error {
 }
 
 func cmdResourceInfo(c *cli.Context) error {
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "info")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	name := c.Args()[0]
 
@@ -328,10 +313,8 @@ func cmdResourceInfo(c *cli.Context) error {
 }
 
 func cmdResourceURL(c *cli.Context) error {
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "url")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	name := c.Args()[0]
 
@@ -354,14 +337,12 @@ func cmdResourceURL(c *cli.Context) error {
 }
 
 func cmdLinkCreate(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "link")
-		return nil
 	}
 
 	name := c.Args()[0]
@@ -376,14 +357,12 @@ func cmdLinkCreate(c *cli.Context) error {
 }
 
 func cmdLinkDelete(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "unlink")
-		return nil
 	}
 
 	name := c.Args()[0]
@@ -398,10 +377,8 @@ func cmdLinkDelete(c *cli.Context) error {
 }
 
 func cmdResourceProxy(c *cli.Context) error {
-	if len(c.Args()) != 1 {
-		stdcli.Usage(c, "proxy")
-		return nil
-	}
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 1)
 
 	name := c.Args()[0]
 

--- a/cmd/convox/ssl.go
+++ b/cmd/convox/ssl.go
@@ -22,7 +22,8 @@ func init() {
 			{
 				Name:        "update",
 				Description: "update the certificate associated with an endpoint",
-				Usage:       "<process:port> <certificate-id>",
+				Usage:       "<process:port> <certificate-id> [options]",
+				ArgsUsage:   "<process:port> <certificate-id>",
 				Action:      cmdSSLUpdate,
 				Flags: []cli.Flag{
 					appFlag,
@@ -34,18 +35,12 @@ func init() {
 }
 
 func cmdSSLList(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, 0)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox ssl` does not take arguments. Perhaps you meant `convox ssl update`?"))
-	}
-
-	if c.Bool("help") {
-		stdcli.Usage(c, "")
-		return nil
 	}
 
 	ssls, err := rackClient(c).ListSSL(app)
@@ -64,14 +59,12 @@ func cmdSSLList(c *cli.Context) error {
 }
 
 func cmdSSLUpdate(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+	stdcli.NeedArg(c, -2)
+
 	_, app, err := stdcli.DirApp(c, ".")
 	if err != nil {
 		return stdcli.Error(err)
-	}
-
-	if len(c.Args()) < 2 {
-		stdcli.Usage(c, "update")
-		return nil
 	}
 
 	target := c.Args()[0]

--- a/cmd/convox/stdcli/stdcli_test.go
+++ b/cmd/convox/stdcli/stdcli_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/convox/rack/cmd/convox/stdcli"
 	"github.com/convox/rack/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
 )
 
 func TestParseOptions(t *testing.T) {
@@ -59,4 +60,39 @@ func TestCheckEnvVars(t *testing.T) {
 			Stderr:  "ERROR: 'foo' is not a valid value for environment variable CONVOX_WAIT (expected: [true false 1 0 ])\n",
 		},
 	)
+}
+
+func TestDebug(t *testing.T) {
+	oldDebug := os.Getenv("CONVOX_DEBUG")
+
+	os.Setenv("CONVOX_DEBUG", "")
+	d := stdcli.Debug()
+	assert.Equal(t, d, false)
+
+	os.Setenv("CONVOX_DEBUG", "true")
+	d = stdcli.Debug()
+	assert.Equal(t, d, true)
+
+	os.Setenv("CONVOX_DEBUG", oldDebug)
+}
+
+func TestStdcliApp(t *testing.T) {
+	app := stdcli.New()
+	assert.Equal(t, "<command>", app.ArgsUsage)
+	assert.Equal(t, "<command> [subcommand] [options...] [args...]", app.Usage)
+	assert.Equal(t, "command-line application management", app.Description)
+	assert.Equal(t, cli.BoolFlag{
+		Name:   "help, h",
+		Usage:  "show help",
+		EnvVar: "",
+		Hidden: false,
+	}, cli.HelpFlag)
+	args := []string{"convox foo"}
+	err := app.Run(args)
+	assert.NoError(t, err)
+
+	stdcli.Spinner.Prefix = "Testing..."
+	stdcli.Spinner.Start()
+	stdcli.Spinner.Stop()
+	assert.Equal(t, stdcli.Spinner.Prefix, "Testing...")
 }

--- a/cmd/convox/stdcli/stdcli_test.go
+++ b/cmd/convox/stdcli/stdcli_test.go
@@ -29,22 +29,6 @@ func TestParseOptions(t *testing.T) {
 	assert.Equal(t, true, ok)
 }
 
-func TestDebug(t *testing.T) {
-	orig := os.Getenv("CONVOX_DEBUG")
-
-	os.Setenv("CONVOX_DEBUG", "")
-	assert.Equal(t, stdcli.Debug(), false)
-
-	os.Setenv("CONVOX_DEBUG", "mraaaa")
-	assert.Equal(t, stdcli.Debug(), true)
-
-	os.Setenv("CONVOX_DEBUG", "true")
-	assert.Equal(t, stdcli.Debug(), true)
-
-	// restore original CONVOX_DEBUG value
-	os.Setenv("CONVOX_DEBUG", orig)
-}
-
 // TestCheckEnvVars ensures stdcli.CheckEnv() prints a warning if bool envvars aren't true/false/1/0
 func TestCheckEnvVars(t *testing.T) {
 	os.Setenv("RACK_PRIVATE", "foo")
@@ -62,7 +46,23 @@ func TestCheckEnvVars(t *testing.T) {
 	)
 }
 
-func TestDebug(t *testing.T) {
+func TestDebugEnv(t *testing.T) {
+	orig := os.Getenv("CONVOX_DEBUG")
+
+	os.Setenv("CONVOX_DEBUG", "")
+	assert.Equal(t, stdcli.Debug(), false)
+
+	os.Setenv("CONVOX_DEBUG", "mraaaa")
+	assert.Equal(t, stdcli.Debug(), true)
+
+	os.Setenv("CONVOX_DEBUG", "true")
+	assert.Equal(t, stdcli.Debug(), true)
+
+	// restore original CONVOX_DEBUG value
+	os.Setenv("CONVOX_DEBUG", orig)
+}
+
+func TestDebugStdcli(t *testing.T) {
 	oldDebug := os.Getenv("CONVOX_DEBUG")
 
 	os.Setenv("CONVOX_DEBUG", "")

--- a/cmd/convox/switch.go
+++ b/cmd/convox/switch.go
@@ -17,6 +17,7 @@ func init() {
 		Name:        "switch",
 		Description: "switch to another Convox rack",
 		Usage:       "[rack name]",
+		ArgsUsage:   "[rack name]",
 		Action:      cmdSwitch,
 	})
 }

--- a/cmd/convox/uninstall.go
+++ b/cmd/convox/uninstall.go
@@ -51,6 +51,8 @@ func init() {
 }
 
 func cmdUninstall(c *cli.Context) error {
+	stdcli.NeedHelp(c)
+
 	ep := stdcli.QOSEventProperties{Start: time.Now()}
 
 	distinctId, err := currentId()
@@ -59,7 +61,7 @@ func cmdUninstall(c *cli.Context) error {
 	}
 
 	if len(c.Args()) != 2 && len(c.Args()) != 3 {
-		stdcli.Usage(c, "uninstall")
+		stdcli.Usage(c)
 		return nil
 	}
 

--- a/test/exec.go
+++ b/test/exec.go
@@ -13,15 +13,16 @@ import (
 )
 
 type ExecRun struct {
-	Command  string
-	Env      map[string]string
-	Exit     int
-	Dir      string
-	Stdin    string
-	Stdout   string
-	OutMatch string
-	Stderr   string
-	Dump     bool
+	Command    string
+	Env        map[string]string
+	Exit       int
+	Dir        string
+	Stdin      string
+	Stdout     string
+	OutMatch   string
+	OutMatches []string
+	Stderr     string
+	Dump       bool
 }
 
 func (er ExecRun) Test(t *testing.T) {


### PR DESCRIPTION
Before:

```
$ convox ps -h
ERROR: no such app: rack
```

After:

```
$ convox ps -h
convox ps: list an app's processes

Usage:
  convox ps <command> [args...]

Subcommands: (convox ps help <subcommand>)
  info		show info for a process (note: you can obtain the process id via 'convox ps')
  stop		stop a process by its id
  help, h	
  
Options:
  --app value, -a value	app name inferred from current directory if not specified
  --rack value		rack name
  --stats		display process cpu/memory stats
  --help, -h		show help
```

Currently, treatment of `-h` and `--help` is very inconsistent. It's not as simple as adding a global --rack flag (as in [this PR](https://github.com/convox/rack/pull/1684/files#diff-641894c246f9a42ae17552d302cdb082)) because the golang flag library panics if `-h` gets redefined.

This PR attempts to unify handling of the help flag as well as the  number of required arguments by adding two methods to `stdcli`: `NeedHelp` and `NeedArg`.

Addresses:

- #2018
- #1860