### PR TITLE
Add process pid to API process/run output

### DIFF
--- a/api/controllers/processes.go
+++ b/api/controllers/processes.go
@@ -116,7 +116,7 @@ func ProcessRunDetached(rw http.ResponseWriter, r *http.Request) *httperr.Error 
 	command := GetForm(r, "command")
 	release := GetForm(r, "release")
 
-	_, err := models.Provider().ProcessRun(app, process, structs.ProcessRunOptions{
+	pid, err := models.Provider().ProcessRun(app, process, structs.ProcessRunOptions{
 		Command: command,
 		Release: release,
 	})
@@ -127,7 +127,10 @@ func ProcessRunDetached(rw http.ResponseWriter, r *http.Request) *httperr.Error 
 		return httperr.Server(err)
 	}
 
-	return RenderSuccess(rw)
+	return RenderJson(rw, structs.ProcessRunBody{
+		Success: true,
+		Pid: pid,
+	})
 }
 
 // ProcessStop stops a Process

--- a/api/controllers/processes_test.go
+++ b/api/controllers/processes_test.go
@@ -132,7 +132,7 @@ func TestProcessRunDetached(t *testing.T) {
 
 		if assert.Nil(t, hf.Request("POST", "/apps/myapp-staging/processes/web/run", v)) {
 			hf.AssertCode(t, 200)
-			hf.AssertJSON(t, `{"success":true}`)
+			hf.AssertJSON(t, `{"Pid":"pid","Success":true}`)
 		}
 	})
 

--- a/api/controllers/processes_test.go
+++ b/api/controllers/processes_test.go
@@ -132,7 +132,7 @@ func TestProcessRunDetached(t *testing.T) {
 
 		if assert.Nil(t, hf.Request("POST", "/apps/myapp-staging/processes/web/run", v)) {
 			hf.AssertCode(t, 200)
-			hf.AssertJSON(t, `{"Pid":"pid","Success":true}`)
+			hf.AssertJSON(t, `{"pid":"pid","success":true}`)
 		}
 	})
 

--- a/api/structs/process.go
+++ b/api/structs/process.go
@@ -45,8 +45,8 @@ type ProcessRunOptions struct {
 
 // ProcessRunBody is the output response
 type ProcessRunBody struct {
-	Success bool
-	Pid     string
+	Success bool    `json:"success"`
+	Pid     string  `json:"pid"`
 }
 
 func (ps Processes) Len() int {

--- a/api/structs/process.go
+++ b/api/structs/process.go
@@ -43,6 +43,12 @@ type ProcessRunOptions struct {
 	Stream  io.ReadWriter
 }
 
+// ProcessRunBody is the output response
+type ProcessRunBody struct {
+	Success bool
+	Pid     string
+}
+
 func (ps Processes) Len() int {
 	return len(ps)
 }


### PR DESCRIPTION
### Description
- This adds support for returning the process id in the API response
- Related #2067 

~~Is there a better way to return the `success` status as the output status `success` vs `Success`?~~
Just updated, using JSON encoding for the struct parsing, allows non-breaking changes to the output case.
I was extending a struct for the object interface for `RenderJson`

This adds the following response to successful HTTP calls to `/apps/<app>/processes/<process>/run`:
```json
{
  "pid": "<process-pid>",
  "success": true
}
```
### Before Release
- [x] Rebase against master
- [ ] Get review approval
- [ ] Confirm test coverage
- [ ] Submit documentation PR for convox/site
