### PR TITLE
policy permission fix and rack log group

### DIFF
--- a/api/models/helpers.go
+++ b/api/models/helpers.go
@@ -342,13 +342,18 @@ func stackResource(stack, resource string) (string, error) {
 	return *res.StackResources[0].PhysicalResourceId, nil
 }
 
-// AppLogGroup returns the cloudwatch log group for an app
-func AppLogGroup(app string) (string, error) {
+// StackLogGroup returns the cloudwatch log group for an app or rack
+func StackLogGroup(app string) (string, error) {
 	if g, ok := cache.Get("appLogGroup", app).(string); ok {
 		return g, nil
 	}
 
-	g, err := stackResource(fmt.Sprintf("%s-%s", os.Getenv("RACK"), app), "LogGroup")
+	stackName := os.Getenv("RACK")
+	if app != stackName {
+		stackName = fmt.Sprintf("%s-%s", os.Getenv("RACK"), app)
+	}
+
+	g, err := stackResource(stackName, "LogGroup")
 	if err != nil {
 		return "", err
 	}

--- a/api/workers/events.go
+++ b/api/workers/events.go
@@ -129,8 +129,6 @@ func handleAccountEvents() {
 	err := processQueue("AccountEvents", func(body string) error {
 		var e event
 
-		// fmt.Printf("body = %+v\n", body)
-
 		if err := json.Unmarshal([]byte(body), &e); err != nil {
 			return err
 		}
@@ -147,8 +145,6 @@ func handleAccountEvents() {
 				return nil
 			}
 
-			// fmt.Printf("%s: %s\n", detail.TaskArn, detail.LastStatus)
-
 			parts := strings.Split(detail.ClusterArn, "/")
 			cluster := parts[len(parts)-1]
 			service := strings.TrimPrefix(detail.Group, "service:")
@@ -162,6 +158,7 @@ func handleAccountEvents() {
 				if err != nil {
 					return err
 				}
+
 				if len(res.Services) < 1 {
 					return fmt.Errorf("could not find service: %s", service)
 				}
@@ -221,7 +218,7 @@ func handleAccountEvents() {
 }
 
 func getAppLogStream(app string) (appLogStream, error) {
-	group, err := models.AppLogGroup(app)
+	group, err := models.StackLogGroup(app)
 	if err != nil {
 		return appLogStream{}, err
 	}

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1861,7 +1861,7 @@
     "CloudformationEventsPolicy": {
       "Type": "AWS::SQS::QueuePolicy",
       "Properties": {
-        "Queues": [ { "Ref": "AccountEvents" } ],
+        "Queues": [ { "Ref": "CloudformationEvents" } ],
         "PolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [
@@ -1869,7 +1869,7 @@
               "Effect": "Allow",
               "Principal": { "AWS": "*" },
               "Action": "sqs:SendMessage",
-              "Resource": { "Fn::GetAtt": [ "AccountEvents", "Arn" ] },
+              "Resource": { "Fn::GetAtt": [ "CloudformationEvents", "Arn" ] },
               "Condition": { "ArnEquals": { "aws:SourceArn": { "Ref": "CloudformationTopic" } } }
             }
           ]


### PR DESCRIPTION
Fixes an issue with the sqs policy. Also fix the stack name when looking for a log group of a rack or app. With a rack name `staging`, it would look for a stack named `staging-staging`.