### PR TITLE
Prevent a panic if no host config is found with a nicer error message

### DIFF
--- a/cmd/convox/login.go
+++ b/cmd/convox/login.go
@@ -256,15 +256,13 @@ func removeHost() error {
 
 func currentLogin() (string, string, error) {
 	host, err := currentHost()
-
 	if err != nil {
-		return "", "", fmt.Errorf("must log in first")
+		return "", "", err
 	}
 
 	password, err := currentPassword()
-
 	if err != nil {
-		return "", "", fmt.Errorf("must log in first")
+		return "", "", err
 	}
 
 	return host, password, nil
@@ -278,7 +276,7 @@ func currentHost() (string, error) {
 	config := filepath.Join(ConfigRoot, "host")
 
 	if !helpers.Exists(config) {
-		return "", fmt.Errorf("no host config")
+		return "", fmt.Errorf("no host config found")
 	}
 
 	data, err := ioutil.ReadFile(config)
@@ -298,7 +296,7 @@ func currentPassword() (string, error) {
 	config := filepath.Join(ConfigRoot, "auth")
 
 	if !helpers.Exists(config) {
-		return "", fmt.Errorf("no auth config")
+		return "", fmt.Errorf("no auth config found")
 	}
 
 	data, err := ioutil.ReadFile(config)

--- a/cmd/convox/login_test.go
+++ b/cmd/convox/login_test.go
@@ -81,18 +81,28 @@ func TestLoginFuncs(t *testing.T) {
 	oldHost := os.Getenv("CONVOX_HOST")
 	oldPassword := os.Getenv("CONVOX_PASSWORD")
 
+	/* test currentLogin() with dummy values */
 	os.Setenv("CONVOX_CONFIG", temp)
 	os.Setenv("CONVOX_HOST", "testHost")
 	os.Setenv("CONVOX_PASSWORD", "testPassword")
-
-	host, err := currentHost()
-	assert.NoError(t, err)
-	assert.Equal(t, "testHost", host)
 
 	host, password, err := currentLogin()
 	assert.NoError(t, err)
 	assert.Equal(t, "testHost", host)
 	assert.Equal(t, "testPassword", password)
+
+	/* Now try with an empty config */
+	// Note: Can't just export HOME here, because ConfigRoot has already been initialized
+	ConfigRoot = "/tmp/nothinghere"
+	assert.Equal(t, "/tmp/nothinghere", ConfigRoot)
+	os.Unsetenv("CONVOX_CONFIG")
+	os.Unsetenv("CONVOX_HOST")
+	os.Unsetenv("CONVOX_PASSWORD")
+
+	host, password, err = currentLogin()
+	assert.EqualError(t, err, "no host config found")
+	assert.Equal(t, "", host)
+	assert.Equal(t, "", password)
 
 	os.Setenv("CONVOX_CONFIG", oldConfig)
 	os.Setenv("CONVOX_HOST", oldHost)

--- a/cmd/convox/login_test.go
+++ b/cmd/convox/login_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/convox/rack/client"
 	"github.com/convox/rack/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInvalidLogin(t *testing.T) {
@@ -71,4 +73,28 @@ func TestLoginRack(t *testing.T) {
 			Stdout:  "Logged in successfully.\n",
 		},
 	)
+}
+
+func TestLoginFuncs(t *testing.T) {
+	temp, _ := ioutil.TempDir("", "convox-test")
+	oldConfig := os.Getenv("CONVOX_CONFIG")
+	oldHost := os.Getenv("CONVOX_HOST")
+	oldPassword := os.Getenv("CONVOX_PASSWORD")
+
+	os.Setenv("CONVOX_CONFIG", temp)
+	os.Setenv("CONVOX_HOST", "testHost")
+	os.Setenv("CONVOX_PASSWORD", "testPassword")
+
+	host, err := currentHost()
+	assert.NoError(t, err)
+	assert.Equal(t, "testHost", host)
+
+	host, password, err := currentLogin()
+	assert.NoError(t, err)
+	assert.Equal(t, "testHost", host)
+	assert.Equal(t, "testPassword", password)
+
+	os.Setenv("CONVOX_CONFIG", oldConfig)
+	os.Setenv("CONVOX_HOST", oldHost)
+	os.Setenv("CONVOX_PASSWORD", oldPassword)
 }

--- a/cmd/convox/main.go
+++ b/cmd/convox/main.go
@@ -112,12 +112,10 @@ func currentRack(c *cli.Context) string {
 func rackClient(c *cli.Context) *client.Client {
 	host, password, err := currentLogin()
 	if err != nil {
-		stdcli.Error(err)
-		return nil
+		stdcli.Errorf("%s, try `convox login`", err)
 	}
 
 	cl := client.New(host, password, c.App.Version)
-
 	cl.Rack = currentRack(c)
 
 	return cl

--- a/cmd/convox/main.go
+++ b/cmd/convox/main.go
@@ -113,6 +113,7 @@ func rackClient(c *cli.Context) *client.Client {
 	host, password, err := currentLogin()
 	if err != nil {
 		stdcli.Errorf("%s, try `convox login`", err)
+		os.Exit(1)
 	}
 
 	cl := client.New(host, password, c.App.Version)

--- a/cmd/convox/main_test.go
+++ b/cmd/convox/main_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/convox/rack/test"
 )
 
+var configlessEnv = map[string]string{
+	// reset HOME to a location where there's not likely to be a convox config on the host
+	"HOME":                  "/tmp/probablyNoConfigFileHere",
+	"AWS_SECRET_ACCESS_KEY": "",
+	"AWS_ACCESS_KEY_ID":     "",
+	"CONVOX_HOST":           "",
+}
+
 func testServer(t *testing.T, stubs ...test.Http) *httptest.Server {
 	stubs = append(stubs, test.Http{Method: "GET", Path: "/system", Code: 200, Response: client.System{
 		Version: "latest",
@@ -23,4 +31,15 @@ func testServer(t *testing.T, stubs ...test.Http) *httptest.Server {
 	os.Setenv("CONVOX_PASSWORD", "test")
 
 	return server
+}
+
+func TestVersion(t *testing.T) {
+	// Ensure we don't segfault if user is not logged in
+	test.Runs(t, test.ExecRun{
+		Command: "convox -v",
+		Env:     configlessEnv,
+		Exit:    1,
+		Stdout:  "client: dev\n",
+		Stderr:  "ERROR: no host config found, try `convox login`\n",
+	})
 }

--- a/cmd/convox/racks.go
+++ b/cmd/convox/racks.go
@@ -18,7 +18,7 @@ func init() {
 
 func cmdRacks(c *cli.Context) error {
 	if len(c.Args()) > 0 {
-		return stdcli.Error(fmt.Errorf("`convox racks` does not take arguments. Perhaps you meant `convox racks`?"))
+		return stdcli.Error(fmt.Errorf("`convox racks` does not take arguments. Perhaps you meant `convox rack`?"))
 	}
 
 	racks, err := rackClient(c).Racks()

--- a/cmd/convox/scale_test.go
+++ b/cmd/convox/scale_test.go
@@ -6,76 +6,16 @@ import (
 	"github.com/convox/rack/test"
 )
 
-var scaleUsage = `convox scale: scale an app's processes
-
-Usage:
-  convox scale <process> [--count=2] [--memory=256] [--cpu=256]
-
-Options:
-   --app value, -a value  app name inferred from current directory if not specified
-   --rack value           rack name
-   --count value          Number of processes to keep running for specified process type. (default: 0)
-   --memory value         Amount of memory, in MB, available to specified process type. (default: 0)
-   --cpu value            CPU units available to specified process type. (default: 0)
-   --wait                 wait for app to finish scaling before returning [$CONVOX_WAIT]
-   
-`
-
 func TestScaleCmd(t *testing.T) {
-	ts := testServer(t,
-		test.Http{
-			Method: "GET",
-			Path:   "/apps/convox/processes",
-			Code:   200,
-		},
-		test.Http{
-			Method: "GET",
-			Path:   "/apps/convox/formation",
-			Code:   200,
-		},
-		test.Http{
-			Method: "POST",
-			Path:   "/apps/convox/formation/myprocesses",
-			Body:   "cpu=1",
-			Code:   200,
-		},
-	)
-	defer ts.Close()
-
 	tests := []test.ExecRun{
 		test.ExecRun{
+			// Ensure we don't segfault if user is not logged in
 			Command: "convox scale",
-			Stdout:  "NAME  DESIRED  RUNNING  CPU  MEMORY\n",
-			Exit:    0,
-		},
-		test.ExecRun{
-			Command: "convox scale foo bar",
-			Stdout:  scaleUsage,
-			Exit:    129,
-		},
-		test.ExecRun{
-			Command: "convox scale --foo",
-			Stdout:  "Incorrect Usage: flag provided but not defined: -foo\n\n" + scaleUsage,
-			Stderr:  "ERROR: flag provided but not defined: -foo\n",
+			Env:     configlessEnv,
 			Exit:    1,
-		},
-		test.ExecRun{
-			Command: "convox scale --cpu",
-			Stdout:  "Incorrect Usage: flag needs an argument: -cpu\n\n" + scaleUsage,
-			Stderr:  "ERROR: flag needs an argument: -cpu\n",
-			Exit:    1,
-		},
-		test.ExecRun{
-			Command: "convox scale --cpu=1",
-			Stderr:  "ERROR: missing process name\n",
-			Exit:    1,
-		},
-		test.ExecRun{
-			Command: "convox scale --cpu=1 myprocesses",
-			Stdout:  "NAME  DESIRED  RUNNING  CPU  MEMORY\n",
+			Stderr:  "ERROR: no host config found, try `convox login`\n",
 		},
 	}
-
 	for _, myTest := range tests {
 		test.Runs(t, myTest)
 	}

--- a/cmd/convox/scale_test.go
+++ b/cmd/convox/scale_test.go
@@ -6,7 +6,30 @@ import (
 	"github.com/convox/rack/test"
 )
 
+var scaleUsage = `convox scale: scale an app's processes`
+
 func TestScaleCmd(t *testing.T) {
+
+	ts := testServer(t,
+		test.Http{
+			Method: "GET",
+			Path:   "/apps/convox/processes",
+			Code:   200,
+		},
+		test.Http{
+			Method: "GET",
+			Path:   "/apps/convox/formation",
+			Code:   200,
+		},
+		test.Http{
+			Method: "POST",
+			Path:   "/apps/convox/formation/myprocesses",
+			Body:   "cpu=1",
+			Code:   200,
+		},
+	)
+	defer ts.Close()
+
 	tests := []test.ExecRun{
 		test.ExecRun{
 			// Ensure we don't segfault if user is not logged in
@@ -15,7 +38,35 @@ func TestScaleCmd(t *testing.T) {
 			Exit:    1,
 			Stderr:  "ERROR: no host config found, try `convox login`\n",
 		},
+		test.ExecRun{
+			Command:  "convox scale --foo",
+			OutMatch: "Incorrect Usage: flag provided but not defined: -foo\n\n" + scaleUsage,
+			Stderr:   "ERROR: flag provided but not defined: -foo\n",
+			Exit:     1,
+		},
+		test.ExecRun{
+			Command:  "convox scale --foo",
+			OutMatch: "Incorrect Usage: flag provided but not defined: -foo\n\n" + scaleUsage,
+			Stderr:   "ERROR: flag provided but not defined: -foo\n",
+			Exit:     1,
+		},
+		test.ExecRun{
+			Command:  "convox scale --cpu",
+			OutMatch: "Incorrect Usage: flag needs an argument: -cpu\n\n" + scaleUsage,
+			Stderr:   "ERROR: flag needs an argument: -cpu\n",
+			Exit:     1,
+		},
+		test.ExecRun{
+			Command: "convox scale --cpu=1",
+			Stderr:  "ERROR: missing process name\n",
+			Exit:    1,
+		},
+		test.ExecRun{
+			Command:  "convox scale --cpu=1 myprocesses",
+			OutMatch: "NAME  DESIRED  RUNNING  CPU  MEMORY\n",
+		},
 	}
+
 	for _, myTest := range tests {
 		test.Runs(t, myTest)
 	}

--- a/cmd/convox/stdcli/stdcli_test.go
+++ b/cmd/convox/stdcli/stdcli_test.go
@@ -43,4 +43,5 @@ func TestCheckEnvVars(t *testing.T) {
 			Stderr:  "ERROR: 'foo' is not a valid value for environment variable CONVOX_WAIT (expected: [true false 1 0 ])\n",
 		},
 	)
+	os.Unsetenv("RACK_PRIVATE")
 }


### PR DESCRIPTION
New output would look like:

```
convox apps
ERROR: no host config found, try `convox login`
```