### PR TITLE
Add short name `-d` for `--description` flag

### DIFF
--- a/cmd/convox/builds.go
+++ b/cmd/convox/builds.go
@@ -47,7 +47,7 @@ var (
 			Usage:  "path to an alternate docker compose manifest file",
 		},
 		cli.StringFlag{
-			Name:  "description",
+			Name:  "description, d",
 			Value: "",
 			Usage: "description of the build",
 		},


### PR DESCRIPTION
This PR adds a short alternate name `-d` for flag `--description`.  

Justification: When running `convox deploy` or `convox build`, it is almost always a good practice to include a description.  Yet typing `--description` is verbose and tiresome.  Therefore adding short alternate name `-d` for this commonly used flag will increase programmer happiness.  