### PR TITLE
Add backup retention period for postgres RDS services.

### DIFF
--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -33,7 +33,7 @@ var resourceTypes = []ResourceType{
 	},
 	{
 		"postgres",
-		"[--allocated-storage=10] [--database=db-name] [--instance-type=db.t2.micro] [--max-connections={DBInstanceClassMemory/15000000}] [--multi-az] [--password=example] [--private] [--username=example] [--version=9.5.2]",
+		"[--allocated-storage=10] [--database=db-name] [--backup-retention-period] [--instance-type=db.t2.micro] [--max-connections={DBInstanceClassMemory/15000000}] [--multi-az] [--password=example] [--private] [--username=example] [--version=9.5.2]",
 	},
 	{
 		"redis",

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -33,7 +33,7 @@ var resourceTypes = []ResourceType{
 	},
 	{
 		"postgres",
-		"[--allocated-storage=10] [--database=db-name] [--backup-retention-period] [--instance-type=db.t2.micro] [--max-connections={DBInstanceClassMemory/15000000}] [--multi-az] [--password=example] [--private] [--username=example] [--version=9.5.2]",
+		"[--allocated-storage=10] [--backup-retention-period=1] [--database=db-name] [--database-snapshot-identifier=db-snapshot-arn] [--instance-type=db.t2.micro] [--max-connections={DBInstanceClassMemory/15000000}] [--multi-az] [--password=example] [--private] [--username=example] [--version=9.5.2]",
 	},
 	{
 		"redis",

--- a/provider/aws/templates/resource/postgres.tmpl
+++ b/provider/aws/templates/resource/postgres.tmpl
@@ -16,6 +16,11 @@
         "Default": "app",
         "Description": "Default database name"
       },
+      "BackupRetentionPeriod": {
+        "Type": "String",
+        "Default": "1",
+        "Description": "The automatic RDS backup retention period, (default 1 day)"
+      },
       "InstanceType": {
         "Type": "String",
         "Default": "db.t2.micro",
@@ -110,6 +115,7 @@
           "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
           "DBName": { "Ref": "Database" },
           "DBParameterGroupName": { "Ref": "ParameterGroup" },
+          "BackupRetentionPeriod":  { "Ref": "BackupRetentionPeriod" },
           "DBSubnetGroupName": { "Ref": "SubnetGroup" },
           "Engine": "postgres",
           "EngineVersion": { "Ref": "Version" },

--- a/provider/aws/templates/resource/postgres.tmpl
+++ b/provider/aws/templates/resource/postgres.tmpl
@@ -2,6 +2,7 @@
   {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Conditions": {
+      "BlankDBSnapshotIdentifier": { "Fn::Equals": [ { "Ref": "DBSnapshotIdentifier"}, "" ] },
       "BlankMaxConnections": { "Fn::Equals": [ { "Ref": "MaxConnections" }, "" ] },
       "Private": { "Fn::Equals": [ { "Ref": "Private" }, "true" ] }
     },
@@ -28,7 +29,7 @@
       },
       "DBSnapshotIdentifier": {
         "Type": "String",
-        "Default": AWS::NoValue,
+        "Default": "",
         "Description": "ARN of database snapshot to restore"
       },
       "Family": {
@@ -118,8 +119,8 @@
           "AllocatedStorage": { "Ref": "AllocatedStorage" },
           "DBInstanceClass": { "Ref": "InstanceType" },
           "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
-          "DBName": { "Ref": "Database" },
-          "DBSnapshotIdentifier": { "Ref": "DBSnapshotIdentifier" },
+          "DBName": { "Fn::If": [ "BlankDBSnapshotIdentifier", { "Ref": "Database" }, { "Ref": "AWS::NoValue" } ] },
+          "DBSnapshotIdentifier": { "Fn::If": [ "BlankDBSnapshotIdentifier", { "Ref": "AWS::NoValue" }, { "Ref": "DBSnapshotIdentifier" } ] },
           "DBParameterGroupName": { "Ref": "ParameterGroup" },
           "BackupRetentionPeriod":  { "Ref": "BackupRetentionPeriod" },
           "DBSubnetGroupName": { "Ref": "SubnetGroup" },

--- a/provider/aws/templates/resource/postgres.tmpl
+++ b/provider/aws/templates/resource/postgres.tmpl
@@ -26,6 +26,11 @@
         "Default": "db.t2.micro",
         "Description": "Instance class for database nodes"
       },
+      "DBSnapshotIdentifier": {
+        "Type": "String",
+        "Default": AWS::NoValue,
+        "Description": "ARN of database snapshot to restore"
+      },
       "Family": {
         "Type": "String",
         "Default": "postgres9.6",
@@ -114,6 +119,7 @@
           "DBInstanceClass": { "Ref": "InstanceType" },
           "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
           "DBName": { "Ref": "Database" },
+          "DBSnapshotIdentifier": { "Ref": "DBSnapshotIdentifier" },
           "DBParameterGroupName": { "Ref": "ParameterGroup" },
           "BackupRetentionPeriod":  { "Ref": "BackupRetentionPeriod" },
           "DBSubnetGroupName": { "Ref": "SubnetGroup" },


### PR DESCRIPTION
Taking over from #2202 and #2284 by @denmat 

# RDS Backup Retention

## Context:
This PR adds the `BackupRetentionPeriod` parameter and allows you to set the automatic backup retention period for postgres RDS instances.

## Change:
Add `--backup-retention-period` to `convox services create postgres`
Add `BackupRetentionPeriod` to postgres template, with a default of 1 day (which is the AWS default).  

# RDS Snapshot

## Context:
This will add the ability to create a postgres RDS instance from a RDS snapshot.

## Change:
Adds the `--database-snapshot-identifier` and `DBSnapshotIdentifier` parameter to the postgres service.

If you do not include the `--database-snapshot-identifier` parameter the default `DBName` will be used.

If you include the `--database-snapshot-identifier` parameter you MUST include the master password for the database you are restoring from.