### PR TITLE
Ami updates

### DIFF
--- a/bin/current-ecs-amis
+++ b/bin/current-ecs-amis
@@ -9,6 +9,6 @@ die() {
 [ -x "$(which jq)" ] || die "needs jq"
 [ -x "$(which pup)" ] || die "needs pup"
 
-curl -s http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html | pup 'table json{}' | jq -r '.[]|select(.children[1].children[0].children[1].text=="AMI ID").children[2].children[]|"      \"\(.children[0].children[0].text)\": { \"Ami\": \"\(.children[1].children[0].text)\" },"' | perl -0pe 's/,\n\z//'
+curl -s http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html | pup 'table json{}' | jq -r '.[2].children[0].children[]|"      \"\(.children[0].children[0].text)\": { \"Ami\": \"\(.children[1].children[0].text)\" },"' | grep -v "null" 
 
 echo

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -64,17 +64,17 @@
       "ap-southeast-2": { "ThirdAvailabilityZone": "Yes" }
     },
     "RegionConfig": {
-      "us-east-1": { "Ami": "ami-d69c74c0" },
-      "us-east-2": { "Ami": "ami-64270201" },
-      "us-west-1": { "Ami": "ami-bc90c2dc" },
-      "us-west-2": { "Ami": "ami-8e7bc4ee" },
-      "eu-west-1": { "Ami": "ami-48f9a52e" },
-      "eu-west-2": { "Ami": "ami-62aea406" },
-      "eu-central-1": { "Ami": "ami-6b428d04" },
-      "ap-northeast-1": { "Ami": "ami-372f5450" },
-      "ap-southeast-1": { "Ami": "ami-69208a0a" },
-      "ap-southeast-2": { "Ami": "ami-307f7853" },
-      "ca-central-1": { "Ami": "ami-b2e65bd6" }
+      "us-east-1": { "Ami": "ami-b2df2ca4" },
+      "us-east-2": { "Ami": "ami-832b0ee6" },
+      "us-west-1": { "Ami": "ami-dd104dbd" },
+      "us-west-2": { "Ami": "ami-022b9262" },
+      "eu-west-1": { "Ami": "ami-a7f2acc1" },
+      "eu-west-2": { "Ami": "ami-3fb6bc5b" },
+      "eu-central-1": { "Ami": "ami-ec2be583" },
+      "ap-northeast-1": { "Ami": "ami-c393d6a4" },
+      "ap-southeast-1": { "Ami": "ami-a88530cb" },
+      "ap-southeast-2": { "Ami": "ami-8af8ffe9" },
+      "ca-central-1": { "Ami": "ami-ead5688e" }
     }
   },
   "Outputs": {


### PR DESCRIPTION
Seems something changed in the docs that the `current-ecs-amis` script wasn't returning anything. After time boxing it for a while, this is my best effort with jq. Any improvements is appreciated.