### PR TITLE
support internal dns at .convox

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -632,6 +632,8 @@ func FriendlyName(t string) string {
 		return "NAT Elastic IP"
 	case "AWS::EC2::InternetGateway":
 		return "VPC Internet Gateway"
+	case "AWS::EC2::NatGateway":
+		return "NAT Gateway"
 	case "AWS::EC2::Route":
 		return ""
 	case "AWS::EC2::RouteTable":
@@ -688,8 +690,10 @@ func FriendlyName(t string) string {
 		return "CloudWatch Log Group"
 	case "AWS::Logs::SubscriptionFilter":
 		return ""
-	case "AWS::EC2::NatGateway":
-		return "NAT Gateway"
+	case "AWS::Route53::HostedZone":
+		return "Hosted Zone"
+	case "AWS::Route53::RecordSet":
+		return ""
 	case "AWS::S3::Bucket":
 		return "S3 Bucket"
 	case "AWS::S3::BucketPolicy":

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -91,7 +91,7 @@
           "Name": "{{.Name}}.{{$.App}}.convox.",
           "Type": "CNAME",
           "TTL": "3600",
-          "ResourceRecords": [ { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Domain" } } ]
+          "ResourceRecords": [ { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Domain{{ if .Internal }}Internal{{ end }}" } } ]
         }
       },
       "Balancer{{ upper .Name }}ListenerRule80Internal": {

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -84,6 +84,34 @@
           "Priority": "{{ priority $.App .Name }}"
         }
       },
+      "RecordSet{{ upper .Name }}Internal": {
+        "Type": "AWS::Route53::RecordSet",
+        "Properties": {
+          "HostedZoneId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:HostedZone" } },
+          "Name": "{{.Name}}.{{$.App}}.convox.",
+          "Type": "CNAME",
+          "TTL": "3600",
+          "ResourceRecords": [ { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Domain" } } ]
+        }
+      },
+      "Balancer{{ upper .Name }}ListenerRule80Internal": {
+        "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+        "Properties": {
+        "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup{{ if .Internal }}Internal{{ end }}" } } ],
+          "Conditions": [ { "Field": "host-header", "Values": [ "{{.Name}}.{{$.App}}.convox" ] } ],
+          "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Listener80" } },
+          "Priority": "{{ priority $.App (print .Name "-i") }}"
+        }
+      },
+      "Balancer{{ upper .Name }}ListenerRule443Internal": {
+        "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+        "Properties": {
+        "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Balancer{{ upper .Name }}TargetGroup{{ if .Internal }}Internal{{ end }}" } } ],
+          "Conditions": [ { "Field": "host-header", "Values": [ "{{.Name}}.{{$.App}}.convox" ] } ],
+          "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Listener443" } },
+          "Priority": "{{ priority $.App (print .Name "-i") }}"
+        }
+      },
       {{ if .Domain }}
         "Balancer{{ upper .Name }}Certificate": {
           "Type": "AWS::CertificateManager::Certificate",

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -127,6 +127,10 @@
       "Condition": "BlankExistingVpc",
       "Value": { "Ref": "GatewayAttachment" }
     },
+    "HostedZone": {
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:HostedZone" } },
+      "Value": { "Ref": "HostedZone" }
+    },
     "Internal": {
       "Value": { "Ref": "Internal" }
     },
@@ -954,6 +958,23 @@
       "Properties": {
         "SubnetId": { "Ref": "SubnetPrivate2" },
         "RouteTableId": { "Ref": "RouteTablePrivate2" }
+      }
+    },
+    "HostedZone": {
+      "Type": "AWS::Route53::HostedZone",
+      "Properties": {
+        "Name": "convox",
+        "VPCs": [ { "VPCId": { "Fn::If": [ "BlankExistingVpc", { "Ref": "Vpc" }, { "Ref": "ExistingVpc" } ] }, "VPCRegion": { "Ref": "AWS::Region" } } ]
+      }
+    },
+    "RecordSetRack": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneId": { "Ref": "HostedZone" },
+        "Name": "rack.convox.",
+        "Type": "CNAME",
+        "TTL": "3600",
+        "ResourceRecords": [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] } ]
       }
     },
     "InstancesSecurity": {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -101,6 +101,11 @@
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:Domain" } },
       "Value": { "Fn::GetAtt": [ "Router", "DNSName" ] }
     },
+    "DomainInternal": {
+      "Condition": "Internal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:DomainInternal" } },
+      "Value": { "Fn::GetAtt": [ "RouterInternal", "DNSName" ] }
+    },
     "DynamoBuilds": {
       "Value": { "Ref": "DynamoBuilds" }
     },


### PR DESCRIPTION
Creates internal DNS that routes inside the Rack:

`rack.convox` - points to the Rack API
`<service>.<app>.convox` points to a given service endpoint

App-level endpoints only work for Generation 2 apps.