### PR TITLE
Spot Instances

### DIFF
--- a/api/cmd/monitor/main.go
+++ b/api/cmd/monitor/main.go
@@ -11,6 +11,7 @@ func main() {
 	go workers.StartCluster()
 	go workers.StartHeartbeat()
 	go workers.StartEventQueue()
+	go workers.StartSpotReplace()
 
 	for {
 		time.Sleep(1 * time.Hour)

--- a/api/workers/spotreplace.go
+++ b/api/workers/spotreplace.go
@@ -1,0 +1,132 @@
+package workers
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/convox/logger"
+	"github.com/convox/rack/api/models"
+)
+
+var (
+	spotreplace = (os.Getenv("SPOT_INSTANCES") == "true")
+)
+
+func StartSpotReplace() {
+	spotReplace()
+
+	for range time.Tick(tick) {
+		spotReplace()
+	}
+}
+
+func spotReplace() {
+	log := logger.New("ns=workers.spotreplace").At("spotReplace")
+
+	// do nothing unless autoscaling is on
+	if !spotreplace {
+		return
+	}
+
+	// get system
+	system, err := models.Provider().SystemGet()
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	log.Logf("status=%q", system.Status)
+
+	// only allow running and converging status through
+	switch system.Status {
+	case "running", "converging":
+	default:
+		return
+	}
+
+	resources, err := models.ListResources(os.Getenv("RACK"))
+	if err != nil {
+		return
+	}
+
+	// get on-demand ASG
+	odres, err := models.AutoScaling().DescribeAutoScalingGroups(
+		&autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: []*string{
+				aws.String(resources["Instances"].Id),
+			},
+		},
+	)
+	if err != nil {
+		return
+	}
+
+	// count the Healthy, InService on-demand instances
+	onDemandCount := 0
+	for _, onDemandInstance := range odres.AutoScalingGroups[0].Instances {
+		if (*onDemandInstance.HealthStatus == "Healthy") &&
+			((*onDemandInstance.LifecycleState == "InService") || (*onDemandInstance.LifecycleState == "Pending")) {
+			onDemandCount += 1
+		}
+	}
+
+	onDemandDesiredCapacity := *odres.AutoScalingGroups[0].DesiredCapacity
+
+	// get spot ASG
+	sres, err := models.AutoScaling().DescribeAutoScalingGroups(
+		&autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: []*string{
+				aws.String(resources["SpotInstances"].Id),
+			},
+		},
+	)
+	if err != nil {
+		return
+	}
+
+	// count the Healthy, InService spot instances
+	spotCount := 0
+	for _, spotInstance := range sres.AutoScalingGroups[0].Instances {
+		if (*spotInstance.HealthStatus == "Healthy") && (*spotInstance.LifecycleState == "InService") {
+			spotCount += 1
+		}
+	}
+
+	totalInstances := onDemandCount + spotCount
+
+	// if total instances > than InstanceCount, reduce on-demand desired count by 1
+	if totalInstances > system.Count {
+		newCapacity := int64(onDemandDesiredCapacity - 1)
+		_, err := models.AutoScaling().SetDesiredCapacity(
+			&autoscaling.SetDesiredCapacityInput{
+				AutoScalingGroupName: aws.String(resources["Instances"].Id),
+				DesiredCapacity:      &newCapacity,
+			},
+		)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+
+	// if total instances < than InstanceCount, increase on-demand desired count by (InstanceCount - total instances)
+	if totalInstances < system.Count {
+		newInstancesNeeded := int64(system.Count - totalInstances)
+		newCapacity := onDemandDesiredCapacity + newInstancesNeeded
+		_, err := models.AutoScaling().SetDesiredCapacity(
+			&autoscaling.SetDesiredCapacityInput{
+				AutoScalingGroupName: aws.String(resources["Instances"].Id),
+				DesiredCapacity:      &newCapacity,
+			},
+		)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+
+	return
+}

--- a/api/workers/spotreplace.go
+++ b/api/workers/spotreplace.go
@@ -15,6 +15,7 @@ var (
 	spotreplace = (os.Getenv("SPOT_INSTANCES") == "true")
 )
 
+// Main worker function
 func StartSpotReplace() {
 	spotReplace()
 
@@ -69,7 +70,7 @@ func spotReplace() {
 	for _, onDemandInstance := range odres.AutoScalingGroups[0].Instances {
 		if (*onDemandInstance.HealthStatus == "Healthy") &&
 			((*onDemandInstance.LifecycleState == "InService") || (*onDemandInstance.LifecycleState == "Pending")) {
-			onDemandCount += 1
+			onDemandCount++
 		}
 	}
 
@@ -91,7 +92,7 @@ func spotReplace() {
 	spotCount := 0
 	for _, spotInstance := range sres.AutoScalingGroups[0].Instances {
 		if (*spotInstance.HealthStatus == "Healthy") && (*spotInstance.LifecycleState == "InService") {
-			spotCount += 1
+			spotCount++
 		}
 	}
 

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -399,6 +399,22 @@
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
     },
+    "SpotInstanceBid": {
+      "Default": "0.01",
+      "Description": "Bid price for spot instances",
+      "Type": "String"
+    },
+    "SpotInstanceCount": {
+      "Default": 0,
+      "Description": "Count of spot instances to launch",
+      "MinValue": "0",
+      "Type": "Number"
+    },
+    "SpotInstanceType": {
+      "Default": "m4.large",
+      "Description": "The type of spot instances to launch",
+      "Type": "String"
+    },
     "Subnet0CIDR": {
       "Default": "10.0.1.0/24",
       "Description": "Public Subnet 0 CIDR Block",
@@ -1909,6 +1925,179 @@
                 }
               ]
             }
+          }
+        ]
+      }
+    },
+    "SpotLaunchConfiguration": {
+      "DependsOn": [ "Balancer", "Cluster", "InstanceProfile", "SecurityGroup", "LogGroup" ],
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": {
+        "AssociatePublicIpAddress": { "Fn::If": [ "Private", false, true ] },
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", { "Ref": "AWS::NoValue" } ] },
+              "VolumeSize": { "Ref": "RootSize" },
+              "VolumeType":"gp2"
+            }
+          },
+          {
+            "DeviceName": "/dev/xvdb",
+            "Ebs": {
+              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", { "Ref": "AWS::NoValue" } ] },
+              "VolumeSize": { "Ref": "SwapSize" },
+              "VolumeType":"gp2"
+            }
+          },
+          {
+            "DeviceName": "/dev/xvdcz",
+            "Ebs": {
+              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", { "Ref": "AWS::NoValue" } ] },
+              "VolumeSize": { "Ref": "VolumeSize" },
+              "VolumeType":"gp2"
+            }
+          }
+        ],
+        "IamInstanceProfile": { "Ref": "InstanceProfile" },
+        "ImageId": { "Fn::If": [ "BlankAmi", { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Ami" ] }, { "Ref": "Ami" } ] },
+        "InstanceMonitoring": true,
+        "InstanceType": { "Ref": "SpotInstanceType" },
+        "KeyName": { "Fn::If": [ "BlankKey", { "Ref": "AWS::NoValue" }, { "Ref": "Key" } ] },
+        "SecurityGroups": [ { "Ref": "SecurityGroup" } ],
+        "SpotPrice": { "Ref": "SpotInstanceBid" },
+        "UserData": { "Fn::Base64":
+          { "Fn::Join": [ "", [
+            "#cloud-config\n",
+            "repo_upgrade_exclude:\n",
+            "  - kernel*\n",
+            "packages:\n",
+            "  - aws-cfn-bootstrap\n",
+            "mounts:\n",
+            "  - ['/dev/xvdb', 'none', 'swap', 'sw', '0', '0']\n",
+            "bootcmd:\n",
+            "  - mkswap /dev/xvdb\n",
+            "  - swapon /dev/xvdb\n",
+            "  - export http_proxy=", { "Ref": "HttpProxy" }, "\n",
+            "  - echo http_proxy=", { "Ref": "HttpProxy" }, " >> /etc/environment\n",
+            "  - export https_proxy=", { "Ref": "HttpProxy" }, "\n",
+            "  - echo https_proxy=", { "Ref": "HttpProxy" }, " >> /etc/environment\n",
+            "  - export HTTP_PROXY=", { "Ref": "HttpProxy" }, "\n",
+            "  - echo HTTP_PROXY=", { "Ref": "HttpProxy" }, " >> /etc/environment\n",
+            "  - export HTTPS_PROXY=", { "Ref": "HttpProxy" }, "\n",
+            "  - echo HTTPS_PROXY=", { "Ref": "HttpProxy" }, " >> /etc/environment\n",
+            "  - export NO_PROXY=169.254.169.254\n",
+            "  - echo NO_PROXY=169.254.169.254 >> /etc/environment\n",
+            { "Fn::If": [ "HttpProxy",
+              { "Fn::Join": ["", ["  - echo \"proxy=", { "Ref": "HttpProxy" }, "/\" >> /etc/yum.conf\n"
+              ] ] },
+              { "Ref": "AWS::NoValue" }
+            ] },
+            "  - until yum install -y aws-cli nfs-utils; do echo \"Waiting for network\"; done;\n",
+            "  - mkdir /volumes\n",
+            { "Fn::If": [ "RegionHasEFS",
+              { "Fn::Join": [ "", [
+                "  - while true; do mount -t nfs -o nfsvers=4.1 $(curl -s --noproxy 169.254.169.254 http://169.254.169.254/latest/meta-data/placement/availability-zone).",
+                { "Ref": "VolumeFilesystem" },
+                ".efs.",
+                { "Ref": "AWS::Region" },
+                ".amazonaws.com:/ /volumes && break; sleep 5; done\n"
+              ] ] },
+              ""
+            ] },
+            "  - [ cloud-init-per, instance, docker_storage_setup, /usr/bin/docker-storage-setup ]\n",
+            "  - echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config\n",
+            "  - echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config\n",
+            "  - echo HTTP_PROXY=", { "Ref": "HttpProxy" }, " >> /etc/ecs/ecs.config\n",
+            "  - echo NO_PROXY=169.254.169.254,169.254.170.2,/var/run/docker.sock >> /etc/ecs/ecs.config\n",
+            "  - head -n -1 /etc/sysconfig/docker >> /etc/sysconfig/docker-tmp\n",
+            "  - mv /etc/sysconfig/docker-tmp /etc/sysconfig/docker\n",
+            "  - echo 'OPTIONS=\"--default-ulimit nofile=1024000:1024000\"' >> /etc/sysconfig/docker\n",
+            { "Fn::Join": [ "", [
+              "  - echo 'OPTIONS=\"${OPTIONS} --storage-opt dm.basesize=", { "Ref": "ContainerDisk" }, "G\"' >> /etc/sysconfig/docker\n",
+              "  - echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker\n",
+              "  - echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"}' >> /etc/ecs/ecs.config\n"
+            ] ] },
+            { "Fn::If": [ "HttpProxy",
+              { "Fn::Join": ["", ["  - echo \"export HTTP_PROXY=", { "Ref": "HttpProxy" }, "/\" >> /etc/sysconfig/docker\n"
+              ] ] },
+              { "Ref": "AWS::NoValue" }
+            ] },
+            "  - mkdir -p /etc/convox\n",
+            "  - echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region\n",
+            "  - echo \"", { "Ref": "ClientId" }, "\" > /etc/convox/client_id\n",
+            "  - echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group\n",
+            { "Fn::If": [ "Agent",
+              "  - curl -s https://convox.s3.amazonaws.com/agent/0.71/convox.conf > /etc/init/convox.conf\n",
+              ""
+            ] },
+            "  - echo -e '/var/log/docker {\\n  rotate 7\\n  daily\\n  nocompress\\n  copytruncate\\n}' >> /etc/logrotate.d/docker\n",
+            { "Fn::If": [ "BlankInstanceBootCommand",
+              { "Ref": "AWS::NoValue" },
+              { "Fn::Join": [ "", [
+              "  - ", { "Ref": "InstanceBootCommand" }, "\n"
+              ] ] }
+            ] },
+            "runcmd:\n",
+            { "Fn::If": [ "BlankInstanceRunCommand",
+              { "Ref": "AWS::NoValue" },
+              { "Fn::Join": [ "", [
+              "  - ", { "Ref": "InstanceRunCommand" }, "\n"
+              ] ] }
+            ] },
+            "  - export INSTANCE_ID=$(curl -s --noproxy 169.254.169.254 http://169.254.169.254/latest/meta-data/instance-id)\n",
+            "  - export ASG_NAME=$(env $(cat /etc/environment) /usr/bin/aws autoscaling describe-auto-scaling-instances --instance-ids=$INSTANCE_ID --region ", {"Ref":"AWS::Region"}, " --output text --query 'AutoScalingInstances[0].AutoScalingGroupName')\n",
+            "  - export LIFECYCLE_HOOK=$(env $(cat /etc/environment) /usr/bin/aws autoscaling describe-lifecycle-hooks --auto-scaling-group-name $ASG_NAME --region ", {"Ref":"AWS::Region"}, " --output text --query \"LifecycleHooks[?contains(LifecycleHookName, '", { "Ref": "AWS::StackName" }, "-InstancesLifecycleLaunching') == \\`true\\`].LifecycleHookName | [0]\")\n",
+            "  - env $(cat /etc/environment) /usr/bin/aws autoscaling complete-lifecycle-action --region ", { "Ref": "AWS::Region" }, " --instance-id $INSTANCE_ID --lifecycle-hook-name $LIFECYCLE_HOOK --auto-scaling-group-name $ASG_NAME --lifecycle-action-result CONTINUE\n",
+            "  - env $(cat /etc/environment) /opt/aws/bin/cfn-signal --http-proxy \"", { "Ref": "HttpProxy" }, "\" --stack ", { "Ref": "AWS::StackName" }, " --region ", { "Ref": "AWS::Region" }, " --resource Instances\n"
+          ] ] }
+        }
+      }
+    },
+    "SpotInstances": {
+      "DependsOn": [ "AvailabilityZones", "Subnet0", "Subnet1" ],
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "Properties" : {
+        "LaunchConfigurationName" : { "Ref": "SpotLaunchConfiguration" },
+        "AvailabilityZones": [
+          { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone0" ] },
+          { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone1" ] },
+          { "Fn::If": [ "ThirdAvailabilityZone", { "Fn::GetAtt": [ "AvailabilityZones", "AvailabilityZone2" ] }, { "Ref": "AWS::NoValue" } ] }
+        ],
+        "VPCZoneIdentifier": {
+          "Fn::If": [ "Private", [
+            { "Ref": "SubnetPrivate0" },
+            { "Ref": "SubnetPrivate1" },
+            { "Fn::If": [ "ThirdAvailabilityZone", { "Ref": "SubnetPrivate2" }, { "Ref": "AWS::NoValue" } ] }
+          ], [
+            { "Ref": "Subnet0" },
+            { "Ref": "Subnet1" },
+            { "Fn::If": [ "ThirdAvailabilityZone", { "Ref": "Subnet2" }, { "Ref": "AWS::NoValue" } ] }
+          ] ]
+        },
+        "Cooldown": 5,
+        "DesiredCapacity": { "Ref": "SpotInstanceCount" },
+        "HealthCheckType": "EC2",
+        "HealthCheckGracePeriod": "120",
+        "MinSize" : { "Ref": "SpotInstanceCount" },
+        "MaxSize" : "1000",
+        "MetricsCollection": [ { "Granularity": "1Minute" } ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": { "Ref": "AWS::StackName" },
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "Rack",
+            "Value": { "Ref": "AWS::StackName" },
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "GatewayAttachment",
+            "Value": { "Fn::If": [ "ExistingVpc", "existing", { "Ref": "GatewayAttachment" } ] },
+            "PropagateAtLaunch": false
           }
         ]
       }

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -405,7 +405,7 @@
       "Type": "String"
     },
     "SpotInstanceCount": {
-      "Default": 0,
+      "Default": "0",
       "Description": "Count of spot instances to launch",
       "MinValue": "0",
       "Type": "Number"

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -12,7 +12,6 @@
     "BlankInstanceBootCommand": { "Fn::Equals": [ { "Ref": "InstanceBootCommand" }, "" ] },
     "BlankInstanceRunCommand": { "Fn::Equals": [ { "Ref": "InstanceRunCommand" }, "" ] },
     "BlankInternetGateway": { "Fn::Equals": [ { "Ref": "InternetGateway"}, "" ] },
-    "BlankSpotInstanceBid": { "Fn::Equals": [ { "Ref": "SpotInstanceBid"}, "" ] },
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "DedicatedBuilder": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstance" }, "" ] } ] },
@@ -40,7 +39,7 @@
     "RegionHasEFSAndThirdAvailabilityZone": {
       "Fn::And": [ { "Condition": "RegionHasEFS" }, { "Condition": "ThirdAvailabilityZone" } ]
     },
-    "SpotFleet": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SpotInstanceBid" }, "" ] } ] },
+    "SpotInstances": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SpotInstanceBid"}, "" ] } ] },
     "ThirdAvailabilityZone": { "Fn::Equals": [
       { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "ThirdAvailabilityZone" ] },
       "Yes"
@@ -1922,7 +1921,7 @@
       }
     },
     "SpotLaunchConfiguration": {
-      "Condition": "SpotFleet",
+      "Condition": "SpotInstances",
       "DependsOn": [ "Balancer", "Cluster", "InstanceProfile", "SecurityGroup", "LogGroup" ],
       "Type": "AWS::AutoScaling::LaunchConfiguration",
       "Properties": {
@@ -2049,7 +2048,7 @@
       }
     },
     "SpotInstances": {
-      "Condition": "SpotFleet",
+      "Condition": "SpotInstances",
       "DependsOn": [ "AvailabilityZones", "Subnet0", "Subnet1" ],
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
@@ -2662,7 +2661,7 @@
               "RELEASE": { "Ref": "Version" },
               "ROLLBAR_TOKEN": "f67f25b8a9024d5690f997bd86bf14b0",
               "SEGMENT_WRITE_KEY": "KLvwCXo6qcTmQHLpF69DEwGf9zh7lt9i",
-	      "SPOT_INSTANCES": { "Fn::If": [ "BlankSpotInstanceBid", "false", "true" ] },
+	      "SPOT_INSTANCES": { "Fn::If": [ "SpotInstances", "true", "false" ] },
               "STACK_ID": { "Ref": "AWS::StackId" },
               "SUBNETS": {
                 "Fn::Join": [ ",", [

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1759,7 +1759,7 @@
         "DesiredCapacity": { "Ref": "InstanceCount" },
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
-        "MinSize" : { "Fn::If": [ "SpotInstanceBid", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },
+        "MinSize" : { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },
         "MaxSize" : "1000",
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "Tags": [

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -27,7 +27,6 @@
     "HttpProxy": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "HttpProxy" }, "" ] } ] },
     "InternetGateway": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "InternetGateway" }, "" ] } ] },
     "NotExistingVpcAndBlankInternetGateway": { "Fn::Not": [ { "Condition": "ExistingVpcAndBlankInternetGateway" } ] },
-    "OnDemandMinCount": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "OnDemandMinCount" }, "" ] } ] },
     "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] },
     "PrivateAndThirdAvailabilityZone": {
       "Fn::And": [ { "Condition": "Private" }, { "Condition": "ThirdAvailabilityZone" } ]
@@ -384,7 +383,7 @@
       "Type": "String"
     },
     "OnDemandMinCount": {
-      "Default": "",
+      "Default": "3",
       "Description": "The minimum number of on-demand instances in the runtime cluster",
       "Type": "Number"
     },
@@ -1760,7 +1759,7 @@
         "DesiredCapacity": { "Ref": "InstanceCount" },
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
-        "MinSize" : { "Fn::If": [ "OnDemandMinCount", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },
+        "MinSize" : { "Fn::If": [ "SpotInstanceBid", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },
         "MaxSize" : "1000",
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "Tags": [

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -2070,7 +2070,7 @@
           ] ]
         },
         "Cooldown": 5,
-        "DesiredCapacity": "0",
+        "DesiredCapacity": { "Ref": "InstanceCount" },
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : "0",

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -27,6 +27,7 @@
     "HttpProxy": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "HttpProxy" }, "" ] } ] },
     "InternetGateway": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "InternetGateway" }, "" ] } ] },
     "NotExistingVpcAndBlankInternetGateway": { "Fn::Not": [ { "Condition": "ExistingVpcAndBlankInternetGateway" } ] },
+    "OnDemandMinCount": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "OnDemandMinCount" }, "" ] } ] },
     "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] },
     "PrivateAndThirdAvailabilityZone": {
       "Fn::And": [ { "Condition": "Private" }, { "Condition": "ThirdAvailabilityZone" } ]
@@ -381,6 +382,11 @@
       "Default": "",
       "Description": "SSH key name for access to cluster instances",
       "Type": "String"
+    },
+    "OnDemandMinCount": {
+      "Default": "",
+      "Description": "The minimum number of on-demand instances in the runtime cluster",
+      "Type": "Number"
     },
     "Password": {
       "Description": "(REQUIRED) API HTTP password",
@@ -1754,7 +1760,7 @@
         "DesiredCapacity": { "Ref": "InstanceCount" },
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
-        "MinSize" : { "Ref": "InstanceCount" },
+        "MinSize" : { "Fn::If": [ "OnDemandMinCount", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },
         "MaxSize" : "1000",
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "Tags": [
@@ -2653,6 +2659,7 @@
               "LOG_GROUP": { "Ref": "LogGroup" },
               "NOTIFICATION_HOST": { "Fn::GetAtt": [ "Balancer", "DNSName" ] },
               "NOTIFICATION_TOPIC": { "Ref": "NotificationTopic"},
+	       "ON_DEMAND_MIN_COUNT": { "Ref": "OnDemandMinCount"},
               "PASSWORD": { "Ref": "Password" },
               "PRIVATE": { "Ref": "Private" },
               "PROCESS": "web",

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1703,7 +1703,7 @@
             "  - echo \"", { "Ref": "ClientId" }, "\" > /etc/convox/client_id\n",
             "  - echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group\n",
             { "Fn::If": [ "Agent",
-              "  - curl -s https://convox.s3.amazonaws.com/agent/0.71/convox.conf > /etc/init/convox.conf\n",
+              "  - curl -s https://convox.s3.amazonaws.com/agent/0.72/convox.conf > /etc/init/convox.conf\n",
               ""
             ] },
             "  - echo -e '/var/log/docker {\\n  rotate 7\\n  daily\\n  nocompress\\n  copytruncate\\n}' >> /etc/logrotate.d/docker\n",
@@ -2021,7 +2021,7 @@
             "  - echo \"", { "Ref": "ClientId" }, "\" > /etc/convox/client_id\n",
             "  - echo \"", { "Ref": "LogGroup" }, "\" > /etc/convox/log_group\n",
             { "Fn::If": [ "Agent",
-              "  - curl -s https://convox.s3.amazonaws.com/agent/0.71/convox.conf > /etc/init/convox.conf\n",
+              "  - curl -s https://convox.s3.amazonaws.com/agent/0.72/convox.conf > /etc/init/convox.conf\n",
               ""
             ] },
             "  - echo -e '/var/log/docker {\\n  rotate 7\\n  daily\\n  nocompress\\n  copytruncate\\n}' >> /etc/logrotate.d/docker\n",

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -12,6 +12,8 @@
     "BlankInstanceBootCommand": { "Fn::Equals": [ { "Ref": "InstanceBootCommand" }, "" ] },
     "BlankInstanceRunCommand": { "Fn::Equals": [ { "Ref": "InstanceRunCommand" }, "" ] },
     "BlankInternetGateway": { "Fn::Equals": [ { "Ref": "InternetGateway"}, "" ] },
+    "BlankSpotInstanceBid": { "Fn::Equals": [ { "Ref": "SpotInstanceBid"}, "" ] },
+    "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "DedicatedBuilder": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstance" }, "" ] } ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
@@ -2660,6 +2662,7 @@
               "RELEASE": { "Ref": "Version" },
               "ROLLBAR_TOKEN": "f67f25b8a9024d5690f997bd86bf14b0",
               "SEGMENT_WRITE_KEY": "KLvwCXo6qcTmQHLpF69DEwGf9zh7lt9i",
+	      "SPOT_INSTANCES": { "Fn::If": [ "BlankSpotInstanceBid", "false", "true" ] },
               "STACK_ID": { "Ref": "AWS::StackId" },
               "SUBNETS": {
                 "Fn::Join": [ ",", [

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -38,6 +38,7 @@
     "RegionHasEFSAndThirdAvailabilityZone": {
       "Fn::And": [ { "Condition": "RegionHasEFS" }, { "Condition": "ThirdAvailabilityZone" } ]
     },
+    "SpotFleet": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SpotInstanceBid" }, "" ] } ] },
     "ThirdAvailabilityZone": { "Fn::Equals": [
       { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "ThirdAvailabilityZone" ] },
       "Yes"
@@ -400,19 +401,8 @@
       "AllowedValues": [ "Yes", "No" ]
     },
     "SpotInstanceBid": {
-      "Default": "0.01",
+      "Default": "",
       "Description": "Bid price for spot instances",
-      "Type": "String"
-    },
-    "SpotInstanceCount": {
-      "Default": "0",
-      "Description": "Count of spot instances to launch",
-      "MinValue": "0",
-      "Type": "Number"
-    },
-    "SpotInstanceType": {
-      "Default": "m4.large",
-      "Description": "The type of spot instances to launch",
       "Type": "String"
     },
     "Subnet0CIDR": {
@@ -1930,6 +1920,7 @@
       }
     },
     "SpotLaunchConfiguration": {
+      "Condition": "SpotFleet",
       "DependsOn": [ "Balancer", "Cluster", "InstanceProfile", "SecurityGroup", "LogGroup" ],
       "Type": "AWS::AutoScaling::LaunchConfiguration",
       "Properties": {
@@ -1963,7 +1954,7 @@
         "IamInstanceProfile": { "Ref": "InstanceProfile" },
         "ImageId": { "Fn::If": [ "BlankAmi", { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Ami" ] }, { "Ref": "Ami" } ] },
         "InstanceMonitoring": true,
-        "InstanceType": { "Ref": "SpotInstanceType" },
+        "InstanceType": { "Ref": "InstanceType" },
         "KeyName": { "Fn::If": [ "BlankKey", { "Ref": "AWS::NoValue" }, { "Ref": "Key" } ] },
         "SecurityGroups": [ { "Ref": "SecurityGroup" } ],
         "SpotPrice": { "Ref": "SpotInstanceBid" },
@@ -2056,6 +2047,7 @@
       }
     },
     "SpotInstances": {
+      "Condition": "SpotFleet",
       "DependsOn": [ "AvailabilityZones", "Subnet0", "Subnet1" ],
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
@@ -2077,10 +2069,10 @@
           ] ]
         },
         "Cooldown": 5,
-        "DesiredCapacity": { "Ref": "SpotInstanceCount" },
+        "DesiredCapacity": "0",
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
-        "MinSize" : { "Ref": "SpotInstanceCount" },
+        "MinSize" : "0",
         "MaxSize" : "1000",
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "Tags": [

--- a/provider/aws/instances.go
+++ b/provider/aws/instances.go
@@ -20,7 +20,7 @@ func (p *AWSProvider) InstanceList() (structs.Instances, error) {
 	req := &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{Name: aws.String("tag:Rack"), Values: []*string{aws.String(os.Getenv("RACK"))}},
-			{Name: aws.String("tag:aws:cloudformation:logical-id"), Values: []*string{aws.String("Instances")}},
+			{Name: aws.String("tag:aws:cloudformation:logical-id"), Values: []*string{aws.String("Instances"), aws.String("SpotInstances")}},
 		},
 	}
 

--- a/provider/aws/instances.go
+++ b/provider/aws/instances.go
@@ -21,6 +21,7 @@ func (p *AWSProvider) InstanceList() (structs.Instances, error) {
 		Filters: []*ec2.Filter{
 			{Name: aws.String("tag:Rack"), Values: []*string{aws.String(os.Getenv("RACK"))}},
 			{Name: aws.String("tag:aws:cloudformation:logical-id"), Values: []*string{aws.String("Instances"), aws.String("SpotInstances")}},
+			{Name: aws.String("instance-state-name"), Values: []*string{aws.String("pending"), aws.String("running"), aws.String("shutting-down"), aws.String("stopping")}},
 		},
 	}
 

--- a/provider/aws/instances_test.go
+++ b/provider/aws/instances_test.go
@@ -91,7 +91,7 @@ func describeContainerInstancesResponse() string {
 }
 
 var cycleInstanceDescribeInstances = awsutil.Cycle{
-	awsutil.Request{"POST", "/", "", `Action=DescribeInstances&Filter.1.Name=tag%3ARack&Filter.1.Value.1=convox&Filter.2.Name=tag%3Aaws%3Acloudformation%3Alogical-id&Filter.2.Value.1=Instances&Version=2016-11-15`},
+	awsutil.Request{"POST", "/", "", `Action=DescribeInstances&Filter.1.Name=tag%3ARack&Filter.1.Value.1=convox&Filter.2.Name=tag%3Aaws%3Acloudformation%3Alogical-id&Filter.2.Value.1=Instances&Filter.2.Value.2=SpotInstances&Filter.3.Name=instance-state-name&Filter.3.Value.1=pending&Filter.3.Value.2=running&Filter.3.Value.3=shutting-down&Filter.3.Value.4=stopping&Version=2016-11-15`},
 	awsutil.Response{200, describeInstancesResponse()},
 }
 


### PR DESCRIPTION
If you set a USD value for the `SpotInstanceBid` rack parameter, Rack will try to run spot instances instead of On-Demand instances in your ECS cluster.

The `OnDemandMinCount` parameter can be set to configure a minimum number of on-demand instances that won't be replaced with spots. Its default value is 3.