### PR TITLE
Add tests

### DIFF
--- a/cmd/convox/main_test.go
+++ b/cmd/convox/main_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/convox/rack/test"
 )
 
+var configlessEnv = map[string]string{
+	// reset HOME to a location where there's not likely to be a convox config on the host
+	"HOME":                  "/tmp/probablyNoConfigFileHere",
+	"AWS_SECRET_ACCESS_KEY": "",
+	"AWS_ACCESS_KEY_ID":     "",
+}
+
 func testServer(t *testing.T, stubs ...test.Http) *httptest.Server {
 	stubs = append(stubs, test.Http{Method: "GET", Path: "/system", Code: 200, Response: client.System{
 		Version: "latest",
@@ -23,4 +30,15 @@ func testServer(t *testing.T, stubs ...test.Http) *httptest.Server {
 	os.Setenv("CONVOX_PASSWORD", "test")
 
 	return server
+}
+
+func TestVersion(t *testing.T) {
+	// Ensure we don't segfault if user is not logged in
+	test.Runs(t, test.ExecRun{
+		Command: "convox -v",
+		Env:     configlessEnv,
+		Exit:    0,
+		Stdout:  "client: dev\n",
+		Stderr:  "ERROR: no host config found, try `convox login`\nERROR: Get https:///system: http: no Host in request URL\n",
+	})
 }

--- a/cmd/convox/main_test.go
+++ b/cmd/convox/main_test.go
@@ -15,6 +15,7 @@ var configlessEnv = map[string]string{
 	"HOME":                  "/tmp/probablyNoConfigFileHere",
 	"AWS_SECRET_ACCESS_KEY": "",
 	"AWS_ACCESS_KEY_ID":     "",
+	"CONVOX_HOST":           "",
 }
 
 func testServer(t *testing.T, stubs ...test.Http) *httptest.Server {

--- a/cmd/convox/scale_test.go
+++ b/cmd/convox/scale_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/convox/rack/test"
+)
+
+func TestScaleCmd(t *testing.T) {
+	tests := []test.ExecRun{
+		test.ExecRun{
+			// Ensure we don't segfault if user is not logged in
+			Command: "convox scale",
+			Env:     configlessEnv,
+			Exit:    0,
+			Stderr:  "ERROR: no host config found, try `convox login`\n",
+		},
+	}
+	for _, myTest := range tests {
+		test.Runs(t, myTest)
+	}
+}


### PR DESCRIPTION
<strike>Tests run fine on their own:

```
$ make test PKG=github.com/convox/rack/cmd/convox TEST=TestScaleCmd
env PROVIDER=test CONVOX_WAIT= bin/test
Running single test TestScaleCmd
ok  	github.com/convox/rack/cmd/convox	0.036s	coverage: 1.7% of statements
```

```
$ make test PKG=github.com/convox/rack/cmd/convox TEST=TestVersion
env PROVIDER=test CONVOX_WAIT= bin/test
Running single test TestVersion
ok  	github.com/convox/rack/cmd/convox	0.017s	coverage: 1.7% of statements
```

... but can't figure out why it fails here:

```
$ make test PKG=github.com/convox/rack/cmd/convox 
[...]
--- FAIL: TestVersion (0.01s)
        Error Trace:    exec.go:45
	Error:		"ERROR: Get https://127.0.0.1:45349/system: dial tcp 127.0.0.1:45349: getsockopt: connection refused
			" does not contain "ERROR: no host config found, try `convox login`
			ERROR: Get https:///system: http: no Host in request URL
			"
	Messages:	stderr "ERROR: Get https://127.0.0.1:45349/system: dial tcp 127.0.0.1:45349: getsockopt: connection refused\n" should contain "ERROR: no host config found, try `convox login`\nERROR: Get https:///system: http: no Host in request URL\n"
		 🢂  convox -v
```

Something to do with `testServer` in `main_test_go`...?</strike>

**Update:** Just needed to set `CONVOX_HOST=""` in `configlessEnv`.