### PR TITLE
don't generate random password if one has been provided

### DIFF
--- a/provider/aws/resource.go
+++ b/provider/aws/resource.go
@@ -476,7 +476,9 @@ func (p *AWSProvider) appendSystemParameters(s *structs.Resource) error {
 		return err
 	}
 
-	s.Parameters["Password"] = password
+	if s.Parameters["Password"] == "" {
+		s.Parameters["Password"] = password
+	}
 	s.Parameters["SecurityGroups"] = p.SecurityGroup
 	s.Parameters["Subnets"] = p.Subnets
 	s.Parameters["SubnetsPrivate"] = coalesceString(p.SubnetsPrivate, p.Subnets)


### PR DESCRIPTION
Fixes a bug where the `--password` parameter to `convox resources create` and `convox resources update` was being ignored.