### PR TITLE
Add support for CONVOX_WAIT to resource creation

### DIFF
--- a/cmd/convox/flags.go
+++ b/cmd/convox/flags.go
@@ -11,3 +11,9 @@ var rackFlag = cli.StringFlag{
 	Name:  "rack",
 	Usage: "rack name",
 }
+
+var waitFlag = cli.BoolFlag{
+	Name:   "wait",
+	EnvVar: "CONVOX_WAIT",
+	Usage:  "wait for change to finish before returning",
+}

--- a/cmd/convox/flags_test.go
+++ b/cmd/convox/flags_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/convox/rack/cmd/convox/stdcli"
 	"github.com/convox/rack/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/urfave/cli.v1"
 )
 
 /* HELP CHECKS */

--- a/cmd/convox/flags_test.go
+++ b/cmd/convox/flags_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/convox/rack/cmd/convox/stdcli"
 	"github.com/convox/rack/test"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/urfave/cli.v1"
 )
 
 /* HELP CHECKS */

--- a/cmd/convox/flags_test.go
+++ b/cmd/convox/flags_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/convox/rack/cmd/convox/stdcli"
 	"github.com/convox/rack/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/urfave/cli.v1"
 )
 
 /* HELP CHECKS */
@@ -80,4 +82,11 @@ func TestHelpFlag(t *testing.T) {
 			},
 		)
 	}
+}
+
+func TestWaitFlag(t *testing.T) {
+	wf := waitFlag
+	require.IsType(t, cli.BoolFlag{}, wf)
+	assert.Equal(t, "CONVOX_WAIT", wf.EnvVar)
+	assert.Equal(t, "wait", wf.Name)
 }

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -84,13 +84,7 @@ func init() {
 				Usage:           "<type> [--name=value] [--option-name=value] [options]\n\n" + usage,
 				ArgsUsage:       "<type>",
 				Action:          cmdResourceCreate,
-				Flags: []cli.Flag{rackFlag,
-					cli.BoolFlag{
-						Name:   "wait",
-						EnvVar: "CONVOX_WAIT",
-						Usage:  "wait for resource update to finish before returning",
-					},
-				},
+				Flags:           []cli.Flag{rackFlag, waitFlag},
 				SkipFlagParsing: true,
 			},
 			{
@@ -99,13 +93,7 @@ func init() {
 				Usage:       "<name> [options]",
 				ArgsUsage:   "<name>",
 				Action:      cmdResourceDelete,
-				Flags: []cli.Flag{rackFlag,
-					cli.BoolFlag{
-						Name:   "wait",
-						EnvVar: "CONVOX_WAIT",
-						Usage:  "wait for resource update to finish before returning",
-					},
-				},
+				Flags:       []cli.Flag{rackFlag, waitFlag},
 			},
 			{
 				Name:            "update",
@@ -114,13 +102,7 @@ func init() {
 				Usage:           "<name> --option-name=value [--option-name=value]\n\n" + usage,
 				ArgsUsage:       "<name>",
 				Action:          cmdResourceUpdate,
-				Flags: []cli.Flag{rackFlag,
-					cli.BoolFlag{
-						Name:   "wait",
-						EnvVar: "CONVOX_WAIT",
-						Usage:  "wait for resource update to finish before returning",
-					},
-				},
+				Flags:           []cli.Flag{rackFlag, waitFlag},
 				SkipFlagParsing: true,
 			},
 			{

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -228,7 +228,7 @@ func cmdResourceCreate(c *cli.Context) error {
 		return stdcli.Error(err)
 	}
 
-	if !c.Bool("wait") {
+	if !c.Bool("wait") && options["wait"] != "true" {
 		fmt.Println("CREATING")
 		return nil
 	}
@@ -273,7 +273,7 @@ func cmdResourceUpdate(c *cli.Context) error {
 		return stdcli.Error(err)
 	}
 
-	if !c.Bool("wait") {
+	if !c.Bool("wait") && options["wait"] != "true" {
 		fmt.Println("UPDATING")
 		return nil
 	}

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -256,7 +256,7 @@ func cmdResourceCreate(c *cli.Context) error {
 	// give the rack a few seconds to start updating
 	time.Sleep(5 * time.Second)
 
-	if err := waitForService(c, options["name"]); err != nil {
+	if err := waitForResource(c, options["name"]); err != nil {
 		return stdcli.Error(err)
 	}
 
@@ -301,7 +301,7 @@ func cmdResourceUpdate(c *cli.Context) error {
 	// give the rack a few seconds to start updating
 	time.Sleep(5 * time.Second)
 
-	if err := waitForService(c, name); err != nil {
+	if err := waitForResource(c, name); err != nil {
 		return stdcli.Error(err)
 	}
 
@@ -331,7 +331,7 @@ func cmdResourceDelete(c *cli.Context) error {
 	// give the rack a few seconds to start updating
 	time.Sleep(5 * time.Second)
 
-	if err := waitForService(c, name); err != nil {
+	if err := waitForResource(c, name); err != nil {
 		return stdcli.Error(err)
 	}
 
@@ -489,7 +489,7 @@ func cmdResourceProxy(c *cli.Context) error {
 	return nil
 }
 
-func waitForService(c *cli.Context, n string) error {
+func waitForResource(c *cli.Context, n string) error {
 	timeout := time.After(30 * time.Minute)
 	tick := time.Tick(2 * time.Second)
 


### PR DESCRIPTION
This adds support for using CONVOX_WAIT to resources creation, update, deletion.  However, --wait flag may not work with create and update (only the env var).  This may be due to "SkipFlagParsing: true" on these subcommands.