### PR TITLE
switch load balancer ports when switching to private api

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -1805,10 +1805,16 @@
         "CrossZone": true,
         "HealthCheck": { "HealthyThreshold": "2", "Interval": 5, "Target": "HTTPS:3002/check", "Timeout": 3, "UnhealthyThreshold": "2" },
         "LBCookieStickinessPolicy": [ { "PolicyName": "affinity" } ],
-        "Listeners": [
-          { "Protocol": "TCP", "LoadBalancerPort": "80", "InstanceProtocol": "TCP", "InstancePort": "3001" },
-          { "Protocol": "TCP", "LoadBalancerPort": "443", "InstanceProtocol": "TCP", "InstancePort": "3002" }
-        ],
+        "Listeners": { "Fn::If": [ "PrivateApi",
+          [
+            { "Protocol": "TCP", "LoadBalancerPort": "80", "InstanceProtocol": "TCP", "InstancePort": "3003" },
+            { "Protocol": "TCP", "LoadBalancerPort": "443", "InstanceProtocol": "TCP", "InstancePort": "3004" }
+          ],
+          [
+            { "Protocol": "TCP", "LoadBalancerPort": "80", "InstanceProtocol": "TCP", "InstancePort": "3001" },
+            { "Protocol": "TCP", "LoadBalancerPort": "443", "InstanceProtocol": "TCP", "InstancePort": "3002" }
+          ]
+        ] },
         "LoadBalancerName": { "Fn::If": [ "PrivateApi", { "Fn::Join": [ "-", [ { "Ref": "AWS::StackName" }, "i" ] ] }, { "Ref": "AWS::StackName" } ] },
         "Scheme": { "Fn::If": [ "PrivateApi", "internal", { "Ref": "AWS::NoValue" } ] },
         "SecurityGroups": [ { "Ref": "BalancerSecurity" } ],
@@ -2113,10 +2119,16 @@
             "Memory": { "Ref": "ApiMemory" },
             "MountPoints": [ { "SourceVolume": "docker", "ContainerPath": "/var/run/docker.sock" } ],
             "Name": "web",
-            "PortMappings": [
-              { "HostPort": "3001", "ContainerPort": "3000", "Protocol": "tcp" },
-              { "HostPort": "3002", "ContainerPort": "4443", "Protocol": "tcp" }
-            ]
+            "PortMappings": { "Fn::If": [ "PrivateApi",
+              [
+                { "HostPort": "3003", "ContainerPort": "3000", "Protocol": "tcp" },
+                { "HostPort": "3004", "ContainerPort": "4443", "Protocol": "tcp" }
+              ],
+              [
+                { "HostPort": "3001", "ContainerPort": "3000", "Protocol": "tcp" },
+                { "HostPort": "3002", "ContainerPort": "4443", "Protocol": "tcp" }
+              ]
+            ] }
           }
         ],
         "Family": { "Fn::Sub": "${AWS::StackName}-web" },


### PR DESCRIPTION
avoids service-level conflict during ecs replacement