### PR TITLE
limit account events to specified resources

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1879,8 +1879,20 @@
     "AccountEventsRule": {
       "Type" : "AWS::Events::Rule",
       "Properties" : {
+        "Description" : "Specified event changes",
         "EventPattern" : {
-          "account":  [ { "Ref": "AWS::AccountId" } ]
+          "account":  [ { "Ref": "AWS::AccountId" } ],
+          "source": [
+            "aws.ecs"
+          ],
+          "detail-type": [
+            "ECS Task State Change"
+          ],
+          "detail": {
+            "clusterArn": [
+              { "Fn::Sub": "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${Cluster}" }
+            ]
+          }
         },
         "State" : "ENABLED",
         "Targets" : [


### PR DESCRIPTION
### Description
Limiting account events to ECS only. 

### Summary for release notes
Interest of further limiting API throttling, this update limits the CloudWatch Event rule to only ECS events. In the future, specific events can be added when needed. 

Unfortunately `eu-west-2` does not support ECS events, so the region will lose the ability to view ECS events in app logs for the time being.

### Guidance for reviewers
`convox logs --filter=ECS` should work as it did before

### Before Release
- [x] Rebase against master
- [ ] Get review approval
- [ ] Confirm test coverage
- [ ] Submit documentation PR for convox/site
