### PR TITLE
Update DatabaseSnapshotIdentifier paramater Postgres template

### DIFF
--- a/provider/aws/templates/resource/postgres.tmpl
+++ b/provider/aws/templates/resource/postgres.tmpl
@@ -2,7 +2,7 @@
   {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Conditions": {
-      "BlankDBSnapshotIdentifier": { "Fn::Equals": [ { "Ref": "DBSnapshotIdentifier"}, "" ] },
+      "BlankDatabaseSnapshotIdentifier": { "Fn::Equals": [ { "Ref": "DatabaseSnapshotIdentifier"}, "" ] },
       "BlankMaxConnections": { "Fn::Equals": [ { "Ref": "MaxConnections" }, "" ] },
       "Private": { "Fn::Equals": [ { "Ref": "Private" }, "true" ] }
     },
@@ -27,7 +27,7 @@
         "Default": "db.t2.micro",
         "Description": "Instance class for database nodes"
       },
-      "DBSnapshotIdentifier": {
+      "DatabaseSnapshotIdentifier": {
         "Type": "String",
         "Default": "",
         "Description": "ARN of database snapshot to restore"
@@ -119,8 +119,8 @@
           "AllocatedStorage": { "Ref": "AllocatedStorage" },
           "DBInstanceClass": { "Ref": "InstanceType" },
           "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
-          "DBName": { "Fn::If": [ "BlankDBSnapshotIdentifier", { "Ref": "Database" }, { "Ref": "AWS::NoValue" } ] },
-          "DBSnapshotIdentifier": { "Fn::If": [ "BlankDBSnapshotIdentifier", { "Ref": "AWS::NoValue" }, { "Ref": "DBSnapshotIdentifier" } ] },
+          "DBName": { "Fn::If": [ "BlankDatabaseSnapshotIdentifier", { "Ref": "Database" }, { "Ref": "AWS::NoValue" } ] },
+          "DatabaseSnapshotIdentifier": { "Fn::If": [ "BlankDatabaseSnapshotIdentifier", { "Ref": "AWS::NoValue" }, { "Ref": "DatabaseSnapshotIdentifier" } ] },
           "DBParameterGroupName": { "Ref": "ParameterGroup" },
           "BackupRetentionPeriod":  { "Ref": "BackupRetentionPeriod" },
           "DBSubnetGroupName": { "Ref": "SubnetGroup" },


### PR DESCRIPTION
This should address missing parameter issue raised [here](https://github.com/convox/rack/pull/2300#issuecomment-336265792). 

Template parameters should be 1:1 match with CLI:

https://github.com/convox/rack/blob/master/cmd/convox/services.go#L38

CC @ddollar @nzoschke 