### PR TITLE
Reduce number of API calls during uninstall

### DIFF
--- a/cmd/convox/uninstall.go
+++ b/cmd/convox/uninstall.go
@@ -165,6 +165,7 @@ func cmdUninstall(c *cli.Context) error {
 		}
 
 		buckets = append(buckets, bs...)
+		time.Sleep(2 * time.Second)
 	}
 
 	success := true


### PR DESCRIPTION
This change allows uninstall to make API calls only when needed, specifically for stack buckets and events. Another fix is to uninstall both a `service` and it's rename `resource`.

Also removed `distinctId` that was being passed around but not used.