### PR TITLE
Parameterize ebs encryption

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1409,7 +1409,7 @@
           {
             "DeviceName": "/dev/xvdb",
             "Ebs": {
-              "Encrypted": { "Ref": "EncryptEbs" },
+              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", "false" ] },
               "VolumeSize": { "Ref": "SwapSize" },
               "VolumeType":"gp2"
             }
@@ -1417,7 +1417,7 @@
           {
             "DeviceName": "/dev/xvdcz",
             "Ebs": {
-              "Encrypted": { "Ref": "EncryptEbs" },
+              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", "false" ] },
               "VolumeSize": { "Ref": "VolumeSize" },
               "VolumeType":"gp2"
             }
@@ -1531,7 +1531,7 @@
           {
             "DeviceName": "/dev/xvdb",
             "Ebs": {
-              "Encrypted": { "Ref": "EncryptEbs" },
+              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", "false" ] },
               "VolumeSize": { "Ref": "SwapSize" },
               "VolumeType":"gp2"
             }
@@ -1539,7 +1539,7 @@
           {
             "DeviceName": "/dev/xvdcz",
             "Ebs": {
-              "Encrypted": "true",
+              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", "false" ] },
               "VolumeSize": { "Ref": "VolumeSize" },
               "VolumeType":"gp2"
             }

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -326,7 +326,7 @@
     "EncryptEbs": {
       "Type": "String",
       "Description": "Enable encryption at rest for EBS volumes",
-      "Default": "Yes",
+      "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
     },
     "Encryption": {

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -14,6 +14,7 @@
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "DedicatedBuilder": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstance" }, "" ] } ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
+    "EncryptEbs" : { "Fn::Equals": [ { "Ref": "EncryptEbs" }, "Yes" ] },
     "ExistingVpc": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "ExistingVpc" }, "" ] } ] },
     "ExistingVpcAndBlankInternetGateway": {
       "Fn::And": [ { "Condition": "ExistingVpc" }, { "Condition": "BlankInternetGateway" } ]
@@ -320,6 +321,12 @@
       "Type": "String",
       "Description": "Development mode",
       "Default": "No",
+      "AllowedValues": [ "Yes", "No" ]
+    },
+    "EncryptEbs": {
+      "Type": "String",
+      "Description": "Enable encryption at rest for EBS volumes",
+      "Default": "Yes",
       "AllowedValues": [ "Yes", "No" ]
     },
     "Encryption": {
@@ -1402,7 +1409,7 @@
           {
             "DeviceName": "/dev/xvdb",
             "Ebs": {
-              "Encrypted": "true",
+              "Encrypted": { "Ref": "EncryptEbs" },
               "VolumeSize": { "Ref": "SwapSize" },
               "VolumeType":"gp2"
             }
@@ -1410,7 +1417,7 @@
           {
             "DeviceName": "/dev/xvdcz",
             "Ebs": {
-              "Encrypted": "true",
+              "Encrypted": { "Ref": "EncryptEbs" },
               "VolumeSize": { "Ref": "VolumeSize" },
               "VolumeType":"gp2"
             }
@@ -1524,7 +1531,7 @@
           {
             "DeviceName": "/dev/xvdb",
             "Ebs": {
-              "Encrypted": "true",
+              "Encrypted": { "Ref": "EncryptEbs" },
               "VolumeSize": { "Ref": "SwapSize" },
               "VolumeType":"gp2"
             }


### PR DESCRIPTION
This makes EBS encryption configurable instead of hard-coded to on. It defaults to off, but if you want to turn it on you can run:

```
convox rack params set EncryptEbs=Yes
```