### PR TITLE
Only deploy if app is in a running state

### DIFF
--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -188,12 +188,8 @@ func cmdBuildsCreate(c *cli.Context) error {
 		return stdcli.Error(err)
 	}
 
-	switch a.Status {
-	case "creating":
-		return stdcli.Error(fmt.Errorf("app is still creating: %s", app))
-	case "running", "updating":
-	default:
-		return stdcli.Error(fmt.Errorf("unable to build app: %s", app))
+	if a.Status == "creating" {
+		return stdcli.Error(fmt.Errorf("app %s is still being created, for more information try `convox apps info`", app))
 	}
 
 	if len(c.Args()) > 0 {

--- a/cmd/convox/builds_test.go
+++ b/cmd/convox/builds_test.go
@@ -19,7 +19,7 @@ func TestBuildsPreventAgainstCreating(t *testing.T) {
 			Command: "convox build https://example.org --app foo",
 			Exit:    1,
 			Stdout:  "",
-			Stderr:  "ERROR: app is still creating: foo\n",
+			Stderr:  "ERROR: app foo is still being created, for more information try `convox apps info`\n",
 		},
 	)
 }

--- a/cmd/convox/deploy.go
+++ b/cmd/convox/deploy.go
@@ -49,11 +49,8 @@ func cmdDeploy(c *cli.Context) error {
 		return stdcli.Error(err)
 	}
 
-	switch a.Status {
-	case "creating":
-		return stdcli.Error(fmt.Errorf("app %s is still being created, check `convox apps info`", app))
-	case "updating":
-		return stdcli.Error(fmt.Errorf("app %s is still being updated, check `convox apps info`", app))
+	if a.Status != "running" {
+		return stdcli.Error(fmt.Errorf("unable to deploy %s in a non-running status: %s", app, a.Status))
 	}
 
 	if !helpers.Exists(c.String("file")) {

--- a/cmd/convox/deploy_test.go
+++ b/cmd/convox/deploy_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/convox/rack/test"
 )
 
-func TestDeployPreventAgainstCreating(t *testing.T) {
+func TestDeployPreventAgainstNonRunningStatus(t *testing.T) {
 	ts := testServer(t,
 		test.Http{Method: "GET", Path: "/apps/foo", Code: 200, Response: client.App{Name: "foo", Status: "creating"}},
 	)
@@ -19,7 +19,7 @@ func TestDeployPreventAgainstCreating(t *testing.T) {
 			Command: "convox deploy --app foo",
 			Exit:    1,
 			Stdout:  "",
-			Stderr:  "ERROR: app foo is still being created, check `convox apps info`\n",
+			Stderr:  "ERROR: unable to deploy foo in a non-running status: creating\n",
 		},
 	)
 }


### PR DESCRIPTION
Changes include:
- `convox deploy` will error out when the app status is not `running`.
- `convox build` will build the app unless the app is still being created.

Any thoughts on the build change? Doesn't seem necessary to stop a build depending on the app status, unless it's still being created.

Fixes #2016