### PR TITLE
Fix for new environment variables set before new build.

### DIFF
--- a/provider/aws/environment.go
+++ b/provider/aws/environment.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/convox/rack/crypt"
@@ -78,6 +79,7 @@ func (p *AWSProvider) EnvironmentPut(app string, env structs.Environment) (strin
 
 	release.Id = generateId("R", 10)
 	release.Env = env.String()
+	release.Created = time.Now()
 
 	if err := p.ReleaseSave(release); err != nil {
 		return "", err


### PR DESCRIPTION
During creation of new environment variable, when application release exists convox is using existing one as a base.

The issue is that after using the existing one `Id` and `Env` fields are replaced, though `Created` is the same. Later when we are trying to create new build, it is not fetching the release info from stack (great!) though, it is sorting by `app_name.created_time` index - which in this case will fail, because `Created` field for new environment variables is the same as the active release. This causes new environment variables not being visible by new builds. (https://github.com/convox/rack/blob/master/provider/aws/builds.go#L625)

This affects only `build` (`convox build ~`) - not affecting `build import` command as the release creation is not overwritten by the latest application release.
