### PR TITLE
use stack's resource for log group

### DIFF
--- a/provider/aws/logs.go
+++ b/provider/aws/logs.go
@@ -13,12 +13,12 @@ import (
 )
 
 func (p *AWSProvider) LogStream(app string, w io.Writer, opts structs.LogStreamOptions) error {
-	a, err := p.AppGet(app)
+	logGroup, err := p.stackResource(fmt.Sprintf("%s-%s", p.Rack, app), "LogGroup")
 	if err != nil {
 		return err
 	}
 
-	return p.subscribeLogs(w, a.Outputs["LogGroup"], opts)
+	return p.subscribeLogs(w, *logGroup.PhysicalResourceId, opts)
 }
 
 func (p *AWSProvider) subscribeLogs(w io.Writer, group string, opts structs.LogStreamOptions) error {

--- a/provider/aws/logs_test.go
+++ b/provider/aws/logs_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestLogStream(t *testing.T) {
 	provider := StubAwsProvider(
-		cycleFormationDescribeStacks,
+		cycleDescribeAppStackResources,
 		cycleLogFilterLogEvents1,
 		cycleLogFilterLogEvents2,
 	)
@@ -128,5 +128,34 @@ var cycleLogFilterLogEvents2 = awsutil.Cycle{
 				}
 			]
 		}`,
+	},
+}
+
+var cycleDescribeAppStackResources = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Operation:  "",
+		Body:       `Action=DescribeStackResources&StackName=convox-httpd&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `
+			<DescribeStackResourcesResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <DescribeStackResourcesResult>
+    <StackResources>
+    <member>
+      <PhysicalResourceId>convox-httpd-LogGroup-L4V203L35WRM</PhysicalResourceId>
+      <ResourceStatus>UPDATE_COMPLETE</ResourceStatus>
+      <LogicalResourceId>LogGroup</LogicalResourceId>
+      <Timestamp>2016-10-22T02:53:23.817Z</Timestamp>
+      <ResourceType>AWS::Logs::LogGroup</ResourceType>
+    </member>
+    </StackResources>
+  </DescribeStackResourcesResult>
+  <ResponseMetadata>
+    <RequestId>50ce1445-9805-11e6-8ba2-2b306877d289</RequestId>
+  </ResponseMetadata>
+</DescribeStackResourcesResponse>
+		`,
 	},
 }

--- a/provider/aws/system.go
+++ b/provider/aws/system.go
@@ -133,12 +133,12 @@ func (p *AWSProvider) SystemGet() (*structs.System, error) {
 
 // SystemLogs streams logs for the Rack
 func (p *AWSProvider) SystemLogs(w io.Writer, opts structs.LogStreamOptions) error {
-	system, err := p.describeStack(p.Rack)
+	logGroup, err := p.stackResource(p.Rack, "LogGroup")
 	if err != nil {
 		return err
 	}
 
-	return p.subscribeLogs(w, stackOutputs(system)["LogGroup"], opts)
+	return p.subscribeLogs(w, *logGroup.PhysicalResourceId, opts)
 }
 
 func (p *AWSProvider) SystemProcesses(opts structs.SystemProcessesOptions) (structs.Processes, error) {


### PR DESCRIPTION
This allows for logs to be availabe if the stack is in rollback-in-progress state. Output values are not avaliable during that time.