### PR TITLE
Apply TaskRole to run TaskDefinition

### DIFF
--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -830,9 +830,12 @@ func (p *AWSProvider) generateTaskDefinition(app, process, release string) (*ecs
 		})
 	}
 
+	tr := a.Parameters["TaskRole"]
+
 	req := &ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions: []*ecs.ContainerDefinition{cd},
 		Family:               aws.String(fmt.Sprintf("%s-%s-%s", p.Rack, app, process)),
+		TaskRoleArn:          &tr,
 	}
 
 	for i, mv := range s.MountableVolumes() {

--- a/provider/aws/processes_test.go
+++ b/provider/aws/processes_test.go
@@ -1007,7 +1007,8 @@ var cycleProcessRegisterTaskDefinition = awsutil.Cycle{
 					"name": "web"
 				}
 			],
-			"family": "convox-myapp-web"
+			"family": "convox-myapp-web",
+			"taskRoleArn": ""
 		}`,
 	},
 	Response: awsutil.Response{


### PR DESCRIPTION
If there is a TaskRole set in the app params this will make sure it gets set on `convox run` tasks as well.