### PR TITLE
Added ServiceRole ARN to application stack output (gen2).

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -11,6 +11,10 @@
     },
     "Services": {
       "Value": "{{ services .Manifest }}"
+    },
+    "ServiceRole": {
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:ServiceRole" } },
+      "Value": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] }
     }
   },
   "Parameters" : {


### PR DESCRIPTION
Though it is sufficient to export Service Role name (this Role is also used as Task Role), it will require to solve https://github.com/convox/rack/commit/526542564d075ebffe6b8e46b0f8e2e52807f466#commitcomment-25924840 as with unsetting `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` variable it will provide no benefit