### PR TITLE
Spot count desired capacity

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -885,7 +885,7 @@ func awsCLICredentials() (*AwsCredentials, error) {
 
 	fmt.Println("Using AWS CLI for authentication...")
 
-	data, err = awsCLI("iam", "get-user")
+	data, err = awsCLI("iam", "get-account-summary")
 	if err != nil {
 		if strings.Contains(string(data), "Unable to locate credentials") {
 			fmt.Println("You appear to have the AWS CLI installed but have not configured credentials.")

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1774,7 +1774,7 @@
             { "Fn::If": [ "ThirdAvailabilityZone", { "Ref": "Subnet2" }, { "Ref": "AWS::NoValue" } ] }
           ] ]
         },
-        "Cooldown": 6,
+        "Cooldown": 5,
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1775,6 +1775,7 @@
           ] ]
         },
         "Cooldown": 5,
+        "DesiredCapacity" : { "Fn::If": [ "SpotInstances", { "Ref": "AWS::NoValue" }, { "Ref": "InstanceCount" } ] },
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -2094,7 +2094,6 @@
           ] ]
         },
         "Cooldown": 5,
-        "DesiredCapacity": "0",
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : "0",

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1774,12 +1774,11 @@
             { "Fn::If": [ "ThirdAvailabilityZone", { "Ref": "Subnet2" }, { "Ref": "AWS::NoValue" } ] }
           ] ]
         },
-        "Cooldown": 5,
-        "DesiredCapacity": { "Ref": "InstanceCount" },
+        "Cooldown": 6,
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },
-        "MaxSize" : "1000",
+        "MaxSize" : { "Ref": "InstanceCount" },
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "Tags": [
           {
@@ -1802,7 +1801,7 @@
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
           "MaxBatchSize": { "Ref": "InstanceUpdateBatchSize" },
-          "MinInstancesInService": { "Ref": "InstanceCount" },
+          "MinInstancesInService": { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },
           "PauseTime" : "PT15M",
           "SuspendProcesses": [
             "ScheduledActions"

--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -2098,7 +2098,7 @@
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : "0",
-        "MaxSize" : "1000",
+        "MaxSize" : { "Ref": "InstanceCount" },
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "Tags": [
           {


### PR DESCRIPTION
Previously, updating `InstanceCount` on a rack with a `SpotInstanceBid` price would:

- Update the on-demand ASG desired capacity to `InstanceCount`
- Which triggers starting many new on-demand instances
- Which waits for many SUCCESS signals
- Then waits for the spot instance worker to reduce the on-demand ASG back to the proper amount

This resulted in long stack updates and windows of unneeded capacity when spot instances are available.

With this change, when spot is enabled, updating `InstanceCount` makes no changes to the on-demand ASG, so the stack update should be very quick, and the spot instance worker will re-balance in the background.

## Milestone Release
- [x] Release branch
- [x] Pass CI
- [x] Code review
- [ ] Merge into master
- [ ] Close milestone
- [ ] Release master
- [ ] Record release number: 
- [ ] Pass CI
- [ ] Update staging
- [ ] Deploy staging/site-staging
- [ ] Deploy staging/console-staging
- [ ] Verbose [release notes](https://github.com/convox/rack/releases)
- [ ] Documentation review
- [ ] Publish release
- [ ] Release CLI