### PR TITLE
Add backup retention period for postgres RDS services.

### DIFF
--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -33,7 +33,7 @@ var resourceTypes = []ResourceType{
 	},
 	{
 		"postgres",
-		"[--allocated-storage=10] [--database=db-name] [--instance-type=db.t2.micro] [--max-connections={DBInstanceClassMemory/15000000}] [--multi-az] [--password=example] [--private] [--username=example] [--version=9.5.2]",
+		"[--allocated-storage=10] [--database=db-name] [--backup-retention-period] [--instance-type=db.t2.micro] [--max-connections={DBInstanceClassMemory/15000000}] [--multi-az] [--password=example] [--private] [--username=example] [--version=9.5.2]",
 	},
 	{
 		"redis",

--- a/provider/aws/templates/resource/postgres.tmpl
+++ b/provider/aws/templates/resource/postgres.tmpl
@@ -16,6 +16,11 @@
         "Default": "app",
         "Description": "Default database name"
       },
+      "BackupRetentionPeriod": {
+        "Type": "String",
+        "Default": "1",
+        "Description": "The automatic RDS backup retention period, (default 1 day)"
+      },
       "InstanceType": {
         "Type": "String",
         "Default": "db.t2.micro",
@@ -110,6 +115,7 @@
           "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
           "DBName": { "Ref": "Database" },
           "DBParameterGroupName": { "Ref": "ParameterGroup" },
+          "BackupRetentionPeriod":  { "Ref": "BackupRetentionPeriod" },
           "DBSubnetGroupName": { "Ref": "SubnetGroup" },
           "Engine": "postgres",
           "EngineVersion": { "Ref": "Version" },


### PR DESCRIPTION
# Context:
This PR adds the `BackupRetentionPeriod` parameter and allows you to set the automatic backup retention period for postgres RDS instances.

# Change:
Add `--backup-retention-period` to `convox services create postgres`
Add `BackupRetentionPeriod` to postgres template, with a default of 1 day (which is the AWS default).  