### PR TITLE
Default to 200GB disk instead of 50GB disk on dedicated build instances

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -297,7 +297,7 @@
     "BuildVolumeSize": {
       "Type": "Number",
       "Description": "Default build disk size in GB",
-      "Default": "50"
+      "Default": "200"
     },
     "ClientId": {
       "Type": "String",


### PR DESCRIPTION
This should reduce the frequency of out-of-disk errors for builds on dedicated build instances.