### PR TITLE
Return error if CONVOX_DEBUG, CONVOX_WAIT or RACK_PRIVATE aren't set to valid boolean values

### DIFF
--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -348,7 +348,7 @@ func CheckEnv() error {
 		if !ok {
 			msg := fmt.Sprintf("'%s' is not a valid value for environment variable %s ", os.Getenv(varName), varName)
 			msg += fmt.Sprintf("(expected: %s)", okVals)
-			Warn(msg)
+			return Errorf(msg)
 		}
 	}
 	return nil

--- a/cmd/convox/stdcli/stdcli_test.go
+++ b/cmd/convox/stdcli/stdcli_test.go
@@ -32,16 +32,15 @@ func TestParseOptions(t *testing.T) {
 func TestCheckEnvVars(t *testing.T) {
 	os.Setenv("RACK_PRIVATE", "foo")
 
-	// Ensure invalid env vars only print a warning and don't raise an error
 	err := stdcli.CheckEnv()
-	assert.NoError(t, err)
+	assert.Error(t, err)
 
 	test.Runs(t,
 		test.ExecRun{
-			Command:  "convox",
-			Env:      map[string]string{"CONVOX_WAIT": "foo"},
-			Exit:     0,
-			OutMatch: "WARNING: 'foo' is not a valid value for environment variable CONVOX_WAIT (expected: [true false 1 0 ])\n",
+			Command: "convox",
+			Env:     map[string]string{"CONVOX_WAIT": "foo"},
+			Exit:    1,
+			Stderr:  "ERROR: 'foo' is not a valid value for environment variable CONVOX_WAIT (expected: [true false 1 0 ])\n",
 		},
 	)
 }

--- a/cmd/convox/stdcli/stdcli_test.go
+++ b/cmd/convox/stdcli/stdcli_test.go
@@ -1,9 +1,11 @@
 package stdcli_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/convox/rack/cmd/convox/stdcli"
+	"github.com/convox/rack/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,4 +26,22 @@ func TestParseOptions(t *testing.T) {
 	assert.Equal(t, "even worse", opts["is"])
 	_, ok := opts["this"]
 	assert.Equal(t, true, ok)
+}
+
+// TestCheckEnvVars ensures stdcli.CheckEnv() prints a warning if bool envvars aren't true/false/1/0
+func TestCheckEnvVars(t *testing.T) {
+	os.Setenv("RACK_PRIVATE", "foo")
+
+	// Ensure invalid env vars only print a warning and don't raise an error
+	err := stdcli.CheckEnv()
+	assert.NoError(t, err)
+
+	test.Runs(t,
+		test.ExecRun{
+			Command:  "convox",
+			Env:      map[string]string{"CONVOX_WAIT": "foo"},
+			Exit:     0,
+			OutMatch: "WARNING: 'foo' is not a valid value for environment variable CONVOX_WAIT (expected: [true false 1 0 ])\n",
+		},
+	)
 }


### PR DESCRIPTION
Before:
```
$ CONVOX_WAIT=foo convox switch
squirrels/dev
```

After:
```
$ CONVOX_WAIT=foo convox switch
WARNING: 'foo' is not a valid value for environment variable CONVOX_WAIT (expected: [true false 1 0 ])
squirrels/dev
```

### Context

This has something to do with urfave/cli not accepting `yes`/`no` as valid boolflag values, I think. See also [this rack change](https://github.com/convox/rack/pull/1989/files#diff-effb1c59e116f169d0acdeb0a44d1f60) and [this site change](https://github.com/convox/site/pull/632).