### PR TITLE
Use CONVOX_DEBUG rather than DEBUG

### DIFF
--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -122,7 +122,7 @@ func ValidatePreconditions(preconditions ...cli.BeforeFunc) cli.BeforeFunc {
 }
 
 func Debug() bool {
-	if debug := os.Getenv("DEBUG"); debug != "" {
+	if debug := os.Getenv("CONVOX_DEBUG"); debug != "" {
 		return true
 	}
 	return false
@@ -303,7 +303,7 @@ func runExecCommand(bin string, args ...string) error {
 	err := cmd.Run()
 
 	if Debug() {
-		fmt.Fprintf(os.Stderr, "DEBUG: exec: '%v', '%v', '%v'\n", bin, args, err)
+		fmt.Fprintf(os.Stderr, "CONVOX_DEBUG: exec: '%v', '%v', '%v'\n", bin, args, err)
 	}
 
 	return err

--- a/cmd/convox/stdcli/stdcli_test.go
+++ b/cmd/convox/stdcli/stdcli_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/convox/rack/cmd/convox/stdcli"
+	"github.com/convox/rack/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/convox/stdcli/stdcli_test.go
+++ b/cmd/convox/stdcli/stdcli_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/convox/rack/cmd/convox/stdcli"
-	"github.com/convox/rack/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,6 +25,22 @@ func TestParseOptions(t *testing.T) {
 	assert.Equal(t, "even worse", opts["is"])
 	_, ok := opts["this"]
 	assert.Equal(t, true, ok)
+}
+
+func TestDebug(t *testing.T) {
+	orig := os.Getenv("CONVOX_DEBUG")
+
+	os.Setenv("CONVOX_DEBUG", "")
+	assert.Equal(t, stdcli.Debug(), false)
+
+	os.Setenv("CONVOX_DEBUG", "mraaaa")
+	assert.Equal(t, stdcli.Debug(), true)
+
+	os.Setenv("CONVOX_DEBUG", "true")
+	assert.Equal(t, stdcli.Debug(), true)
+
+	// restore original CONVOX_DEBUG value
+	os.Setenv("CONVOX_DEBUG", orig)
 }
 
 // TestCheckEnvVars ensures stdcli.CheckEnv() prints a warning if bool envvars aren't true/false/1/0

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -120,7 +120,7 @@ func (p *AWSProvider) config() *aws.Config {
 		config.Endpoint = aws.String(p.Endpoint)
 	}
 
-	if os.Getenv("DEBUG") == "true" || os.Getenv("CONVOX_DEBUG") == "true" {
+	if os.Getenv("DEBUG") == "true" {
 		config.WithLogLevel(aws.LogDebugWithHTTPBody)
 	}
 

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -120,7 +120,7 @@ func (p *AWSProvider) config() *aws.Config {
 		config.Endpoint = aws.String(p.Endpoint)
 	}
 
-	if os.Getenv("DEBUG") == "true" {
+	if os.Getenv("DEBUG") == "true" || os.Getenv("CONVOX_DEBUG") == "true" {
 		config.WithLogLevel(aws.LogDebugWithHTTPBody)
 	}
 


### PR DESCRIPTION
`DEBUG` is too generic to rely on for CLI debug printing purposes. If this PR is accepted, the CLI will use `CONVOX_DEBUG` instead.