### PR TITLE
dont set on demand desired capacity directly

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1775,7 +1775,6 @@
           ] ]
         },
         "Cooldown": 5,
-        "DesiredCapacity": { "Ref": "InstanceCount" },
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },
@@ -1802,7 +1801,7 @@
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
           "MaxBatchSize": { "Ref": "InstanceUpdateBatchSize" },
-          "MinInstancesInService": { "Ref": "InstanceCount" },
+          "MinInstancesInService": { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },
           "PauseTime" : "PT15M",
           "SuspendProcesses": [
             "ScheduledActions"


### PR DESCRIPTION
Previously, updating `InstanceCount` on a rack with a `SpotInstanceBid` price would:

- Update the on-demand ASG desired capacity to `InstanceCount`
- Which triggers starting many new on-demand instances
- Which waits for many SUCCESS signals
- Then waits for the spot instance worker to reduce the on-demand ASG back to the proper amount

This resulted in long stack updates and windows of unneeded capacity when spot instances are available.

With this change, when spot is enabled, updating `InstanceCount` makes no changes to the on-demand ASG, so the stack update should be very quick, and the spot instance worker will re-balance in the background.
