### PR TITLE
Reliable build export

### DIFF
--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -195,11 +195,15 @@ func BuildExport(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		return httperr.Server(err)
 	}
 
-	rw.Header().Set("Content-Type", "application/octet-stream")
+	rw.Header().Set("Content-Type", "application/gzip")
+	rw.Header().Set("Transfer-Encoding", "chunked")
+	rw.Header().Set("Trailer", "Done")
 
 	if err = models.Provider().BuildExport(app, b.Id, rw); err != nil {
 		return httperr.Server(err)
 	}
+
+	rw.Header().Set("Done", "OK")
 
 	return nil
 }

--- a/dist/haproxy.cfg
+++ b/dist/haproxy.cfg
@@ -44,7 +44,8 @@ defaults
     log                     global
     option                  httplog
     option                  dontlognull
-    option http-server-close
+    option                  http-server-close
+    option                  http-pretend-keepalive
     option forwardfor       except 127.0.0.0/8
     option                  redispatch
     retries                 3

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -382,7 +382,8 @@ func (p *AWSProvider) BuildImport(app string, r io.Reader) (*structs.Build, erro
 			}
 
 			if err := cmd.Wait(); err != nil {
-				return nil, log.Errorf("%s: %s\n", lastline(outb.Bytes()), err.Error())
+				out := strings.TrimSpace(outb.String())
+				return nil, log.Errorf("%s: %s\n", out, err.Error())
 			}
 
 			if len(manifest) != 1 || len(manifest[0].RepoTags) != 1 {

--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -215,7 +215,7 @@ func TestBuildExport(t *testing.T) {
 
 	h, err = tr.Next()
 	assert.NoError(t, err)
-	assert.Equal(t, "web.BAFVEWUCAYT.tar", h.Name)
+	assert.Equal(t, "httpd.BAFVEWUCAYT.tar", h.Name)
 	assert.Equal(t, int64(13), h.Size)
 
 	h, err = tr.Next()
@@ -281,7 +281,7 @@ func TestBuildImport(t *testing.T) {
 
 	ltw := tar.NewWriter(lbuf)
 
-	data = []byte(`[{"RepoTags":["test-tag"]}]`)
+	data = []byte(`[{"RepoTags":["12345.dkr.ecr.us-east-1.amazonaws.com/convox-httpd-aaaaaaa:web.BRZMXKKHCMR"]}]`)
 
 	err = ltw.WriteHeader(&tar.Header{
 		Typeflag: tar.TypeReg,
@@ -292,14 +292,14 @@ func TestBuildImport(t *testing.T) {
 
 	n, err = ltw.Write(data)
 	require.NoError(t, err)
-	assert.Equal(t, 27, n)
+	assert.Equal(t, 93, n)
 
 	err = ltw.Close()
 	require.NoError(t, err)
 
 	err = tw.WriteHeader(&tar.Header{
 		Typeflag: tar.TypeReg,
-		Name:     "web.B12345.tar",
+		Name:     "httpd.B12345.tar",
 		Size:     int64(lbuf.Len()),
 	})
 	require.NoError(t, err)
@@ -1454,7 +1454,7 @@ var cycleBuildDockerSave = awsutil.Cycle{
 
 var cycleBuildDockerTag = awsutil.Cycle{
 	Request: awsutil.Request{
-		RequestURI: "/v1.24/images/test-tag/tag?repo=778743527532.dkr.ecr.us-east-1.amazonaws.com%2Fconvox-rails-sslibosttb&tag=web.B12345",
+		RequestURI: "/v1.24/images/12345.dkr.ecr.us-east-1.amazonaws.com/convox-httpd-aaaaaaa:web.BRZMXKKHCMR/tag?repo=778743527532.dkr.ecr.us-east-1.amazonaws.com%2Fconvox-rails-sslibosttb&tag=web.B12345",
 	},
 	Response: awsutil.Response{
 		StatusCode: 200,

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -434,6 +434,11 @@
       "Description": "Default swap volume size in GB",
       "Default": "5"
     },
+    "RootSize": {
+      "Type": "Number",
+      "Description": "Default root disk size in GB",
+      "Default": "8"
+    },
     "Version": {
       "Description": "(REQUIRED) Convox release version",
       "MinLength" : "1",
@@ -1596,6 +1601,14 @@
       "Properties": {
         "AssociatePublicIpAddress": { "Fn::If": [ "Private", false, true ] },
         "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", { "Ref": "AWS::NoValue" } ] },
+              "VolumeSize": { "Ref": "RootSize" },
+              "VolumeType":"gp2"
+            }
+          },
           {
             "DeviceName": "/dev/xvdb",
             "Ebs": {

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -208,7 +208,15 @@ func humanStatus(original string) string {
 
 func lastline(data []byte) string {
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	return lines[len(lines)-1]
+
+	for i := len(lines) - 1; i < 0; i-- {
+		if lines[i] == "" {
+			continue
+		}
+		return lines[i]
+	}
+
+	return ""
 }
 
 func stackName(app *structs.App) string {

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -208,15 +208,7 @@ func humanStatus(original string) string {
 
 func lastline(data []byte) string {
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-
-	for i := len(lines) - 1; i < 0; i-- {
-		if lines[i] == "" {
-			continue
-		}
-		return lines[i]
-	}
-
-	return ""
+	return lines[len(lines)-1]
 }
 
 func stackName(app *structs.App) string {


### PR DESCRIPTION
During a build export, docker commands in the backend can take some time to complete so we parallelize them and write the response as soon as possible.

Also added some headers and haproxy options so client/servers aren't assuming behavior that caused the connection to close mid-export.