### PR TITLE
Respect --app flag regardless of position

### DIFF
--- a/cmd/convox/main.go
+++ b/cmd/convox/main.go
@@ -98,28 +98,13 @@ func coalesce(ss ...string) string {
 	return ""
 }
 
-// urfave/cli has a habit of discarding flags when they're between a command and a subcommand.
-// if --rack is missing from c.String(), recover it here by checking os.Args
-func getRackFlag(c *cli.Context) string {
-	rackFlag := c.String("rack")
-	if rackFlag != "" {
-		return rackFlag
-	}
-
-	// set rackFlag to everything after --rack
-	rackFlag = stdcli.ParseOpts(os.Args)["rack"]
-
-	// stdcli.ParseOpts() includes everything after --rack, so discard everything after the first space
-	return strings.Split(rackFlag, " ")[0]
-}
-
 func currentRack(c *cli.Context) string {
 	cr, err := ioutil.ReadFile(filepath.Join(ConfigRoot, "rack"))
 	if err != nil && !os.IsNotExist(err) {
 		stdcli.Error(err)
 	}
 
-	rackFlag := getRackFlag(c)
+	rackFlag := stdcli.RecoverFlag(c, []string{"rack"})
 
 	return coalesce(rackFlag, os.Getenv("CONVOX_RACK"), stdcli.ReadSetting("rack"), strings.TrimSpace(string(cr)))
 }

--- a/cmd/convox/main.go
+++ b/cmd/convox/main.go
@@ -104,7 +104,7 @@ func currentRack(c *cli.Context) string {
 		stdcli.Error(err)
 	}
 
-	rackFlag := stdcli.RecoverFlag(c, []string{"rack"})
+	rackFlag := stdcli.RecoverFlag(c, "rack")
 
 	return coalesce(rackFlag, os.Getenv("CONVOX_RACK"), stdcli.ReadSetting("rack"), strings.TrimSpace(string(cr)))
 }

--- a/cmd/convox/releases_test.go
+++ b/cmd/convox/releases_test.go
@@ -23,3 +23,34 @@ func TestPromotePreventAgainstCreating(t *testing.T) {
 		},
 	)
 }
+
+func TestReleasesCmd(t *testing.T) {
+	ts := testServer(t,
+		test.Http{Method: "GET", Path: "/apps/foo", Code: 200, Response: client.App{Name: "foo", Status: "running"}},
+		test.Http{Method: "GET", Path: "/apps/foo/releases", Code: 200, Response: client.Releases{client.Release{}}},
+	)
+	defer ts.Close()
+
+	tests := []test.ExecRun{
+		test.ExecRun{
+			Command: "convox releases --app foo",
+			Stdout:  "ID  CREATED  BUILD  STATUS\n                    active\n",
+		},
+		test.ExecRun{
+			Command: "convox releases -a foo",
+			Stdout:  "ID  CREATED  BUILD  STATUS\n                    active\n",
+		},
+		test.ExecRun{
+			Command: "convox --app foo releases",
+			Stdout:  "ID  CREATED  BUILD  STATUS\n                    active\n",
+		},
+		test.ExecRun{
+			Command: "convox -a foo releases",
+			Stdout:  "ID  CREATED  BUILD  STATUS\n                    active\n",
+		},
+	}
+
+	for _, myTest := range tests {
+		test.Runs(t, myTest)
+	}
+}

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -116,7 +116,7 @@ func Debug() bool {
 }
 
 // RecoverFlag allows us to capture things like --app FOO which would otherwise be discarded by urfave/cli if passed in position 0
-func RecoverFlag(c *cli.Context, flagNames []string) string {
+func RecoverFlag(c *cli.Context, flagNames ...string) string {
 	for _, flagName := range flagNames {
 		f := c.String(flagName)
 		if f != "" {
@@ -141,7 +141,7 @@ func DirApp(c *cli.Context, wd string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	app := RecoverFlag(c, []string{"a", "app"})
+	app := RecoverFlag(c, "a", "app")
 
 	if app == "" {
 		app = ReadSetting("app")


### PR DESCRIPTION
Before (convox drops `-a`, `--app` flag if passed in position 0):

```
$ convox -a foo releases
ERROR: no such app: rack
```

After:

```
$ convox -a foo releases
ERROR: no such app: foo
```

We were already doing this with the `--rack` flag via `getRackFlag()`. I replaced this with a more generic function `RecoverFlag` which takes a list instead of a string (because we need to check for both `-a` and `--app`).
**Important:** I also modified `stdcli.ParseOpts`: it previously only handled double-dash prefix, now it treats an item with only a single dash prefix as a flag. I don't _think_ this will cause issues, but maybe you know something I don't.