### PR TITLE
RDS snapshot

### DIFF
--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -33,7 +33,7 @@ var resourceTypes = []ResourceType{
 	},
 	{
 		"postgres",
-		"[--allocated-storage=10] [--database=db-name] [--instance-type=db.t2.micro] [--max-connections={DBInstanceClassMemory/15000000}] [--multi-az] [--password=example] [--private] [--username=example] [--version=9.5.2]",
+		"[--allocated-storage=10] [--database=db-name] [--database-snapshot-identifier=db-snapshot-arn] [--instance-type=db.t2.micro] [--max-connections={DBInstanceClassMemory/15000000}] [--multi-az] [--password=example] [--private] [--username=example] [--version=9.5.2]",
 	},
 	{
 		"redis",

--- a/provider/aws/templates/resource/postgres.tmpl
+++ b/provider/aws/templates/resource/postgres.tmpl
@@ -21,6 +21,11 @@
         "Default": "db.t2.micro",
         "Description": "Instance class for database nodes"
       },
+      "DBSnapshotIdentifier": {
+        "Type": "String",
+        "Default": AWS::NoValue,
+        "Description": "ARN of database snapshot to restore"
+      },
       "Family": {
         "Type": "String",
         "Default": "postgres9.6",
@@ -109,6 +114,7 @@
           "DBInstanceClass": { "Ref": "InstanceType" },
           "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
           "DBName": { "Ref": "Database" },
+          "DBSnapshotIdentifier": { "Ref": "DBSnapshotIdentifier" },
           "DBParameterGroupName": { "Ref": "ParameterGroup" },
           "DBSubnetGroupName": { "Ref": "SubnetGroup" },
           "Engine": "postgres",

--- a/provider/aws/templates/resource/postgres.tmpl
+++ b/provider/aws/templates/resource/postgres.tmpl
@@ -2,6 +2,7 @@
   {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Conditions": {
+      "BlankDBSnapshotIdentifier": { "Fn::Equals": [ { "Ref": "DBSnapshotIdentifier"}, "" ] },
       "BlankMaxConnections": { "Fn::Equals": [ { "Ref": "MaxConnections" }, "" ] },
       "Private": { "Fn::Equals": [ { "Ref": "Private" }, "true" ] }
     },
@@ -23,7 +24,7 @@
       },
       "DBSnapshotIdentifier": {
         "Type": "String",
-        "Default": AWS::NoValue,
+        "Default": "",
         "Description": "ARN of database snapshot to restore"
       },
       "Family": {
@@ -113,8 +114,8 @@
           "AllocatedStorage": { "Ref": "AllocatedStorage" },
           "DBInstanceClass": { "Ref": "InstanceType" },
           "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
-          "DBName": { "Ref": "Database" },
-          "DBSnapshotIdentifier": { "Ref": "DBSnapshotIdentifier" },
+          "DBName": { "Fn::If": [ "BlankDBSnapshotIdentifier", { "Ref": "Database" }, { "Ref": "AWS::NoValue" } ] },
+          "DBSnapshotIdentifier": { "Fn::If": [ "BlankDBSnapshotIdentifier", { "Ref": "AWS::NoValue" }, { "Ref": "DBSnapshotIdentifier" } ] },
           "DBParameterGroupName": { "Ref": "ParameterGroup" },
           "DBSubnetGroupName": { "Ref": "SubnetGroup" },
           "Engine": "postgres",


### PR DESCRIPTION
https://github.com/convox/rack/issues/2202

## Context:
This will add the ability to create a postgres RDS instance from a RDS snapshot.

## Change:
Adds the `--database-snapshot-identifier` and `DBSnapshotIdentifier` parameter to the postgres service.

If you do not include the `--database-snapshot-identifier` parameter the default `DBName` will be used.

If you include the `--database-snapshot-identifier` parameter you MUST include the master password for the database you are restoring from.

I'm happy to update the documentation too if needed.