### PR TITLE
Allow for shorter app names

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -101,7 +101,7 @@ func getAppByStackName(stackName string) (*App, error) {
 	return app, nil
 }
 
-var regexValidAppName = regexp.MustCompile(`\A[a-zA-Z][-a-zA-Z0-9]{2,29}\z`)
+var regexValidAppName = regexp.MustCompile(`\A[a-zA-Z][-a-zA-Z0-9]{0,127}\z`)
 
 func (a *App) IsBound() bool {
 	if a.Tags == nil {

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -101,7 +101,7 @@ func getAppByStackName(stackName string) (*App, error) {
 	return app, nil
 }
 
-var regexValidAppName = regexp.MustCompile(`\A[a-zA-Z][-a-zA-Z0-9]{3,29}\z`)
+var regexValidAppName = regexp.MustCompile(`\A[a-zA-Z][-a-zA-Z0-9]{2,29}\z`)
 
 func (a *App) IsBound() bool {
 	if a.Tags == nil {


### PR DESCRIPTION
Turns out the rule for docker tags to be between 4-30 characters was not maintained for very long on docker. The rules have now changed to be 1-128 characters. See: https://github.com/docker/docker/pull/8447

I'm not sure how to add tests for this so some guidance on that would be great.