### PR TITLE
Drop trailing slash from api get and delete args

### DIFF
--- a/cmd/convox/api.go
+++ b/cmd/convox/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/convox/rack/cmd/convox/stdcli"
 	"gopkg.in/urfave/cli.v1"
@@ -53,6 +54,7 @@ func cmdApiGet(c *cli.Context) error {
 	}
 
 	path := c.Args()[0]
+	path = strings.TrimRight(path, "/")
 
 	var object interface{}
 
@@ -77,6 +79,7 @@ func cmdApiDelete(c *cli.Context) error {
 	}
 
 	path := c.Args()[0]
+	path = strings.TrimRight(path, "/")
 
 	var object interface{}
 

--- a/cmd/convox/api_test.go
+++ b/cmd/convox/api_test.go
@@ -275,3 +275,22 @@ func TestApiGetNoArg(t *testing.T) {
 		},
 	)
 }
+
+// TestApiGet404 should ensure an error is returned when a user runs 'convox api get' with an invalid API endpoint.
+func TestApiTrailingSlash(t *testing.T) {
+	ts := testServer(t,
+		test.Http{Method: "GET", Path: "/apps", Code: 200, Response: client.Apps{
+			client.App{Name: "sinatra", Status: "running"},
+		}},
+	)
+
+	defer ts.Close()
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox api get /apps/",
+			Exit:    0,
+			Stdout:  "[\n  {\n    \"name\": \"sinatra\",\n    \"release\": \"\",\n    \"status\": \"running\"\n  }\n]\n",
+		},
+	)
+}

--- a/cmd/convox/api_test.go
+++ b/cmd/convox/api_test.go
@@ -276,7 +276,7 @@ func TestApiGetNoArg(t *testing.T) {
 	)
 }
 
-// TestApiGet404 should ensure an error is returned when a user runs 'convox api get' with an invalid API endpoint.
+// TestApiTrailingSlash should ensure we fall back to /endpoint when user runs `convox api get /endpoint/`
 func TestApiTrailingSlash(t *testing.T) {
 	ts := testServer(t,
 		test.Http{Method: "GET", Path: "/apps", Code: 200, Response: client.Apps{


### PR DESCRIPTION
Dumbest, tiniest PR ever, but i keep typoing it and it bugs me. (Feel free to reject.)

Before:

```
$ /usr/local/bin/convox api get /apps/
ERROR: response status: 404 404 page not found
```

After:

```
$ convox api get /apps/
[
  {
    "name": "cv-soulshake-net",
    "release": "RRANZYKRPSM",
    "status": "running"
  },
  {
    "name": "trainingwheels",
    "release": "",
    "status": "running"
  }
]
```