### PR TITLE
Support a minor version number for v2 Docker Compose config files

### DIFF
--- a/manifest/fixtures/v2-0.yml
+++ b/manifest/fixtures/v2-0.yml
@@ -1,0 +1,4 @@
+version: "2.0"
+services:
+  web:
+    image: test

--- a/manifest/fixtures/v2-1.yml
+++ b/manifest/fixtures/v2-1.yml
@@ -1,0 +1,4 @@
+version: 2.1
+services:
+  web:
+    image: test

--- a/manifest/fixtures/v2-2.yml
+++ b/manifest/fixtures/v2-2.yml
@@ -1,0 +1,4 @@
+version: '2.2'
+services:
+  web:
+    image: test

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -46,7 +46,7 @@ func Load(data []byte) (*Manifest, error) {
 		if err := yaml.Unmarshal(data, &m.Services); err != nil {
 			return nil, fmt.Errorf("error loading manifest: %s", err)
 		}
-	case "2":
+	case "2", "2.0", "2.1", "2.2":
 		if err := yaml.Unmarshal(data, m); err != nil {
 			return nil, fmt.Errorf("error loading manifest: %s", err)
 		}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -52,6 +52,41 @@ func TestLoadVersion2(t *testing.T) {
 	}
 }
 
+func TestLoadVersion2Minor(t *testing.T) {
+	m, err := manifestFixture("v2-0")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, m.Version, "2.0")
+		assert.Equal(t, len(m.Services), 1)
+
+		if web := m.Services["web"]; assert.NotNil(t, web) {
+			assert.Equal(t, web.Image, "test")
+		}
+	}
+
+	m, err = manifestFixture("v2-1")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, m.Version, "2.1")
+		assert.Equal(t, len(m.Services), 1)
+
+		if web := m.Services["web"]; assert.NotNil(t, web) {
+			assert.Equal(t, web.Image, "test")
+		}
+	}
+
+	m, err = manifestFixture("v2-2")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, m.Version, "2.2")
+		assert.Equal(t, len(m.Services), 1)
+
+		if web := m.Services["web"]; assert.NotNil(t, web) {
+			assert.Equal(t, web.Image, "test")
+		}
+	}
+}
+
 func TestLoadCommandString(t *testing.T) {
 	m, err := manifestFixture("command-string")
 


### PR DESCRIPTION
I'm trying to use [`docker-compose config`](https://docs.docker.com/compose/reference/config/) to pre-process a Compose file template (`docker-compose.convox.yml`) and generate the Compose file (`docker-compose.<rack>.yml`) that I will pass to `convox build`, but it spits out the version as "2.0" which the builder doesn't seem to like.

```
❯ cat docker-compose.convox.yml | grep version
version: '2'

❯ docker-compose -f docker-compose.convox.yml config > docker-compose.staging.yml

❯ cat docker-compose.staging.yml | grep version
version: '2.0'

❯ convox build --app test -f docker-compose.staging.yml
Creating tarball... OK
Uploading: 3.93 MB / 3.93 MB [==========================] 100.00 % 48s
Starting build... OK
Authenticating nnnnnnnnnnnn.dkr.ecr.us-east-1.amazonaws.com: Login Succeeded
Authenticating https://index.docker.io/v1/: Login Succeeded

ERROR: unknown manifest version: 2.0
ERROR: test build failed
```

If you'd rather not explicitly support v2.1 I'm happy to take that out.