### PR TITLE
Generation 2 Links and Internal Services

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -153,7 +153,6 @@ func (a *App) Create() error {
 
 	params := map[string]string{
 		"Cluster":        os.Getenv("CLUSTER"),
-		"Internal":       os.Getenv("INTERNAL"),
 		"LogBucket":      os.Getenv("LOG_BUCKET"),
 		"Private":        os.Getenv("PRIVATE"),
 		"Subnets":        os.Getenv("SUBNETS"),

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -16,6 +16,7 @@ type Service struct {
 	Environment ServiceEnvironment `yaml:"environment,omitempty"`
 	Health      ServiceHealth      `yaml:"health,omitempty"`
 	Image       string             `yaml:"image,omitempty"`
+	Links       []string           `yaml:"links,omitempty"`
 	Port        ServicePort        `yaml:"port,omitempty"`
 	Privileged  bool               `yaml:"privileged,omitempty"`
 	Resources   []string           `yaml:"resources,omitempty"`

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -16,6 +16,7 @@ type Service struct {
 	Environment ServiceEnvironment `yaml:"environment,omitempty"`
 	Health      ServiceHealth      `yaml:"health,omitempty"`
 	Image       string             `yaml:"image,omitempty"`
+	Internal    bool               `yaml:"internal,omitempty"`
 	Links       []string           `yaml:"links,omitempty"`
 	Port        ServicePort        `yaml:"port,omitempty"`
 	Privileged  bool               `yaml:"privileged,omitempty"`

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -46,6 +46,7 @@ type AWSProvider struct {
 	DynamoBuilds        string
 	DynamoReleases      string
 	EncryptionKey       string
+	Internal            bool
 	LogBucket           string
 	NotificationHost    string
 	NotificationTopic   string
@@ -76,6 +77,7 @@ func FromEnv() *AWSProvider {
 		DynamoBuilds:        os.Getenv("DYNAMO_BUILDS"),
 		DynamoReleases:      os.Getenv("DYNAMO_RELEASES"),
 		EncryptionKey:       os.Getenv("ENCRYPTION_KEY"),
+		Internal:            os.Getenv("INTERNAL") == "Yes",
 		LogBucket:           os.Getenv("LOG_BUCKET"),
 		NotificationHost:    os.Getenv("NOTIFICATION_HOST"),
 		NotificationTopic:   os.Getenv("NOTIFICATION_TOPIC"),

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -235,7 +235,7 @@
               {{ end }}
               {{ range .Links }}
                 { "Name": "{{ upcase . }}_URL", "Value": { "Fn::Join": [ ".", [
-                  "{{$.App}}-{{.}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router . $.Manifest }}Host" } }
+                  "https://{{$.App}}-{{.}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router . $.Manifest }}Host" } }
                 ] ] } },
               {{ end }}
               {{ range .Resources }}

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -47,7 +47,7 @@
   {{ range .Manifest.Services }}
     {{ if .Port.Port }}
       "{{ upper .Name }}Endpoint": {
-        "Value": { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] }
+        "Value": { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Host" } } ] ] }
       },
     {{ end }}
   {{ end }}
@@ -59,18 +59,18 @@
       "Balancer{{ upper .Name }}ListenerRule80": {
         "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
         "Properties": {
-          "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup" } } ],
-          "Conditions": [ { "Field": "host-header", "Values": [ { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] } ] } ],
-          "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener80" } },
+        "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup{{ if .Internal }}Internal{{ end }}" } } ],
+          "Conditions": [ { "Field": "host-header", "Values": [ { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Host" } } ] ] } ] } ],
+          "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Listener80" } },
           "Priority": "{{ priority $.App .Name }}"
         }
       },
       "Balancer{{ upper .Name }}ListenerRule443": {
         "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
         "Properties": {
-          "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup" } } ],
-          "Conditions": [ { "Field": "host-header", "Values": [ { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] } ] } ],
-          "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener443" } },
+        "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup{{ if .Internal }}Internal{{ end }}" } } ],
+          "Conditions": [ { "Field": "host-header", "Values": [ { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Host" } } ] ] } ] } ],
+          "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Listener443" } },
           "Priority": "{{ priority $.App .Name }}"
         }
       },
@@ -97,7 +97,7 @@
           "Type": "AWS::ElasticLoadBalancingV2::ListenerCertificate",
           "Properties": {
             "Certificates": [ { "CertificateArn": { "Ref": "Balancer{{ upper .Name }}Certificate" } } ],
-            "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener443" } }
+            "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Listener443" } }
           }
         },
         {{ range $i, $domain := .Domains }}
@@ -107,9 +107,9 @@
               "DependsOn": "Balancer{{ upper $service.Name }}ListenerRule80Domain{{ dec $i }}",
             {{ end }}
             "Properties": {
-              "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper $service.Name }}TargetGroup" } } ],
+            "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper $service.Name }}TargetGroup{{ if $service.Internal }}Internal{{ end }}" } } ],
               "Conditions": [ { "Field": "host-header", "Values": [ "{{$domain}}" ] } ],
-              "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener80" } },
+              "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router $service.Name $.Manifest }}Listener80" } },
               "Priority": "{{ priority $.App $domain }}"
             }
           },
@@ -119,15 +119,15 @@
               "DependsOn": "Balancer{{ upper $service.Name }}ListenerRule443Domain{{ dec $i }}",
             {{ end }}
             "Properties": {
-              "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper $service.Name }}TargetGroup" } } ],
+            "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper $service.Name }}TargetGroup{{ if $service.Internal }}Internal{{ end }}" } } ],
               "Conditions": [ { "Field": "host-header", "Values": [ "{{$domain}}" ] } ],
-              "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener443" } },
+              "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Listener443" } },
               "Priority": "{{ priority $.App $domain }}"
             }
           },
         {{ end }}
       {{ end }}
-      "Balancer{{ upper .Name }}TargetGroup": {
+      "Balancer{{ upper .Name }}TargetGroup{{ if .Internal }}Internal{{ end }}": {
         "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
         "Properties": {
           "HealthCheckIntervalSeconds": "{{.Health.Interval}}",
@@ -209,7 +209,7 @@
         "DeploymentConfiguration": { "MinimumHealthyPercent": "50", "MaximumPercent": "200" },
         "DesiredCount": { "Fn::Select": [ 0, { "Ref": "{{ upper .Name }}Formation" } ] },
         {{ if .Port.Port }}
-          "LoadBalancers": [ { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup" } } ],
+          "LoadBalancers": [ { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup{{ if .Internal }}Internal{{ end }}" } } ],
           "Role": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:ServiceRole" } },
         {{ end }}
         "PlacementStrategies": [
@@ -235,7 +235,7 @@
               {{ end }}
               {{ range .Links }}
                 { "Name": "{{ upcase . }}_URL", "Value": { "Fn::Join": [ ".", [
-                  "{{$.App}}-{{.}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } }
+                  "{{$.App}}-{{.}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router . $.Manifest }}Host" } }
                 ] ] } },
               {{ end }}
               {{ range .Resources }}

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -233,6 +233,11 @@
               {{ range $k, $v := .EnvironmentDefaults }}
                 { "Name": "{{$k}}", "Value": "{{ safe $v }}" },
               {{ end }}
+              {{ range .Links }}
+                { "Name": "{{ upcase . }}_URL", "Value": { "Fn::Join": [ ".", [
+                  "{{$.App}}-{{.}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } }
+                ] ] } },
+              {{ end }}
               {{ range .Resources }}
                 { "Name": "{{ upcase . }}_URL", "Value": { "Fn::GetAtt": [ "Resource{{ upper . }}", "Outputs.Url" ] } },
               {{ end }}

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -171,7 +171,7 @@
   {{ range .Services }}
     "{{ upper .Name }}Formation": {
       "Type": "CommaDelimitedList",
-      "Default": "0,128,256",
+      "Default": "{{.Scale.Count.Min}},128,256",
       "Description": "Count,CPU,Memory"
     },
   {{ end }}

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -25,6 +25,7 @@
       "Fn::And": [ { "Condition": "ExistingVpc" }, { "Condition": "InternetGateway" } ]
     },
     "HttpProxy": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "HttpProxy" }, "" ] } ] },
+    "Internal": { "Fn::Equals": [ { "Ref": "Internal" }, "Yes" ] },
     "InternetGateway": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "InternetGateway" }, "" ] } ] },
     "NotExistingVpcAndBlankInternetGateway": { "Fn::Not": [ { "Condition": "ExistingVpcAndBlankInternetGateway" } ] },
     "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] },
@@ -193,14 +194,6 @@
     "Release": {
       "Value": { "Ref": "Version" }
     },
-    "Router": {
-      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:Router" } },
-      "Value": { "Fn::Join": [ ".", [
-        { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "Router", "DNSName" ] } ] } ] },
-        { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "Router", "DNSName" ] } ] } ] },
-        "rack.convox.io"
-      ] ] }
-    },
     "RouterHost": {
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:RouterHost" } },
       "Value": { "Fn::Join": [ ".", [
@@ -216,6 +209,25 @@
     "RouterListener443": {
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:RouterListener443" } },
       "Value": { "Ref": "RouterListener443" }
+    },
+    "RouterInternalHost": {
+      "Condition": "Internal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:RouterInternalHost" } },
+      "Value": { "Fn::Join": [ ".", [
+        { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "RouterInternal", "DNSName" ] } ] } ] },
+        { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "RouterInternal", "DNSName" ] } ] } ] },
+        "convox.site"
+      ] ] }
+    },
+    "RouterInternalListener80": {
+      "Condition": "Internal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:RouterInternalListener80" } },
+      "Value": { "Ref": "RouterInternalListener80" }
+    },
+    "RouterInternalListener443": {
+      "Condition": "Internal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:RouterInternalListener443" } },
+      "Value": { "Ref": "RouterInternalListener443" }
     },
     "RouteTablePublic": {
       "Condition": "NotExistingVpcAndBlankInternetGateway",
@@ -381,7 +393,7 @@
     },
     "Internal": {
       "Type": "String",
-      "Description": "Create applications that are only accessible inside the VPC",
+      "Description": "Support applications that are only accessible inside the VPC",
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
     },
@@ -1728,8 +1740,8 @@
       }
     },
     "RouterSecurity": {
-      "DependsOn": "ApiRole",
       "Type": "AWS::EC2::SecurityGroup",
+      "DependsOn": "ApiRole",
       "Properties": {
         "GroupDescription": { "Fn::Sub": "${AWS::StackName} router" },
         "SecurityGroupIngress": [ { "CidrIp": "0.0.0.0/0", "IpProtocol": "tcp", "FromPort": "0", "ToPort": "65535" } ],
@@ -1757,8 +1769,8 @@
       }
     },
     "RouterApiCertificate": {
-      "DependsOn": "RouterApiTargetGroup",
       "Type": "AWS::CertificateManager::Certificate",
+      "DependsOn": "RouterApiTargetGroup",
       "Properties": {
         "DomainName": { "Fn::Join": [ ".", [
           "*",
@@ -1784,6 +1796,102 @@
       "DependsOn": "Router",
       "Properties": {
         "Name": { "Fn::Sub": "${AWS::StackName}-api" },
+        "HealthCheckIntervalSeconds": "5",
+        "HealthCheckTimeoutSeconds": "3",
+        "UnhealthyThresholdCount": "2",
+        "HealthCheckPath": "/check",
+        "Port": "4443",
+        "Protocol": "HTTPS",
+        "TargetGroupAttributes": [
+          { "Key": "deregistration_delay.timeout_seconds", "Value": "30" },
+          { "Key": "stickiness.enabled", "Value": "true" }
+        ],
+        "VpcId": { "Fn::If": [ "BlankExistingVpc", { "Ref": "Vpc" }, { "Ref": "ExistingVpc" } ] }
+      }
+    },
+    "RouterInternal": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Condition": "Internal",
+      "DependsOn": [ "ApiRole", "LogsPolicy" ],
+      "Properties": {
+        "LoadBalancerAttributes": [
+          { "Key": "access_logs.s3.enabled", "Value": "true" },
+          { "Key": "access_logs.s3.bucket", "Value": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] } },
+          { "Key": "access_logs.s3.prefix", "Value": { "Fn::Sub": "convox/logs/${AWS::StackName}/alb" } },
+          { "Key": "idle_timeout.timeout_seconds", "Value": "3600" }
+        ],
+        "Name": { "Fn::Sub": "${AWS::StackName}-rti" },
+        "Scheme": "internal",
+        "Subnets": [
+          { "Ref": "Subnet0" },
+          { "Ref": "Subnet1" },
+          { "Fn::If": [ "ThirdAvailabilityZone", { "Ref": "Subnet2" }, { "Ref": "AWS::NoValue" } ] }
+        ],
+        "SecurityGroups": [ { "Ref": "RouterSecurity" } ]
+      }
+    },
+    "RouterInternalSecurity": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Condition": "Internal",
+      "DependsOn": "ApiRole",
+      "Properties": {
+        "GroupDescription": { "Fn::Sub": "${AWS::StackName} internal router" },
+        "SecurityGroupIngress": [ { "CidrIp": { "Ref": "VPCCIDR" }, "IpProtocol": "tcp", "FromPort": "0", "ToPort": "65535" } ],
+        "Tags": [ { "Key": "Name", "Value": { "Fn::Sub": "${AWS::StackName}-router-internal" } } ],
+        "VpcId": { "Fn::If": [ "BlankExistingVpc", { "Ref": "Vpc" }, { "Ref": "ExistingVpc" } ] }
+      }
+    },
+    "RouterInternalListener80": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Condition": "Internal",
+      "Properties": {
+        "DefaultActions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "RouterInternalApiTargetGroup" } } ],
+        "LoadBalancerArn": { "Ref" : "RouterInternal" },
+        "Port": "80",
+        "Protocol": "HTTP"
+      }
+    },
+    "RouterInternalListener443": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Condition": "Internal",
+      "Properties": {
+        "Certificates": [ { "CertificateArn": { "Ref": "RouterInternalCertificate" } } ],
+        "DefaultActions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "RouterInternalApiTargetGroup" } } ],
+        "LoadBalancerArn": { "Ref" : "RouterInternal" },
+        "Port": "443",
+        "Protocol": "HTTPS"
+      }
+    },
+    "RouterInternalCertificate": {
+      "Type": "AWS::CertificateManager::Certificate",
+      "Condition": "Internal",
+      "DependsOn": "RouterInternalApiTargetGroup",
+      "Properties": {
+        "DomainName": { "Fn::Join": [ ".", [
+          "*",
+          { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "RouterInternal", "DNSName" ] } ] } ] },
+          { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "RouterInternal", "DNSName" ] } ] } ] },
+          "convox.site"
+        ] ] },
+        "DomainValidationOptions": [
+          {
+            "DomainName": { "Fn::Join": [ ".", [
+              "*",
+              { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "RouterInternal", "DNSName" ] } ] } ] },
+              { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "RouterInternal", "DNSName" ] } ] } ] },
+              "convox.site"
+            ] ] },
+            "ValidationDomain": "convox.site"
+          }
+        ]
+      }
+    },
+    "RouterInternalApiTargetGroup": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Condition": "Internal",
+      "DependsOn": "RouterInternal",
+      "Properties": {
+        "Name": { "Fn::Sub": "${AWS::StackName}-api-internal" },
         "HealthCheckIntervalSeconds": "5",
         "HealthCheckTimeoutSeconds": "3",
         "UnhealthyThresholdCount": "2",

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -134,6 +134,12 @@ func (p *AWSProvider) ReleasePromote(r *structs.Release) error {
 		return err
 	}
 
+	for _, s := range m.Services {
+		if s.Internal && !p.Internal {
+			return fmt.Errorf("rack does not support internal services")
+		}
+	}
+
 	tp := map[string]interface{}{
 		"App":      r.App,
 		"Env":      env,

--- a/provider/aws/template.go
+++ b/provider/aws/template.go
@@ -37,6 +37,16 @@ func formationHelpers() template.FuncMap {
 			}
 			return (crc32.ChecksumIEEE([]byte(fmt.Sprintf("%s-%s", app, domain))) % 25000) + tier
 		},
+		"router": func(service string, m *manifest.Manifest) (string, error) {
+			s, err := m.Service(service)
+			if err != nil {
+				return "", err
+			}
+			if s.Internal {
+				return "RouterInternal", nil
+			}
+			return "Router", nil
+		},
 		"safe": func(s string) template.HTML {
 			return template.HTML(s)
 		},


### PR DESCRIPTION
Adds support for service links and internal services.

Declare an internal service like this:

```
web:
  internal: true
```

Your rack must have the `Internal` param set to `Yes` to deploy internal services. You can set it with:

    $ convox rack params set Internal=Yes

Declare links between services like this:

```
web:
  build: .
worker:
  build: .
  links:
    - web
```

In this case the `worker` service would receive a `WEB_URL` environment variable.