### PR TITLE
remove restrictions from env parser

### DIFF
--- a/api/models/environment_test.go
+++ b/api/models/environment_test.go
@@ -12,37 +12,31 @@ import (
 func TestParseEnvLine(t *testing.T) {
 	tests := []struct {
 		line  string
-		valid bool
 		key   string
 		value string
 	}{
-		{"", true, "", ""},
-		{" ", true, "", ""},
-		{"	 ", true, "", ""},
+		{"", "", ""},
+		{" ", "", ""},
+		{"	 ", "", ""},
 
-		{"#", true, "", ""},
-		{"# ", true, "", ""},
-		{"  #", true, "", ""},
-		{"	 #", true, "", ""},
-		{"# comment", true, "", ""},
+		{"#", "", ""},
+		{"# ", "", ""},
+		{"  #", "", ""},
+		{"	 #", "", ""},
+		{"# comment", "", ""},
 
-		{"An Invalid line", false, "", ""},
+		{"An Invalid line", "", ""},
 
-		{"heroku='likes to put things in single quotes'", true, "heroku", "likes to put things in single quotes"},
+		{"heroku='likes to put things in single quotes'", "heroku", "likes to put things in single quotes"},
 
-		{"K=V", true, "K", "V"},
-		{"Key =value", true, "Key", "value"},
-		{"KEY = 123", true, "KEY", "123"},
-		{"k  =  292929", true, "k", "292929"},
+		{"K=V", "K", "V"},
+		{"Key =value", "Key", "value"},
+		{"KEY = 123", "KEY", "123"},
+		{"k  =  292929", "k", "292929"},
 	}
 
 	for _, tr := range tests {
-		k, v, err := models.ParseEnvLine(tr.line)
-		if tr.valid {
-			assert.NoError(t, err, "env line should be valid format")
-		} else {
-			assert.Error(t, err, "env line should be invalid format")
-		}
+		k, v := models.ParseEnvLine(tr.line)
 
 		assert.Equal(t, tr.key, k, "for parsed env format key=value, invalid key returned")
 		assert.Equal(t, tr.value, v, "for parsed env format key=value, invalid value returned")


### PR DESCRIPTION
### Description
This change removes the strict validation of env var names. There are some existing apps in the wild with environments that do not match the validation and this caused them to be un-updateable.

### Summary for release notes
This removes the restrictions on env var names.

### Guidance for reviewers
The model test still passes. Try to set some tests with dots.

### Before Release
- [ ] Rebase against master
- [ ] Get review approval
- [ ] Confirm test coverage
- [ ] Submit documentation PR for convox/site
