### PR TITLE
remove single quotes from env vars

### DIFF
--- a/api/models/environment.go
+++ b/api/models/environment.go
@@ -225,7 +225,7 @@ func ParseEnvLine(line string) (string, string) {
 	}
 
 	// strip leading/trailing ' only if both exist
-	if v[0] == '\'' && v[len(v)-1] == '\'' {
+	if len(v) > 1 && v[0] == '\'' && v[len(v)-1] == '\'' {
 		v = strings.Trim(v, "'")
 	}
 

--- a/api/models/environment.go
+++ b/api/models/environment.go
@@ -224,8 +224,10 @@ func ParseEnvLine(line string) (string, string) {
 		return "", ""
 	}
 
-	// strip leading/trailing ' if they exist
-	v = strings.Trim(v, "'")
+	// strip leading/trailing ' only if both exist
+	if v[0] == '\'' && v[len(v)-1] == '\'' {
+		v = strings.Trim(v, "'")
+	}
 
 	return k, v
 }

--- a/api/models/environment_test.go
+++ b/api/models/environment_test.go
@@ -30,8 +30,10 @@ func TestParseEnvLine(t *testing.T) {
 		{"heroku='likes to put things in single quotes'", "heroku", "likes to put things in single quotes"},
 		{"leading='leading quote is kept", "leading", "'leading quote is kept"},
 		{"trailing=single quote at the end'", "trailing", "single quote at the end'"},
+		{"K='", "K", "'"},
 
 		{"K=V", "K", "V"},
+		{"K=", "K", ""},
 		{"Key =value", "Key", "value"},
 		{"KEY = 123", "KEY", "123"},
 		{"k  =  292929", "k", "292929"},

--- a/api/models/environment_test.go
+++ b/api/models/environment_test.go
@@ -28,6 +28,8 @@ func TestParseEnvLine(t *testing.T) {
 		{"An Invalid line", "", ""},
 
 		{"heroku='likes to put things in single quotes'", "heroku", "likes to put things in single quotes"},
+		{"leading='leading quote is kept", "leading", "'leading quote is kept"},
+		{"trailing=single quote at the end'", "trailing", "single quote at the end'"},
 
 		{"K=V", "K", "V"},
 		{"Key =value", "Key", "value"},


### PR DESCRIPTION
### Description
Remove single quotes from env vars only if value has a leading/trailing quote. 

Fixes #2172


### Summary for release notes
See description

### Guidance for reviewers
Environment variables with leading/trailing single quotes will have them removed. If it's just leading or trailing quote, it will be kept.

### Before Release
- [ ] Rebase against master
- [ ] Get review approval
- [ ] Confirm test coverage
- [ ] Submit documentation PR for convox/site
