### PR TITLE
gen2 agent support

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -41,6 +41,18 @@ func Load(data []byte, env Environment) (*Manifest, error) {
 	return &m, nil
 }
 
+func (m *Manifest) Agents() []string {
+	a := []string{}
+
+	for _, s := range m.Services {
+		if s.Agent {
+			a = append(a, s.Name)
+		}
+	}
+
+	return a
+}
+
 func (m *Manifest) Service(name string) (*Service, error) {
 	for _, s := range m.Services {
 		if s.Name == name {

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -10,6 +10,7 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
+	Agent       bool               `yaml:"agent,omitempty"`
 	Build       ServiceBuild       `yaml:"build,omitempty"`
 	Command     string             `yaml:"command,omitempty"`
 	Domains     ServiceDomains     `yaml:"domain,omitempty"`

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -6,6 +6,9 @@
   "Outputs": {
     {{ template "balancer-outputs" . }}
 
+    "Agents": {
+      "Value": "{{ join .Manifest.Agents "," }}"
+    },
     "Release": {
       "Value": "{{ .Release.Id }}"
     },
@@ -219,10 +222,16 @@
           "LoadBalancers": [ { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup{{ if .Internal }}Internal{{ end }}" } } ],
           "Role": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:ServiceRole" } },
         {{ end }}
-        "PlacementStrategies": [
-          { "Type": "spread", "Field": "attribute:ecs.availability-zone" },
-          { "Type": "spread", "Field": "instanceId" }
-        ],
+        {{ if .Agent }}
+          "PlacementConstraints": [
+            { "Type": "distinctInstance" }
+          ],
+        {{ else }}
+          "PlacementStrategies": [
+            { "Type": "spread", "Field": "attribute:ecs.availability-zone" },
+            { "Type": "spread", "Field": "instanceId" }
+          ],
+        {{ end }}
         "TaskDefinition": { "Ref": "Service{{ upper .Name }}Tasks" }
       }
     },

--- a/provider/aws/template.go
+++ b/provider/aws/template.go
@@ -35,6 +35,9 @@ func formationHelpers() template.FuncMap {
 		"dec": func(i int) int {
 			return i - 1
 		},
+		"join": func(ss []string, j string) string {
+			return strings.Join(ss, j)
+		},
 		"priority": func(app, domain string) uint32 {
 			tier := uint32(1)
 			if strings.HasPrefix(domain, "*.") {


### PR DESCRIPTION
Adds support for "agent" process types in Generation 2:

```
services:
  myagent:
    agent: true
    build: .
    command: bin/agent
```