### PR TITLE
support multiple domains for gen2 services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 .env
 .git
-/monitor
+coverage.txt
 docker-compose.yml
 api/models/fixtures/fixture
 cmd/changes/changes

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -31,7 +31,7 @@ func TestManifestLoad(t *testing.T) {
 				Build: manifest.ServiceBuild{
 					Path: "api",
 				},
-				Domain:  "foo.example.org",
+				Domains: []string{"foo.example.org"},
 				Command: "",
 				Environment: []string{
 					"DEVELOPMENT=false",
@@ -53,6 +53,7 @@ func TestManifestLoad(t *testing.T) {
 			manifest.Service{
 				Name:    "proxy",
 				Command: "bash",
+				Domains: []string{"bar.example.org", "*.example.org"},
 				Health: manifest.ServiceHealth{
 					Path:     "/auth",
 					Interval: 5,
@@ -74,6 +75,7 @@ func TestManifestLoad(t *testing.T) {
 					Path: ".",
 				},
 				Command: "foo",
+				Domains: []string{"baz.example.org", "qux.example.org"},
 				Health: manifest.ServiceHealth{
 					Interval: 5,
 					Path:     "/",

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -12,7 +12,7 @@ type Service struct {
 
 	Build       ServiceBuild       `yaml:"build,omitempty"`
 	Command     string             `yaml:"command,omitempty"`
-	Domain      string             `yaml:"domain,omitempty"`
+	Domains     ServiceDomains     `yaml:"domain,omitempty"`
 	Environment ServiceEnvironment `yaml:"environment,omitempty"`
 	Health      ServiceHealth      `yaml:"health,omitempty"`
 	Image       string             `yaml:"image,omitempty"`
@@ -36,6 +36,8 @@ type ServiceCommand struct {
 	Test        string
 	Production  string
 }
+
+type ServiceDomains []string
 
 type ServiceEnvironment []string
 
@@ -64,8 +66,12 @@ func (s Service) BuildHash() string {
 	return fmt.Sprintf("%x", sha1.Sum([]byte(fmt.Sprintf("build[path=%q, args=%v] image=%q", s.Build.Path, s.Build.Args, s.Image))))
 }
 
-func (s Service) GetName() string {
-	return s.Name
+func (s Service) Domain() string {
+	if len(s.Domains) < 1 {
+		return ""
+	}
+
+	return s.Domains[0]
 }
 
 func (s Service) EnvironmentDefaults() map[string]string {
@@ -91,6 +97,10 @@ func (s Service) EnvironmentKeys() string {
 	sort.Strings(keys)
 
 	return strings.Join(keys, ",")
+}
+
+func (s Service) GetName() string {
+	return s.Name
 }
 
 func (s *Service) SetDefaults() error {

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -18,6 +18,9 @@ services:
     test: make ${BAR} test
   proxy:
     command: bash
+    domain:
+      - bar.example.org
+      - "*.example.org"
     image: ubuntu:16.04
     environment:
       - SECRET
@@ -27,6 +30,7 @@ services:
       memory: 512
   foo:
     command: foo
+    domain: baz.example.org, qux.example.org
     health:
       timeout: 3
     port:

--- a/manifest/yaml.go
+++ b/manifest/yaml.go
@@ -108,6 +108,34 @@ func (v *ServiceCommand) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	return nil
 }
 
+func (v *ServiceDomains) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var w interface{}
+
+	if err := unmarshal(&w); err != nil {
+		return err
+	}
+
+	switch t := w.(type) {
+	case []interface{}:
+		for _, s := range t {
+			switch st := s.(type) {
+			case string:
+				*v = append(*v, st)
+			default:
+				return fmt.Errorf("unknown type for service domain: %T", s)
+			}
+		}
+	case string:
+		for _, d := range strings.Split(t, ",") {
+			*v = append(*v, strings.TrimSpace(d))
+		}
+	default:
+		return fmt.Errorf("unknown type for service domain: %T", t)
+	}
+
+	return nil
+}
+
 func (v *ServiceEnvironment) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var w interface{}
 

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -54,7 +54,7 @@
 {{ end }}
 
 {{ define "balancer-resources" }}
-  {{ range .Manifest.Services }}
+  {{ range $service := .Manifest.Services }}
     {{ if .Port.Port }}
       "Balancer{{ upper .Name }}ListenerRule80": {
         "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
@@ -79,10 +79,18 @@
           "Type": "AWS::CertificateManager::Certificate",
           "Properties": {
             "DomainName": "{{ .Domain }}",
-            "DomainValidationOptions": [{
-              "DomainName": "{{ .Domain }}",
-              "ValidationDomain": "{{ apex .Domain }}"
-            }]
+            "DomainValidationOptions": [
+              {{ range .Domains }}
+                { "DomainName": "{{ . }}", "ValidationDomain": "{{ apex . }}" },
+              {{ end }}
+              { "Ref": "AWS::NoValue" }
+            ],
+            "SubjectAlternativeNames": [
+              {{ range .Domains }}
+                "{{.}}",
+              {{ end }}
+              { "Ref": "AWS::NoValue" }
+            ]
           }
         },
         "Balancer{{ upper .Name }}ListenerCertificate": {
@@ -92,24 +100,32 @@
             "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener443" } }
           }
         },
-        "Balancer{{ upper .Name }}ListenerRule80Domain": {
-          "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
-          "Properties": {
-            "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup" } } ],
-            "Conditions": [ { "Field": "host-header", "Values": [ "{{ .Domain }}" ] } ],
-            "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener80" } },
-            "Priority": "{{ priority $.App (print .Name "-Domain") }}"
-          }
-        },
-        "Balancer{{ upper .Name }}ListenerRule443Domain": {
-          "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
-          "Properties": {
-            "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup" } } ],
-            "Conditions": [ { "Field": "host-header", "Values": [ "{{ .Domain }}" ] } ],
-            "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener443" } },
-            "Priority": "{{ priority $.App (print .Name "-Domain") }}"
-          }
-        },
+        {{ range $i, $domain := .Domains }}
+          "Balancer{{ upper $service.Name }}ListenerRule80Domain{{$i}}": {
+            "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+            {{ if gt $i 0 }}
+              "DependsOn": "Balancer{{ upper $service.Name }}ListenerRule80Domain{{ dec $i }}",
+            {{ end }}
+            "Properties": {
+              "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper $service.Name }}TargetGroup" } } ],
+              "Conditions": [ { "Field": "host-header", "Values": [ "{{$domain}}" ] } ],
+              "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener80" } },
+              "Priority": "{{ priority $.App $domain }}"
+            }
+          },
+          "Balancer{{ upper $service.Name }}ListenerRule443Domain{{$i}}": {
+            "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+            {{ if gt $i 0 }}
+              "DependsOn": "Balancer{{ upper $service.Name }}ListenerRule443Domain{{ dec $i }}",
+            {{ end }}
+            "Properties": {
+              "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper $service.Name }}TargetGroup" } } ],
+              "Conditions": [ { "Field": "host-header", "Values": [ "{{$domain}}" ] } ],
+              "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener443" } },
+              "Priority": "{{ priority $.App $domain }}"
+            }
+          },
+        {{ end }}
       {{ end }}
       "Balancer{{ upper .Name }}TargetGroup": {
         "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",

--- a/provider/aws/template.go
+++ b/provider/aws/template.go
@@ -27,8 +27,15 @@ func formationHelpers() template.FuncMap {
 			}
 			return domain
 		},
-		"priority": func(app, service string) uint32 {
-			return crc32.ChecksumIEEE([]byte(fmt.Sprintf("%s-%s", app, service))) % 50000
+		"dec": func(i int) int {
+			return i - 1
+		},
+		"priority": func(app, domain string) uint32 {
+			tier := uint32(1)
+			if strings.HasPrefix(domain, "*.") {
+				tier = 25000
+			}
+			return (crc32.ChecksumIEEE([]byte(fmt.Sprintf("%s-%s", app, domain))) % 25000) + tier
 		},
 		"safe": func(s string) template.HTML {
 			return template.HTML(s)


### PR DESCRIPTION
You can specify multiple domains in either of these formats:

```
service:
  foo:
    domain:
      - foo.example.org
      - *.foo.example.org
  bar:
    domain: bar.example.org, *.bar.example.org
```

