### PR TITLE
add s3-template-url.

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -162,6 +162,11 @@ func init() {
 				Value: defaultSubnetCIDRs,
 				Usage: "subnet CIDRs",
 			},
+			cli.StringFlag{
+				Name:   "s3-template-url",
+				Value:  "",
+				Usage:  "specify an amazon s3 template url for rack",
+			},
 		},
 	})
 }
@@ -415,7 +420,9 @@ func cmdInstall(c *cli.Context) error {
 
 		req.TemplateURL = nil
 		req.TemplateBody = aws.String(t.String())
-	}
+	} else if c.String("s3-template-url") != "" {
+		req.TemplateURL = aws.String(c.String("s3-template-url"))
+        }
 
 	res, err := CloudFormation.CreateStack(req)
 	if err != nil {


### PR DESCRIPTION
Support customized CFN template in user's S3 Bucket, `convox install --stack-name myrack --s3-template-url https://bucket.s3.amazonaws.com/release/20171113014715/formation.json`.