### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+### Description
+What is being fixed or added?
+Any helpful screenshots or terminal transcripts?
+
+### Summary for release notes
+Briefly explain to other Convox users how this PR impacts them.
+Which changes should be noticeable or not noticeable?
+Does the scope of the change have side effects?
+Any new flags or parameters?
+
+### Guidance for reviewers
+Any difficult trade-offs or uncertainty worth highlighting?
+How can this change be tested?
+
+### Before Release
+- [ ] Rebase against master
+- [ ] Get review approval
+- [ ] Confirm test coverage
+- [ ] Submit documentation PR for convox/site


### PR DESCRIPTION
### Description
This adds a .github/PULL_REQUEST_TEMPLATE.md that will hopefully steer team members and contributors towards providing more useful information in PR descriptions. This PR follows the new template.

### Summary for release notes
We now recommend that convox/rack contributors use the optional template when submitting PRs.

### Guidance for reviewers
I'd appreciate feedback from anyone who is in the engineering flow on a daily basis. Does the template add too much overhead? Anything missing?

### Before Release
- [ ] Rebase against master
- [ ] Get review approval
- [ ] Confirm test coverage
- [ ] Submit documentation PR for convox/site
