### PR TITLE
ECS Throttling

### DIFF
--- a/api/models/docker.go
+++ b/api/models/docker.go
@@ -9,14 +9,12 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecr"
-	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/convox/rack/api/structs"
 	"github.com/fsouza/go-dockerclient"
 )
@@ -154,74 +152,6 @@ func AppDockerLogin(app structs.App) (string, error) {
 		ServerAddress: fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", app.Outputs["RegistryId"], os.Getenv("AWS_REGION")),
 		Username:      os.Getenv("AWS_ACCESS"),
 	})
-}
-
-func PullAppImages() {
-	log := Logger.At("PullAppImages").Start()
-
-	if os.Getenv("DEVELOPMENT") == "true" {
-		return
-	}
-
-	maxRetries := 5
-
-	apps, err := ListApps()
-
-	if err != nil {
-		log.Step("ListApps").Error(err)
-		return
-	}
-
-	for _, app := range apps {
-		a, err := Provider().AppGet(app.Name)
-		if err != nil {
-			log.Step("GetApp").Error(err)
-			continue
-		}
-
-		// retry login a few times in case v1 registry is not yet available
-		for i := 0; i < maxRetries; i++ {
-			_, err = AppDockerLogin(*a)
-
-			if err == nil {
-				break
-			}
-
-			log.Step("AppDockerLogin").Error(err)
-			time.Sleep(30 * time.Second)
-		}
-
-		resources, err := ListResources(a.Name)
-		if err != nil {
-			log.Step("Resources").Error(err)
-		}
-
-		for key, r := range resources {
-			if strings.HasSuffix(key, "TaskDefinition") {
-				td, err := ECS().DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
-					TaskDefinition: aws.String(r.Id),
-				})
-
-				if err != nil {
-					log.Step("DescribeTaskDefinition").Error(err)
-					continue
-				}
-
-				for _, cd := range td.TaskDefinition.ContainerDefinitions {
-					log = log.Namespace("image=%q", *cd.Image).Step("Pull")
-					_, err := exec.Command("docker", "pull", *cd.Image).CombinedOutput()
-
-					if err != nil {
-						log.Error(err)
-						fmt.Printf("ns=kernel cn=docker fn=PullAppImages at=exec.Command cmd=%q err=%q\n", fmt.Sprintf("docker pull %s", *cd.Image), err.Error())
-						continue
-					}
-
-					log.Success()
-				}
-			}
-		}
-	}
 }
 
 func GetPrivateRegistriesAuth() (Environment, docker.AuthConfigurations119, error) {

--- a/provider/aws/capacity.go
+++ b/provider/aws/capacity.go
@@ -128,7 +128,7 @@ func (p *AWSProvider) clusterServices() (ECSServices, error) {
 			return nil, err
 		}
 
-		dres, err := p.ecs().DescribeServices(&ecs.DescribeServicesInput{
+		dres, err := p.describeServices(&ecs.DescribeServicesInput{
 			Cluster:  aws.String(p.Cluster),
 			Services: lres.ServiceArns,
 		})

--- a/provider/aws/capacity.go
+++ b/provider/aws/capacity.go
@@ -48,7 +48,9 @@ func (p *AWSProvider) CapacityGet() (*structs.Capacity, error) {
 	for _, service := range services {
 		if len(service.LoadBalancers) > 0 {
 			for _, deployment := range service.Deployments {
-				td, err := p.describeTaskDefinition(*deployment.TaskDefinition)
+				res, err := p.describeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+					TaskDefinition: deployment.TaskDefinition,
+				})
 				if err != nil {
 					log.Error(err)
 					return nil, err
@@ -56,7 +58,7 @@ func (p *AWSProvider) CapacityGet() (*structs.Capacity, error) {
 
 				tdPorts := map[string]int64{}
 
-				for _, cd := range td.ContainerDefinitions {
+				for _, cd := range res.TaskDefinition.ContainerDefinitions {
 					for _, pm := range cd.PortMappings {
 						tdPorts[fmt.Sprintf("%s.%d", *cd.Name, *pm.ContainerPort)] = *pm.HostPort
 					}
@@ -70,7 +72,7 @@ func (p *AWSProvider) CapacityGet() (*structs.Capacity, error) {
 			}
 		}
 
-		res, err := p.ecs().DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		res, err := p.describeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 			TaskDefinition: service.TaskDefinition,
 		})
 		if err != nil {

--- a/provider/aws/capacity.go
+++ b/provider/aws/capacity.go
@@ -14,7 +14,7 @@ func (p *AWSProvider) CapacityGet() (*structs.Capacity, error) {
 
 	capacity := &structs.Capacity{}
 
-	ires, err := p.describeContainerInstances()
+	ires, err := p.listAndDescribeContainerInstances()
 	if err != nil {
 		log.Error(err)
 		return nil, err

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -499,6 +499,28 @@ func (p *AWSProvider) describeTaskDefinition(name string) (*ecs.TaskDefinition, 
 	return td, nil
 }
 
+func (p *AWSProvider) describeTasks(input *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
+	res, ok := cache.Get("describeTasks", input).(*ecs.DescribeTasksOutput)
+
+	if ok {
+		return res, nil
+	}
+
+	res, err := p.ecs().DescribeTasks(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !p.SkipCache {
+		if err := cache.Set("describeTasks", input, res, 10*time.Second); err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
+}
+
 func (p *AWSProvider) listContainerInstances(input *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error) {
 	res, ok := cache.Get("listContainerInstances", input).(*ecs.ListContainerInstancesOutput)
 

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -344,6 +344,28 @@ func (p *AWSProvider) dynamoBatchDeleteItems(wrs []*dynamodb.WriteRequest, table
 	return nil
 }
 
+func (p *AWSProvider) describeContainerInstances(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error) {
+	res, ok := cache.Get("describeContainerInstances", input).(*ecs.DescribeContainerInstancesOutput)
+
+	if ok {
+		return res, nil
+	}
+
+	res, err := p.ecs().DescribeContainerInstances(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !p.SkipCache {
+		if err := cache.Set("describeContainerInstances", input, res, 5*time.Second); err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
+}
+
 func (p *AWSProvider) describeServices(input *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error) {
 	res, ok := cache.Get("describeServices", input.Services).(*ecs.DescribeServicesOutput)
 

--- a/provider/aws/instances.go
+++ b/provider/aws/instances.go
@@ -142,7 +142,7 @@ func (p *AWSProvider) listAndDescribeContainerInstances() (*ecs.DescribeContaine
 			return nil, err
 		}
 
-		dres, err := p.ecs().DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+		dres, err := p.describeContainerInstances(&ecs.DescribeContainerInstancesInput{
 			Cluster:            aws.String(p.Cluster),
 			ContainerInstances: res.ContainerInstanceArns,
 		})

--- a/provider/aws/instances.go
+++ b/provider/aws/instances.go
@@ -42,7 +42,7 @@ func (p *AWSProvider) InstanceList() (structs.Instances, error) {
 		return nil, err
 	}
 
-	cis, err := p.describeContainerInstances()
+	cis, err := p.listAndDescribeContainerInstances()
 	if err != nil {
 		return nil, err
 	}
@@ -124,9 +124,9 @@ func (p *AWSProvider) InstanceTerminate(id string) error {
 	return nil
 }
 
-// describeContainerInstances lists and describes all the ECS instances.
+// listAndDescribeContainerInstances lists and describes all the ECS instances.
 // It handles pagination for clusters > 100 instances.
-func (p *AWSProvider) describeContainerInstances() (*ecs.DescribeContainerInstancesOutput, error) {
+func (p *AWSProvider) listAndDescribeContainerInstances() (*ecs.DescribeContainerInstancesOutput, error) {
 	instances := []*ecs.ContainerInstance{}
 	var nextToken string
 

--- a/provider/aws/logs.go
+++ b/provider/aws/logs.go
@@ -154,7 +154,7 @@ func (p *AWSProvider) writeLogEvents(w io.Writer, events []*cloudwatchlogs.Filte
 				// if task definition has never been seen, get its RELEASE env var
 				if tdARN, ok := taskDefinitions[taskID]; ok {
 					if _, ok := releases[tdARN]; !ok {
-						td, err := p.ecs().DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+						td, err := p.describeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 							TaskDefinition: aws.String(tdARN),
 						})
 						if err != nil {

--- a/provider/aws/logs.go
+++ b/provider/aws/logs.go
@@ -138,7 +138,7 @@ func (p *AWSProvider) writeLogEvents(w io.Writer, events []*cloudwatchlogs.Filte
 
 				// if task has never been seen, get its task definition
 				if _, ok := taskDefinitions[taskID]; !ok {
-					t, err := p.ecs().DescribeTasks(&ecs.DescribeTasksInput{
+					t, err := p.describeTasks(&ecs.DescribeTasksInput{
 						Cluster: aws.String(os.Getenv("CLUSTER")),
 						Tasks:   []*string{aws.String(taskID)},
 					})

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -487,7 +487,7 @@ func (p *AWSProvider) containerDefinitionForTask(arn string) (*ecs.ContainerDefi
 		return cd, nil
 	}
 
-	res, err := p.ecs().DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+	res, err := p.describeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(arn),
 	})
 	if err != nil {
@@ -737,7 +737,7 @@ func (p *AWSProvider) generateTaskDefinition(app, process, release string) (*ecs
 		return nil, fmt.Errorf("could not look up service for process: %s", process)
 	}
 
-	tres, err := p.ecs().DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+	tres, err := p.describeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: sres.Services[0].TaskDefinition,
 	})
 	if err != nil {

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -726,7 +726,7 @@ func (p *AWSProvider) generateTaskDefinition(app, process, release string) (*ecs
 		return nil, fmt.Errorf("could not find service for process: %s", process)
 	}
 
-	sres, err := p.ecs().DescribeServices(&ecs.DescribeServicesInput{
+	sres, err := p.describeServices(&ecs.DescribeServicesInput{
 		Cluster:  aws.String(p.Cluster),
 		Services: []*string{aws.String(sarn)},
 	})

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -64,7 +64,7 @@ func (p *AWSProvider) ProcessExec(app, pid, command string, stream io.ReadWriter
 		return log.Errorf("no running container for process: %s", pid)
 	}
 
-	cires, err := p.ecs().DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+	cires, err := p.describeContainerInstances(&ecs.DescribeContainerInstancesInput{
 		Cluster:            aws.String(p.Cluster),
 		ContainerInstances: []*string{task.ContainerInstanceArn},
 	})
@@ -512,14 +512,14 @@ func (p *AWSProvider) containerInstance(id string) (*ecs.ContainerInstance, erro
 		return ci, nil
 	}
 
-	res, err := p.ecs().DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+	res, err := p.describeContainerInstances(&ecs.DescribeContainerInstancesInput{
 		Cluster:            aws.String(p.Cluster),
 		ContainerInstances: []*string{aws.String(id)},
 	})
 	// check the build cluster too
 	for _, f := range res.Failures {
 		if f.Reason != nil && *f.Reason == "MISSING" && p.BuildCluster != p.Cluster {
-			res, err = p.ecs().DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+			res, err = p.describeContainerInstances(&ecs.DescribeContainerInstancesInput{
 				Cluster:            aws.String(p.BuildCluster),
 				ContainerInstances: []*string{aws.String(id)},
 			})

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -309,7 +309,7 @@ func (p *AWSProvider) taskProcesses(tasks []string) (structs.Processes, error) {
 			iptasks[i] = &ptasks[i]
 		}
 
-		tres, err := p.ecs().DescribeTasks(&ecs.DescribeTasksInput{
+		tres, err := p.describeTasks(&ecs.DescribeTasksInput{
 			Cluster: aws.String(p.Cluster),
 			Tasks:   iptasks,
 		})
@@ -323,7 +323,7 @@ func (p *AWSProvider) taskProcesses(tasks []string) (structs.Processes, error) {
 
 		// list tasks on build cluster too
 		if p.Cluster != p.BuildCluster {
-			tres, err := p.ecs().DescribeTasks(&ecs.DescribeTasksInput{
+			tres, err := p.describeTasks(&ecs.DescribeTasksInput{
 				Cluster: aws.String(p.BuildCluster),
 				Tasks:   iptasks,
 			})
@@ -568,14 +568,14 @@ func (p *AWSProvider) describeInstance(id string) (*ec2.Instance, error) {
 }
 
 func (p *AWSProvider) describeTask(arn string) (*ecs.Task, error) {
-	res, err := p.ecs().DescribeTasks(&ecs.DescribeTasksInput{
+	res, err := p.describeTasks(&ecs.DescribeTasksInput{
 		Cluster: aws.String(p.Cluster),
 		Tasks:   []*string{aws.String(arn)},
 	})
 	// check the build cluster too
 	for _, f := range res.Failures {
 		if f.Reason != nil && *f.Reason == "MISSING" && p.BuildCluster != p.Cluster {
-			res, err = p.ecs().DescribeTasks(&ecs.DescribeTasksInput{
+			res, err = p.describeTasks(&ecs.DescribeTasksInput{
 				Cluster: aws.String(p.BuildCluster),
 				Tasks:   []*string{aws.String(arn)},
 			})

--- a/provider/aws/system.go
+++ b/provider/aws/system.go
@@ -93,7 +93,7 @@ func (p *AWSProvider) SystemGet() (*structs.System, error) {
 				return nil, log.Error(err)
 			}
 
-			dres, err := p.ecs().DescribeServices(&ecs.DescribeServicesInput{
+			dres, err := p.describeServices(&ecs.DescribeServicesInput{
 				Cluster:  aws.String(p.Cluster),
 				Services: lres.ServiceArns,
 			})


### PR DESCRIPTION
In heavily utilized clusters we are observing ECS throttling on `convox ps` and `convox run`. The goal of this PR is to reduce ECS Describe* calls by caching.

With caching of ECS requests/responses we should be able to avoid AWS throttling, even when heavily polling the Convox API.

Questions:

- What is a good cache age? 5s? 10s?
- What are the side effects?
- Are there some paths that should explicitly not go through the cache?