### PR TITLE
fix DescribeInstances throttling

### DIFF
--- a/provider/aws/formation_test.go
+++ b/provider/aws/formation_test.go
@@ -983,7 +983,7 @@ func cycleDescribeStacksNotFound(name string) awsutil.Cycle {
 var cycleNotificationPublish = awsutil.Cycle{
 	Request: awsutil.Request{
 		RequestURI: "/",
-		Body:       `Action=Publish&Message=%7B%22action%22%3A%22release%3Ascale%22%2C%22status%22%3A%22success%22%2C%22data%22%3A%7B%22app%22%3A%22httpd%22%2C%22id%22%3A%22RVFETUHHKKD%22%7D%2C%22timestamp%22%3A%220001-01-01T00%3A00%3A00Z%22%7D&Subject=release%3Ascale&TargetArn=&Version=2010-03-31`,
+		Body:       `Action=Publish&Message=%7B%22action%22%3A%22release%3Ascale%22%2C%22status%22%3A%22success%22%2C%22data%22%3A%7B%22app%22%3A%22httpd%22%2C%22id%22%3A%22RVFETUHHKKD%22%2C%22rack%22%3A%22convox%22%7D%2C%22timestamp%22%3A%220001-01-01T00%3A00%3A00Z%22%7D&Subject=release%3Ascale&TargetArn=&Version=2010-03-31`,
 	},
 	Response: awsutil.Response{
 		StatusCode: 200,

--- a/provider/aws/processes_test.go
+++ b/provider/aws/processes_test.go
@@ -26,12 +26,9 @@ func TestProcessExec(t *testing.T) {
 		cycleProcessDescribeTasksAll,
 		cycleProcessDescribeTaskDefinition1,
 		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
 		cycleProcessDescribeTaskDefinition1,
 		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
+		cycleProcessDescribeRackInstances,
 		cycleProcessListTasksAll,
 		cycleProcessDescribeTasks,
 		cycleProcessDescribeContainerInstances,
@@ -40,12 +37,6 @@ func TestProcessExec(t *testing.T) {
 	defer provider.Close()
 
 	d := stubDocker(
-		cycleProcessDockerListContainers2,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
-		cycleProcessDockerListContainers1,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
 		cycleProcessDockerListContainers1,
 		cycleProcessDockerCreateExec,
 		cycleProcessDockerStartExec,
@@ -75,24 +66,11 @@ func TestProcessList(t *testing.T) {
 		cycleProcessDescribeTasksAll,
 		cycleProcessDescribeTaskDefinition1,
 		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
 		cycleProcessDescribeTaskDefinition2,
 		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
+		cycleProcessDescribeRackInstances,
 	)
 	defer provider.Close()
-
-	d := stubDocker(
-		cycleProcessDockerListContainers2,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
-		cycleProcessDockerListContainers1,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
-	)
-	defer d.Close()
 
 	s, err := provider.ProcessList("myapp")
 
@@ -102,26 +80,26 @@ func TestProcessList(t *testing.T) {
 			App:      "myapp",
 			Name:     "web",
 			Release:  "R1234",
-			Command:  "ls -la",
+			Command:  "",
 			Host:     "10.0.1.244",
 			Image:    "778743527532.dkr.ecr.us-east-1.amazonaws.com/convox-myapp-nkdecwppkq:web.BMPBJLITPZT",
 			Instance: "i-5bc45dc2",
 			Ports:    []string{},
 			CPU:      0,
-			Memory:   0.0974,
+			Memory:   0,
 		},
 		structs.Process{
 			ID:       "5850760f0846",
 			App:      "myapp",
 			Name:     "web",
 			Release:  "R1234",
-			Command:  "ls -la",
+			Command:  "ls -la 'name space'",
 			Host:     "10.0.1.244",
 			Image:    "778743527532.dkr.ecr.us-east-1.amazonaws.com/convox-myapp-nkdecwppkq:web.BMPBJLITPZT",
 			Instance: "i-5bc45dc2",
 			Ports:    []string{},
 			CPU:      0,
-			Memory:   0.0974,
+			Memory:   0,
 		},
 	}
 
@@ -135,24 +113,9 @@ func TestProcessListEmpty(t *testing.T) {
 		cycleProcessListTasksByService1Empty,
 		cycleProcessListTasksByService2Empty,
 		cycleProcessListTasksByStartedEmpty,
-		cycleProcessDescribeTasks,
-		cycleProcessDescribeTaskDefinition1,
-		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeTaskDefinition2,
-		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
+		cycleProcessDescribeRackInstances,
 	)
 	defer provider.Close()
-
-	d := stubDocker(
-		cycleProcessDockerListContainers1,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
-	)
-	defer d.Close()
 
 	s, err := provider.ProcessList("myapp")
 
@@ -171,31 +134,13 @@ func TestProcessListWithBuildCluster(t *testing.T) {
 		cycleProcessDescribeTasksAllOnBuildCluster,
 		cycleProcessDescribeTaskDefinition1,
 		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
 		cycleProcessDescribeTaskDefinition2,
 		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
 		cycleProcessDescribeTaskDefinition2,
 		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
+		cycleProcessDescribeRackInstances,
 	)
 	defer provider.Close()
-
-	d := stubDocker(
-		cycleProcessDockerListContainers2,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
-		cycleProcessDockerListContainers1,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
-		cycleProcessDockerListContainers3,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
-	)
-	defer d.Close()
 
 	provider.BuildCluster = "cluster-build"
 
@@ -207,39 +152,39 @@ func TestProcessListWithBuildCluster(t *testing.T) {
 			App:      "myapp",
 			Name:     "web",
 			Release:  "R1234",
-			Command:  "ls -la",
+			Command:  "",
 			Host:     "10.0.1.244",
 			Image:    "778743527532.dkr.ecr.us-east-1.amazonaws.com/convox-myapp-nkdecwppkq:web.BMPBJLITPZT",
 			Instance: "i-5bc45dc2",
 			Ports:    []string{},
 			CPU:      0,
-			Memory:   0.0974,
+			Memory:   0,
 		},
 		structs.Process{
 			ID:       "5850760f0846",
 			App:      "myapp",
 			Name:     "web",
 			Release:  "R1234",
-			Command:  "ls -la",
+			Command:  "ls -la 'name space'",
 			Host:     "10.0.1.244",
 			Image:    "778743527532.dkr.ecr.us-east-1.amazonaws.com/convox-myapp-nkdecwppkq:web.BMPBJLITPZT",
 			Instance: "i-5bc45dc2",
 			Ports:    []string{},
 			CPU:      0,
-			Memory:   0.0974,
+			Memory:   0,
 		},
 		structs.Process{
 			ID:       "5850760f0848",
 			App:      "myapp",
 			Name:     "web",
 			Release:  "R1234",
-			Command:  "ls -la",
+			Command:  "",
 			Host:     "10.0.1.244",
 			Image:    "778743527532.dkr.ecr.us-east-1.amazonaws.com/convox-myapp-nkdecwppkq:web.BMPBJLITPZT",
 			Instance: "i-5bc45dc2",
 			Ports:    []string{},
 			CPU:      0,
-			Memory:   0.0974,
+			Memory:   0,
 		},
 	}
 
@@ -268,12 +213,9 @@ func TestProcessRunAttached(t *testing.T) {
 		cycleProcessDescribeTasksAll,
 		cycleProcessDescribeTaskDefinition1,
 		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
 		cycleProcessDescribeTaskDefinition1,
 		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessDescribeInstances,
+		cycleProcessDescribeRackInstances,
 		cycleProcessListTasksAll,
 		cycleProcessDescribeTasks,
 		cycleProcessDescribeContainerInstances,
@@ -283,12 +225,6 @@ func TestProcessRunAttached(t *testing.T) {
 	defer provider.Close()
 
 	d := stubDocker(
-		cycleProcessDockerListContainers2,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
-		cycleProcessDockerListContainers1,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
 		cycleProcessDockerListContainers1,
 		cycleProcessDockerCreateExec,
 		cycleProcessDockerStartExec,
@@ -381,6 +317,35 @@ var cycleProcessDescribeInstances = awsutil.Cycle{
 		RequestURI: "/",
 		Operation:  "",
 		Body:       `Action=DescribeInstances&InstanceId.1=i-5bc45dc2&Version=2016-11-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `
+			<?xml version="1.0" encoding="UTF-8"?>
+			<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+				<reservationSet>
+					<item>
+						<reservationId>r-003ed1d7</reservationId>
+						<ownerId>778743527532</ownerId>
+						<groupSet/>
+						<instancesSet>
+							<item>
+								<instanceId>i-5bc45dc2</instanceId>
+								<privateIpAddress>10.0.1.244</privateIpAddress>
+							</item>
+						</instancesSet>
+					</item>
+				</reservationSet>
+			</DescribeInstancesRepsonse>
+		}`,
+	},
+}
+
+var cycleProcessDescribeRackInstances = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Operation:  "",
+		Body:       `Action=DescribeInstances&Filter.1.Name=tag%3ARack&Filter.1.Value.1=convox&Version=2016-11-15`,
 	},
 	Response: awsutil.Response{
 		StatusCode: 200,
@@ -781,6 +746,7 @@ var cycleProcessDescribeTaskDefinition1 = awsutil.Cycle{
 				"taskDefinitionArn": "arn:aws:ecs:us-east-1:778743527532:task-definition/convox-myapp-web:34",
 				"containerDefinitions": [
 					{
+						"command": [ "ls", "-la", "name space" ],
 						"environment": [
 							{
 								"name": "RELEASE",

--- a/provider/aws/system_test.go
+++ b/provider/aws/system_test.go
@@ -151,19 +151,11 @@ func TestSystemProcessesList(t *testing.T) {
 		cycleSystemDescribeTasks,
 		cycleSystemDescribeTaskDefinition,
 		cycleSystemDescribeContainerInstances,
-		cycleSystemDescribeInstances,
-		cycleSystemDescribeInstances,
+		cycleSystemDescribeRackInstances,
 		cycleSystemDescribeTaskDefinition2,
 		cycleSystemDescribeContainerInstances,
 	)
 	defer provider.Close()
-
-	d := stubDocker(
-		cycleSystemDockerListContainers2,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
-	)
-	defer d.Close()
 
 	_, err := provider.SystemProcesses(structs.SystemProcessesOptions{
 		All: false,
@@ -178,19 +170,11 @@ func TestSystemProcessesListAll(t *testing.T) {
 		cycleSystemDescribeTasks,
 		cycleSystemDescribeTaskDefinition,
 		cycleSystemDescribeContainerInstances,
-		cycleSystemDescribeInstances,
-		cycleSystemDescribeInstances,
+		cycleSystemDescribeRackInstances,
 		cycleSystemDescribeTaskDefinition2,
 		cycleSystemDescribeContainerInstances,
 	)
 	defer provider.Close()
-
-	d := stubDocker(
-		cycleSystemDockerListContainers2,
-		cycleProcessDockerInspect,
-		cycleProcessDockerStats,
-	)
-	defer d.Close()
 
 	_, err := provider.SystemProcesses(structs.SystemProcessesOptions{
 		All: true,
@@ -899,11 +883,11 @@ var cycleSystemDescribeContainerInstances = awsutil.Cycle{
 	},
 }
 
-var cycleSystemDescribeInstances = awsutil.Cycle{
+var cycleSystemDescribeRackInstances = awsutil.Cycle{
 	Request: awsutil.Request{
 		RequestURI: "/",
 		Operation:  "",
-		Body:       `Action=DescribeInstances&InstanceId.1=i-5bc45dc2&Version=2016-11-15`,
+		Body:       `Action=DescribeInstances&Filter.1.Name=tag%3ARack&Filter.1.Value.1=convox&Version=2016-11-15`,
 	},
 	Response: awsutil.Response{
 		StatusCode: 200,

--- a/vendor/github.com/kballard/go-shellquote/LICENSE
+++ b/vendor/github.com/kballard/go-shellquote/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2014 Kevin Ballard
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/kballard/go-shellquote/README
+++ b/vendor/github.com/kballard/go-shellquote/README
@@ -1,0 +1,36 @@
+PACKAGE
+
+package shellquote
+    import "github.com/kballard/go-shellquote"
+
+    Shellquote provides utilities for joining/splitting strings using sh's
+    word-splitting rules.
+
+VARIABLES
+
+var (
+    UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+    UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+    UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
+)
+
+
+FUNCTIONS
+
+func Join(args ...string) string
+    Join quotes each argument and joins them with a space. If passed to
+    /bin/sh, the resulting string will be split back into the original
+    arguments.
+
+func Split(input string) (words []string, err error)
+    Split splits a string according to /bin/sh's word-splitting rules. It
+    supports backslash-escapes, single-quotes, and double-quotes. Notably it
+    does not support the $'' style of quoting. It also doesn't attempt to
+    perform any other sort of expansion, including brace expansion, shell
+    expansion, or pathname expansion.
+
+    If the given input has an unterminated quoted string or ends in a
+    backslash-escape, one of UnterminatedSingleQuoteError,
+    UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+
+

--- a/vendor/github.com/kballard/go-shellquote/doc.go
+++ b/vendor/github.com/kballard/go-shellquote/doc.go
@@ -1,0 +1,3 @@
+// Shellquote provides utilities for joining/splitting strings using sh's
+// word-splitting rules.
+package shellquote

--- a/vendor/github.com/kballard/go-shellquote/quote.go
+++ b/vendor/github.com/kballard/go-shellquote/quote.go
@@ -1,0 +1,102 @@
+package shellquote
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+)
+
+// Join quotes each argument and joins them with a space.
+// If passed to /bin/sh, the resulting string will be split back into the
+// original arguments.
+func Join(args ...string) string {
+	var buf bytes.Buffer
+	for i, arg := range args {
+		if i != 0 {
+			buf.WriteByte(' ')
+		}
+		quote(arg, &buf)
+	}
+	return buf.String()
+}
+
+const (
+	specialChars      = "\\'\"`${[|&;<>()*?!"
+	extraSpecialChars = " \t\n"
+	prefixChars       = "~"
+)
+
+func quote(word string, buf *bytes.Buffer) {
+	// We want to try to produce a "nice" output. As such, we will
+	// backslash-escape most characters, but if we encounter a space, or if we
+	// encounter an extra-special char (which doesn't work with
+	// backslash-escaping) we switch over to quoting the whole word. We do this
+	// with a space because it's typically easier for people to read multi-word
+	// arguments when quoted with a space rather than with ugly backslashes
+	// everywhere.
+	origLen := buf.Len()
+
+	if len(word) == 0 {
+		// oops, no content
+		buf.WriteString("''")
+		return
+	}
+
+	cur, prev := word, word
+	atStart := true
+	for len(cur) > 0 {
+		c, l := utf8.DecodeRuneInString(cur)
+		cur = cur[l:]
+		if strings.ContainsRune(specialChars, c) || (atStart && strings.ContainsRune(prefixChars, c)) {
+			// copy the non-special chars up to this point
+			if len(cur) < len(prev) {
+				buf.WriteString(prev[0 : len(prev)-len(cur)-l])
+			}
+			buf.WriteByte('\\')
+			buf.WriteRune(c)
+			prev = cur
+		} else if strings.ContainsRune(extraSpecialChars, c) {
+			// start over in quote mode
+			buf.Truncate(origLen)
+			goto quote
+		}
+		atStart = false
+	}
+	if len(prev) > 0 {
+		buf.WriteString(prev)
+	}
+	return
+
+quote:
+	// quote mode
+	// Use single-quotes, but if we find a single-quote in the word, we need
+	// to terminate the string, emit an escaped quote, and start the string up
+	// again
+	inQuote := false
+	for len(word) > 0 {
+		i := strings.IndexRune(word, '\'')
+		if i == -1 {
+			break
+		}
+		if i > 0 {
+			if !inQuote {
+				buf.WriteByte('\'')
+				inQuote = true
+			}
+			buf.WriteString(word[0:i])
+			word = word[i+1:]
+		}
+		if inQuote {
+			buf.WriteByte('\'')
+			inQuote = false
+		}
+		buf.WriteString("\\'")
+	}
+	if len(word) > 0 {
+		if !inQuote {
+			buf.WriteByte('\'')
+		}
+		buf.WriteString(word)
+		buf.WriteByte('\'')
+	}
+}

--- a/vendor/github.com/kballard/go-shellquote/unquote.go
+++ b/vendor/github.com/kballard/go-shellquote/unquote.go
@@ -1,0 +1,144 @@
+package shellquote
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+	UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+	UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
+)
+
+var (
+	splitChars        = " \n\t"
+	singleChar        = '\''
+	doubleChar        = '"'
+	escapeChar        = '\\'
+	doubleEscapeChars = "$`\"\n\\"
+)
+
+// Split splits a string according to /bin/sh's word-splitting rules. It
+// supports backslash-escapes, single-quotes, and double-quotes. Notably it does
+// not support the $'' style of quoting. It also doesn't attempt to perform any
+// other sort of expansion, including brace expansion, shell expansion, or
+// pathname expansion.
+//
+// If the given input has an unterminated quoted string or ends in a
+// backslash-escape, one of UnterminatedSingleQuoteError,
+// UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+func Split(input string) (words []string, err error) {
+	var buf bytes.Buffer
+	words = make([]string, 0)
+
+	for len(input) > 0 {
+		// skip any splitChars at the start
+		c, l := utf8.DecodeRuneInString(input)
+		if strings.ContainsRune(splitChars, c) {
+			input = input[l:]
+			continue
+		}
+
+		var word string
+		word, input, err = splitWord(input, &buf)
+		if err != nil {
+			return
+		}
+		words = append(words, word)
+	}
+	return
+}
+
+func splitWord(input string, buf *bytes.Buffer) (word string, remainder string, err error) {
+	buf.Reset()
+
+raw:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == singleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto single
+			} else if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto double
+			} else if c == escapeChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto escape
+			} else if strings.ContainsRune(splitChars, c) {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				return buf.String(), cur, nil
+			}
+		}
+		if len(input) > 0 {
+			buf.WriteString(input)
+			input = ""
+		}
+		goto done
+	}
+
+escape:
+	{
+		if len(input) == 0 {
+			return "", "", UnterminatedEscapeError
+		}
+		c, l := utf8.DecodeRuneInString(input)
+		if c == '\n' {
+			// a backslash-escaped newline is elided from the output entirely
+		} else {
+			buf.WriteString(input[:l])
+		}
+		input = input[l:]
+	}
+	goto raw
+
+single:
+	{
+		i := strings.IndexRune(input, singleChar)
+		if i == -1 {
+			return "", "", UnterminatedSingleQuoteError
+		}
+		buf.WriteString(input[0:i])
+		input = input[i+1:]
+		goto raw
+	}
+
+double:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto raw
+			} else if c == escapeChar {
+				// bash only supports certain escapes in double-quoted strings
+				c2, l2 := utf8.DecodeRuneInString(cur)
+				cur = cur[l2:]
+				if strings.ContainsRune(doubleEscapeChars, c2) {
+					buf.WriteString(input[0 : len(input)-len(cur)-l-l2])
+					if c2 == '\n' {
+						// newline is special, skip the backslash entirely
+					} else {
+						buf.WriteRune(c2)
+					}
+					input = cur
+				}
+			}
+		}
+		return "", "", UnterminatedDoubleQuoteError
+	}
+
+done:
+	return buf.String(), input, nil
+}


### PR DESCRIPTION
this fixes throttling in the presence of large numbers of containers/instances

process-level stats are temporarily disabled

the `Command` attribute of the process will only be set if there is a custom override (`command:` in the manifest)