### PR TITLE
Listing processes use a cache to prevent throttling

### DIFF
--- a/api/controllers/processes.go
+++ b/api/controllers/processes.go
@@ -13,22 +13,6 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-func ProcessList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
-	app := mux.Vars(r)["app"]
-
-	ps, err := models.Provider().ProcessList(app)
-	if provider.ErrorNotFound(err) {
-		return httperr.NotFound(err)
-	}
-	if err != nil {
-		return httperr.Server(err)
-	}
-
-	sort.Sort(ps)
-
-	return RenderJson(rw, ps)
-}
-
 func ProcessExecAttached(ws *websocket.Conn) *httperr.Error {
 	vars := mux.Vars(ws.Request())
 	header := ws.Request().Header
@@ -59,6 +43,37 @@ func ProcessExecAttached(ws *websocket.Conn) *httperr.Error {
 	}
 
 	return nil
+}
+
+func ProcessGet(rw http.ResponseWriter, r *http.Request) *httperr.Error {
+	app := mux.Vars(r)["app"]
+	process := mux.Vars(r)["process"]
+
+	ps, err := models.Provider().ProcessGet(app, process)
+	if provider.ErrorNotFound(err) {
+		return httperr.NotFound(err)
+	}
+	if err != nil {
+		return httperr.Server(err)
+	}
+
+	return RenderJson(rw, ps)
+}
+
+func ProcessList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
+	app := mux.Vars(r)["app"]
+
+	ps, err := models.Provider().ProcessList(app)
+	if provider.ErrorNotFound(err) {
+		return httperr.NotFound(err)
+	}
+	if err != nil {
+		return httperr.Server(err)
+	}
+
+	sort.Sort(ps)
+
+	return RenderJson(rw, ps)
 }
 
 func ProcessRunAttached(ws *websocket.Conn) *httperr.Error {

--- a/api/controllers/processes.go
+++ b/api/controllers/processes.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+// ProcessExecAttached runs an attached command in an existing process
 func ProcessExecAttached(ws *websocket.Conn) *httperr.Error {
 	vars := mux.Vars(ws.Request())
 	header := ws.Request().Header
@@ -45,6 +46,7 @@ func ProcessExecAttached(ws *websocket.Conn) *httperr.Error {
 	return nil
 }
 
+// ProcessGet returns a process for an app
 func ProcessGet(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	app := mux.Vars(r)["app"]
 	process := mux.Vars(r)["process"]
@@ -60,6 +62,7 @@ func ProcessGet(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	return RenderJson(rw, ps)
 }
 
+// ProcessList returns a list of processes for an app
 func ProcessList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	app := mux.Vars(r)["app"]
 
@@ -76,6 +79,7 @@ func ProcessList(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 	return RenderJson(rw, ps)
 }
 
+// ProcessRunAttached runs an attached command in an new process
 func ProcessRunAttached(ws *websocket.Conn) *httperr.Error {
 	vars := mux.Vars(ws.Request())
 	header := ws.Request().Header

--- a/api/controllers/routes.go
+++ b/api/controllers/routes.go
@@ -33,6 +33,7 @@ func NewRouter() (router *mux.Router) {
 	router.HandleFunc("/apps/{app}/parameters", api("parameters.set", ParametersSet)).Methods("POST")
 	router.HandleFunc("/apps/{app}/processes", api("process.list", ProcessList)).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{process}", api("process.stop", ProcessStop)).Methods("DELETE")
+	router.HandleFunc("/apps/{app}/processes/{process}", api("process.get", ProcessGet)).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{process}/run", api("process.run.detach", ProcessRunDetached)).Methods("POST")
 	router.HandleFunc("/apps/{app}/releases", api("release.list", ReleaseList)).Methods("GET")
 	router.HandleFunc("/apps/{app}/releases", api("release.list", ReleaseList)).Methods("GET").Queries("limit", "{limit:[0-9]+}")

--- a/ci/dependencies-pre.sh
+++ b/ci/dependencies-pre.sh
@@ -12,7 +12,7 @@ go get -d github.com/convox/rack/cmd/convox
 (
 	cd ${GOPATH%%:*}/src/github.com/convox/rack/cmd/convox
 	[ -n "$CIRCLE_BRANCH" ] && git fetch && git reset --hard origin/$CIRCLE_BRANCH
-	go install -ldflags "-X main.Version $VERSION"
+	go install -ldflags "-X main.Version=$VERSION"
 )
 
 # configure client id if on CircleCI

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,8 @@ machine:
   post:
     - sudo apt-get update; sudo apt-get install curl
     - sudo rm -rf /usr/local/go
-    - curl https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz -O
-    - sudo tar -C /usr/local -xzf go1.6.3.linux-amd64.tar.gz
+    - curl https://storage.googleapis.com/golang/go1.7.5.linux-amd64.tar.gz -O
+    - sudo tar -C /usr/local -xzf go1.7.5.linux-amd64.tar.gz
 
 dependencies:
   pre:

--- a/cmd/convox/scale.go
+++ b/cmd/convox/scale.go
@@ -65,17 +65,10 @@ func cmdScale(c *cli.Context) error {
 			return stdcli.Error(fmt.Errorf("missing process name"))
 		}
 
-		if err := displayFormation(c, app); err != nil {
-			return stdcli.Error(err)
-		}
-
-		return nil
+		return displayFormation(c, app)
 	case 1:
 		if opts.Count == "" && opts.CPU == "" && opts.Memory == "" {
-			if err := displayFormation(c, app); err != nil {
-				return stdcli.Error(err)
-			}
-			return nil
+			return displayFormation(c, app)
 		}
 		// fall through to scale API call
 	default:

--- a/cmd/convox/stdcli/stdcli.go
+++ b/cmd/convox/stdcli/stdcli.go
@@ -363,9 +363,7 @@ func CheckEnv() error {
 			}
 		}
 		if !ok {
-			msg := fmt.Sprintf("'%s' is not a valid value for environment variable %s ", os.Getenv(varName), varName)
-			msg += fmt.Sprintf("(expected: %s)", okVals)
-			return Errorf(msg)
+			return fmt.Errorf("'%s' is not a valid value for environment variable %s (expected: %s)", os.Getenv(varName), varName, okVals)
 		}
 	}
 	return nil

--- a/provider/mock_Provider.go
+++ b/provider/mock_Provider.go
@@ -714,6 +714,29 @@ func (_m *MockProvider) ProcessExec(app string, pid string, command string, stre
 	return r0
 }
 
+// ProcessGet provides a mock function with given fields: app, pid
+func (_m *MockProvider) ProcessGet(app string, pid string) (*structs.Process, error) {
+	ret := _m.Called(app, pid)
+
+	var r0 *structs.Process
+	if rf, ok := ret.Get(0).(func(string, string) *structs.Process); ok {
+		r0 = rf(app, pid)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*structs.Process)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(app, pid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ProcessList provides a mock function with given fields: app
 func (_m *MockProvider) ProcessList(app string) (structs.Processes, error) {
 	ret := _m.Called(app)
@@ -1177,5 +1200,3 @@ func (_m *MockProvider) SystemSave(system structs.System) error {
 
 	return r0
 }
-
-var _ Provider = (*MockProvider)(nil)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -61,6 +61,7 @@ type Provider interface {
 	ObjectStore(key string, r io.Reader, opts structs.ObjectOptions) (string, error)
 
 	ProcessExec(app, pid, command string, stream io.ReadWriter, opts structs.ProcessExecOptions) error
+	ProcessGet(app, pid string) (*structs.Process, error)
 	ProcessList(app string) (structs.Processes, error)
 	ProcessRun(app, process string, opts structs.ProcessRunOptions) (string, error)
 	ProcessStop(app, pid string) error


### PR DESCRIPTION
When gathering information for a large number of processes (e.g > 300), API throttling becomes an issue. This is addressed by caching various resources that are unlikely to change while gathering the process data. That includes container definitions and instances that are shared amongst the processes. I was able to gather over ~420 processes without being throttled back to back. Fixes #1990

Other fixes include:
- Bumping CircleCI golang to 1.7.5 as rack itself
- Added the `ProcessGet` interface so that `convox ps info <ID>` works. Fixes #2021
- Added some logging to the `SystemGet` interface