### PR TITLE
only start a service and its dependencies when specified to convox start

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -284,7 +284,7 @@ func (m *Manifest) runOrder(target string) (Services, error) {
 	// Make a map of service names to services
 	serviceMap := make(map[string]Service, 0)
 
-	// Sort the service nams alphabetically
+	// Sort the service names alphabetically
 	sortedNames := make([]string, 0, len(m.Services))
 	for key := range m.Services {
 		sortedNames = append(sortedNames, key)


### PR DESCRIPTION
`convox start` will start all services

`convox start <service-foo>` will start only `service-foo` and its dependencies.

This fixes a bug where all services were started even when `convox start <service-foo>`.