### PR TITLE
hard code ASG max size

### DIFF
--- a/provider/aws/dist/rack.json
+++ b/provider/aws/dist/rack.json
@@ -1779,7 +1779,7 @@
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Ref": "InstanceCount" } ] },
-        "MaxSize" : { "Ref": "InstanceCount" },
+        "MaxSize" : "1000",
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "Tags": [
           {
@@ -2098,7 +2098,7 @@
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : "0",
-        "MaxSize" : { "Ref": "InstanceCount" },
+        "MaxSize" : "1000",
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "Tags": [
           {


### PR DESCRIPTION
Turning on spot instances on a rack with #2291 results in a CF error:

> 22:16:06 UTC-0700    UPDATE_FAILED    AWS::AutoScaling::AutoScalingGroup    Instances    MinInstancesInService must be less than the autoscaling group's MaxSize

Returning to a hard-coded large ASG MaxSize should avoid this

## Milestone Release
- [x] Release branch (20170918171936-spot-count)
- [x] Pass CI
- [x] Code review
- [x] Merge into master
- [ ] Close milestone
- [ ] Release master
- [ ] Record release number:
- [ ] Pass CI
- [ ] Update staging
- [ ] Deploy staging/site-staging
- [ ] Deploy staging/console-staging
- [ ] Verbose [release notes](https://github.com/convox/rack/releases)
- [ ] Documentation review
- [ ] Publish release
- [ ] Release CLI