### PR TITLE
Update Submodules when building from git

### DIFF
--- a/api/cmd/build/source/git.go
+++ b/api/cmd/build/source/git.go
@@ -48,18 +48,8 @@ func (s *SourceGit) Fetch(out io.Writer) (string, error) {
 		repo = r
 	}
 
-	cmd := exec.Command("git", "clone", "-b", ref, repo, tmp)
+	cmd := exec.Command("git", "clone", "--recursive", "-b", ref, repo, tmp)
 
-	cmd.Stdout = out
-	cmd.Stderr = out
-
-	if err := cmd.Run(); err != nil {
-		return "", err
-	}
-
-	cmd = exec.Command("git", "submodule", "update", "--init", "--recursive")
-
-	cmd.Dir = tmp
 	cmd.Stdout = out
 	cmd.Stderr = out
 

--- a/api/cmd/build/source/git.go
+++ b/api/cmd/build/source/git.go
@@ -57,6 +57,16 @@ func (s *SourceGit) Fetch(out io.Writer) (string, error) {
 		return "", err
 	}
 
+	cmd = exec.Command("git", "submodule", "update", "--recursive")
+
+	cmd.Dir = tmp
+	cmd.Stdout = out
+	cmd.Stderr = out
+
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
 	return tmp, nil
 }
 

--- a/api/cmd/build/source/git.go
+++ b/api/cmd/build/source/git.go
@@ -57,7 +57,7 @@ func (s *SourceGit) Fetch(out io.Writer) (string, error) {
 		return "", err
 	}
 
-	cmd = exec.Command("git", "submodule", "update", "--recursive")
+	cmd = exec.Command("git", "submodule", "update", "--init", "--recursive")
 
 	cmd.Dir = tmp
 	cmd.Stdout = out


### PR DESCRIPTION
### Description

When an app is built from a .git URL like this:

`convox build https://github.com/org/repo.git`

submodules will be updated after the clone. This is accomplished by the builder running:

`git submodule update --init --recursive`

### Summary for release notes

See description.

### Guidance for reviewers

See https://github.com/mattmanning/httpd for a test app.

### Before Release
- [ ] Rebase against master
- [ ] Get review approval
- [ ] Confirm test coverage
- [ ] Submit documentation PR for convox/site
