### PR TITLE
BuildRelease sets last release decrypted env in new release

### DIFF
--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -568,8 +568,12 @@ func (p *AWSProvider) BuildRelease(b *structs.Build) (*structs.Release, error) {
 	r := structs.NewRelease(b.App)
 	newId := r.Id
 
+	// get the last release, including decrypted env not available in ReleaseList
 	if len(releases) > 0 {
-		r = &releases[0]
+		r, err = p.ReleaseGet(b.App, releases[0].Id)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	r.Id = newId


### PR DESCRIPTION
### Description

#2097 introduced a regression where a new build creates a release with an empty environment. This fixes it by getting the decrypted environment.

### Summary for release notes
Briefly explain to other Convox users how this PR impacts them.
Which changes should be noticeable or not noticeable?
Does the scope of the change have side effects?
Any new flags or parameters?

### Guidance for reviewers

- [x] create/deploy an app
- [x] `convox env set FOO=bar --promote`
- [x] see expected env vars in `convox releases info`
- [x] see expected env vars in task definition
- [x] re-deploy the app
- [x] see expected env vars in `convox releases info`
- [x] see expected env vars in task definition

### Before Release
- [ ] Rebase against master
- [ ] Get review approval
- [ ] Confirm test coverage
- [ ] Submit documentation PR for convox/site
