### PR TITLE
newline after error msg

### DIFF
--- a/cmd/convox/apps.go
+++ b/cmd/convox/apps.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/convox/rack/cmd/convox/stdcli"
-	"gopkg.in/urfave/cli.v1"
 )
 
 func init() {
@@ -86,7 +85,7 @@ func cmdApps(c *cli.Context) error {
 	}
 
 	if len(apps) == 0 {
-		stdcli.Writef("no apps found, try creating one via `convox apps create`")
+		stdcli.Writef("no apps found, try creating one via `convox apps create`\n")
 		return nil
 	}
 

--- a/cmd/convox/apps.go
+++ b/cmd/convox/apps.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	cli "gopkg.in/urfave/cli.v1"
+
 	"github.com/convox/rack/cmd/convox/stdcli"
 )
 

--- a/cmd/convox/apps_test.go
+++ b/cmd/convox/apps_test.go
@@ -36,7 +36,7 @@ func TestAppsNoAppsFound(t *testing.T) {
 		test.ExecRun{
 			Command: "convox apps",
 			Exit:    0,
-			Stdout:  "no apps found, try creating one via `convox apps create`",
+			Stdout:  "no apps found, try creating one via `convox apps create`\n",
 		},
 	)
 }


### PR DESCRIPTION
The missing newline causes this output on a new rack:

```
$ convox apps
no apps found, try creating one via `convox apps create`Chappie:~ noah (personal/dev)$ convox apps create foo
```