### PR TITLE
Build Options

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -294,6 +294,11 @@
       "Description": "How much memory should be reserved by the builder",
       "Default": "1024"
     },
+    "BuildVolumeSize": {
+      "Type": "Number",
+      "Description": "Default build disk size in GB",
+      "Default": "50"
+    },
     "ClientId": {
       "Type": "String",
       "Description": "Anonymous identifier",
@@ -1449,7 +1454,7 @@
             "DeviceName": "/dev/xvdcz",
             "Ebs": {
               "Encrypted": { "Fn::If": [ "EncryptEbs", "true", { "Ref": "AWS::NoValue" } ] },
-              "VolumeSize": { "Ref": "VolumeSize" },
+              "VolumeSize": { "Ref": "BuildVolumeSize" },
               "VolumeType":"gp2"
             }
           }

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -2340,7 +2340,7 @@
             },
             "Image": { "Fn::If": [ "BlankBuildImage", { "Fn::Join": [ ":", [ "convox/api", { "Ref": "Version" } ] ] }, { "Ref": "BuildImage" } ] },
             "Links": [],
-            "Memory": { "Ref": "BuildMemory" },
+            "MemoryReservation": { "Ref": "BuildMemory" },
             "Name": "build",
             "Volumes": [
               "/etc/sysconfig/docker:/etc/sysconfig/docker",

--- a/provider/aws/lambda/formation/handler/ecs.go
+++ b/provider/aws/lambda/formation/handler/ecs.go
@@ -162,11 +162,6 @@ func ECSTaskDefinitionCreate(req Request) (string, map[string]string, error) {
 			}
 		}
 
-		memory, err := strconv.Atoi(task["Memory"].(string))
-		if err != nil {
-			return "invalid", nil, err
-		}
-
 		privileged := false
 
 		if p, ok := task["Privileged"].(string); ok && p != "" {
@@ -181,8 +176,23 @@ func ECSTaskDefinitionCreate(req Request) (string, map[string]string, error) {
 			Essential:  aws.Bool(true),
 			Image:      aws.String(task["Image"].(string)),
 			Cpu:        aws.Int64(int64(cpu)),
-			Memory:     aws.Int64(int64(memory)),
 			Privileged: aws.Bool(privileged),
+		}
+
+		if m, ok := task["Memory"].(string); ok && m != "" {
+			memory, err := strconv.Atoi(m)
+			if err != nil {
+				return "invalid", nil, err
+			}
+			r.ContainerDefinitions[i].Memory = aws.Int64(int64(memory))
+		}
+
+		if m, ok := task["MemoryReservation"].(string); ok && m != "" {
+			memory, err := strconv.Atoi(m)
+			if err != nil {
+				return "invalid", nil, err
+			}
+			r.ContainerDefinitions[i].MemoryReservation = aws.Int64(int64(memory))
 		}
 
 		// set Command from either -


### PR DESCRIPTION
This adds new ways to tune builds:

- BuildVolumeSize parameter that sets a build instance volume independently of the main cluster
- Build tasks get a soft memory reservation

A way to use this together is:

- BuildInstance=m4.2xlarge
- BuildMemory=256
- BuildVolumeSize=500

This instance has 32 GB of memory, so it will support 128 concurrent builds, each one taking as much memory as it can. The build volume is 10X bigger than default which will greatly reduce the chance of the disk filling up.

This should fix https://github.com/convox/rack/issues/2210 (docker build errors when device mapper is full), and address https://github.com/convox/rack/issues/1272 for build processes (memory reservations blocking new build processes).