### PR TITLE
[Bug Fix] Return correct status code on app create

### DIFF
--- a/cmd/convox/apps.go
+++ b/cmd/convox/apps.go
@@ -155,7 +155,7 @@ func cmdAppCreate(c *cli.Context) error {
 		stdcli.Startf("Waiting for <app>%s</app>", app)
 
 		if err := waitForAppRunning(c, app); err != nil {
-			stdcli.Error(err)
+			return stdcli.Error(err)
 		}
 
 		stdcli.OK()


### PR DESCRIPTION
### Description
Should solve issue #2158 
Seems the wrong status code was returned on a failure of the convox app create command.

### Summary for release notes
BugFix - should return an error exit code when convox app create fails, in certain circumstances it would have still been reported with an exit status of 0 even though there was a failure with the Cloud Formation stack deployment.

### Before Release
- [ ] Get review approval
