### PR TITLE
Make health check interval settable in via docker-compose label

### DIFF
--- a/manifest/balancer.go
+++ b/manifest/balancer.go
@@ -283,7 +283,12 @@ func (mb ManifestBalancer) HealthTimeout() string {
 // HealthInterval The amount of time in between health checks.
 // This is derived from the timeout value, which must be less than the interval
 func (mb ManifestBalancer) HealthInterval() (string, error) {
+	if interval := mb.Entry.Labels["convox.health.interval"]; interval != "" {
+		return interval, nil
+	}
+
 	timeout := mb.HealthTimeout()
+
 	timeoutInt, err := strconv.Atoi(timeout)
 	if err != nil {
 		return "", err

--- a/manifest/balancer.go
+++ b/manifest/balancer.go
@@ -288,7 +288,6 @@ func (mb ManifestBalancer) HealthInterval() (string, error) {
 	}
 
 	timeout := mb.HealthTimeout()
-
 	timeoutInt, err := strconv.Atoi(timeout)
 	if err != nil {
 		return "", err

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -111,11 +111,11 @@ func (m Manifest) Validate() []error {
 			}
 		}
 
-		labels = entry.LabelsByPrefix("convox.interval.timeout")
+		labels = entry.LabelsByPrefix("convox.health.interval")
 		for _, v := range labels {
 			i, err := strconv.Atoi(v)
 			if err != nil || i < 5 || i > 300 {
-				errors = append(errors, fmt.Errorf("convox.interval.timeout is invalid for %s, must be a number between 5 and 300", entry.Name))
+				errors = append(errors, fmt.Errorf("convox.health.interval is invalid for %s, must be a number between 5 and 300", entry.Name))
 			}
 		}
 

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -111,6 +111,14 @@ func (m Manifest) Validate() []error {
 			}
 		}
 
+		labels = entry.LabelsByPrefix("convox.interval.timeout")
+		for _, v := range labels {
+			i, err := strconv.Atoi(v)
+			if err != nil || i < 5 || i > 300 {
+				errors = append(errors, fmt.Errorf("convox.interval.timeout is invalid for %s, must be a number between 5 and 300", entry.Name))
+			}
+		}
+
 		labels = entry.LabelsByPrefix("convox.health.timeout")
 		for _, v := range labels {
 			i, err := strconv.Atoi(v)


### PR DESCRIPTION
A custom value for the ELB health check interval may now be set via docker-compose.yml:

```
services:
  web:
    labels:
      - convox.health.interval=300
```

Valid values are from 5 to 300.

If no label is set, the default of timeout + 2 will be used.