### PR TITLE
Add extra prompt before deleting resources

### DIFF
--- a/cmd/convox/resources_test.go
+++ b/cmd/convox/resources_test.go
@@ -127,7 +127,17 @@ func TestResourcesDelete(t *testing.T) {
 		test.ExecRun{
 			Command: "convox resources delete syslog-1234",
 			Exit:    0,
-			Stdout:  "Deleting syslog-1234... DELETING\n",
+			Stdout:  "Are you sure you want to delete syslog-1234? (N/y): Deleting syslog-1234... DELETING\n",
+			Stdin: "y",
+		},
+	)
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox resources delete syslog-1234",
+			Exit:    1,
+			Stdout:  "Are you sure you want to delete syslog-1234? (N/y): ",
+			Stdin: "n",
 		},
 	)
 }

--- a/cmd/convox/services.go
+++ b/cmd/convox/services.go
@@ -13,6 +13,8 @@ import (
 	"github.com/convox/rack/cmd/convox/stdcli"
 	"gopkg.in/urfave/cli.v1"
 	"time"
+	"bufio"
+	"os"
 )
 
 // ResourceType is the type of an external resource.
@@ -281,9 +283,15 @@ func cmdResourceDelete(c *cli.Context) error {
 
 	name := c.Args()[0]
 
+	err := verifyDelete(name)
+
+	if err != nil {
+		return stdcli.Error(err)
+	}
+
 	fmt.Printf("Deleting %s... ", name)
 
-	_, err := rackClient(c).DeleteResource(name)
+	_, err = rackClient(c).DeleteResource(name)
 	if err != nil {
 		return stdcli.Error(err)
 	}
@@ -490,4 +498,17 @@ func waitForResource(c *client.Client, n string, t string, w bool) error {
 	}
 
 	return nil
+}
+
+func verifyDelete(name string) error {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("Are you sure you want to delete %s? (N/y): ", name)
+	text, _ := reader.ReadString('\n')
+	lowerText := strings.TrimSpace(strings.ToLower(text))
+
+	if lowerText != "y" {
+		return fmt.Errorf("Aborting delete for: %s", name)
+	}
+
+	return  nil
 }

--- a/cmd/convox/services_test.go
+++ b/cmd/convox/services_test.go
@@ -131,7 +131,17 @@ func TestServicesDelete(t *testing.T) {
 		test.ExecRun{
 			Command: "convox services delete syslog-1234",
 			Exit:    0,
-			Stdout:  "Deleting syslog-1234... DELETING\n",
+			Stdout:  "Are you sure you want to delete syslog-1234? (N/y): Deleting syslog-1234... DELETING\n",
+			Stdin:  "y",
+		},
+	)
+
+	test.Runs(t,
+		test.ExecRun{
+			Command: "convox services delete syslog-1234",
+			Exit:    1,
+			Stdout:  "Are you sure you want to delete syslog-1234? (N/y): ",
+			Stdin:  "r",
 		},
 	)
 }


### PR DESCRIPTION
Add a second prompt so that accidental database deletions happen less frequently. 

I tried running the tests locally but didn't want to set up AWS. If travis fails, I will update the PR. 

UPDATE: tests pass :) 