### PR TITLE
avoid DescribeStacks call during event logging

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1860,7 +1860,7 @@
                 {
                   "Effect": "Allow",
                   "Action": [
-                    "cloudformation:DescribeStacks",
+                    "cloudformation:DescribeStackResources",
                     "logs:CreateLogGroup",
                     "logs:CreateLogStream",
                     "logs:PutLogEvents"
@@ -1897,7 +1897,7 @@
                 {
                   "Effect": "Allow",
                   "Action": [
-                    "cloudformation:DescribeStacks",
+                    "cloudformation:DescribeStackResources",
                     "ecs:DescribeServices",
                     "logs:CreateLogGroup",
                     "logs:CreateLogStream",

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1821,6 +1821,11 @@
           "S3Key": { "Fn::Join": [ "", [ "release/", { "Ref": "Version" }, "/lambda/cloudformationevents.zip" ] ] }
         },
         "Description": "Handler for Cloudformation events.",
+        "Environment": {
+          "Variables": {
+            "LOG_GROUP": { "Ref": "LogGroup" }
+          }
+        },
         "Handler": "index.external",
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "CloudformationEventsHandlerRole", "Arn" ] },
@@ -1921,6 +1926,11 @@
           "S3Key": { "Fn::Join": [ "", [ "release/", { "Ref": "Version" }, "/lambda/ecsevents.zip" ] ] }
         },
         "Description": "Handler for ECS events.",
+        "Environment": {
+          "Variables": {
+            "LOG_GROUP": { "Ref": "LogGroup" }
+          }
+        },
         "Handler": "index.external",
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "ECSEventHandlerRole", "Arn" ] },

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1821,11 +1821,6 @@
           "S3Key": { "Fn::Join": [ "", [ "release/", { "Ref": "Version" }, "/lambda/cloudformationevents.zip" ] ] }
         },
         "Description": "Handler for Cloudformation events.",
-        "Environment": {
-          "Variables": {
-            "LOG_GROUP": { "Ref": "LogGroup" }
-          }
-        },
         "Handler": "index.external",
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "CloudformationEventsHandlerRole", "Arn" ] },
@@ -1926,11 +1921,6 @@
           "S3Key": { "Fn::Join": [ "", [ "release/", { "Ref": "Version" }, "/lambda/ecsevents.zip" ] ] }
         },
         "Description": "Handler for ECS events.",
-        "Environment": {
-          "Variables": {
-            "LOG_GROUP": { "Ref": "LogGroup" }
-          }
-        },
         "Handler": "index.external",
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "ECSEventHandlerRole", "Arn" ] },

--- a/provider/aws/lambda/cfevents/main.go
+++ b/provider/aws/lambda/cfevents/main.go
@@ -59,33 +59,8 @@ func handle(r Record) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("m = %+v\n", m)
 
-	resp, err := cf.DescribeStacks(&cloudformation.DescribeStacksInput{
-		StackName: aws.String(m["StackName"]),
-	})
-	if err != nil {
-		return err
-	}
-
-	if len(resp.Stacks) == 0 {
-		return fmt.Errorf("stack not found")
-	}
-
-	stack := resp.Stacks[0]
-
-	var logGroup string
-	for _, output := range stack.Outputs {
-		if *output.OutputKey == "LogGroup" {
-			logGroup = *output.OutputValue
-			break
-		}
-	}
-
-	if logGroup == "" {
-		return fmt.Errorf("log group for %s not found", *stack.StackName)
-	}
-	fmt.Printf("logGroup = %+v\n", logGroup)
+	logGroup := os.Getenv("LOG_GROUP")
 
 	_, err = cwl.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
 		LogGroupName:  aws.String(logGroup),

--- a/provider/aws/lambda/ecsevents/main.go
+++ b/provider/aws/lambda/ecsevents/main.go
@@ -182,31 +182,7 @@ func getServiceEvents(service, cluster string) ([]*ecs.ServiceEvent, error) {
 }
 
 func getLogGroup(stack string) (string, error) {
-	resp, err := CF.DescribeStacks(&cloudformation.DescribeStacksInput{
-		StackName: aws.String(stack),
-	})
-	if err != nil {
-		return "", err
-	}
-
-	if len(resp.Stacks) == 0 {
-		return "", fmt.Errorf("stack not found")
-	}
-
-	s := resp.Stacks[0]
-
-	var logGroup string
-	for _, output := range s.Outputs {
-		if *output.OutputKey == "LogGroup" {
-			logGroup = *output.OutputValue
-			break
-		}
-	}
-
-	if logGroup == "" {
-		return "", fmt.Errorf("log group for %s not found", *s.StackName)
-	}
-	return logGroup, nil
+	return os.Getenv("LOG_GROUP"), nil
 }
 
 func die(err error) {

--- a/provider/aws/lambda/ecsevents/main.go
+++ b/provider/aws/lambda/ecsevents/main.go
@@ -182,7 +182,18 @@ func getServiceEvents(service, cluster string) ([]*ecs.ServiceEvent, error) {
 }
 
 func getLogGroup(stack string) (string, error) {
-	return os.Getenv("LOG_GROUP"), nil
+	res, err := CF.DescribeStackResources(&cloudformation.DescribeStackResourcesInput{
+		StackName:         aws.String(stack),
+		LogicalResourceId: aws.String("LogGroup"),
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(res.StackResources) != 1 {
+		return "", fmt.Errorf("unable to find log group for stack: %s", stack)
+	}
+
+	return *res.StackResources[0].PhysicalResourceId, nil
 }
 
 func die(err error) {


### PR DESCRIPTION
`cloudformation:DescribeStacks` seems to be getting throttled. This change uses `DescribeStackResources` to directly look up the log group for apps.