### PR TITLE
Add `BuildAutoscalingGroup` output

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -84,6 +84,9 @@
     "BuildCluster": {
       "Value": { "Fn::If": [ "DedicatedBuilder", { "Ref": "BuildCluster" }, { "Ref": "Cluster" } ] }
     },
+    "BuildAutoscalingGroup": {
+      "Value": { "Fn::If": [ "DedicatedBuilder", { "Ref": "BuildInstances" }, { "Ref": "Instances" } ] }
+    },
     "CloudformationTopic": {
       "Value": { "Ref": "CloudformationTopic" }
     },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -81,11 +81,11 @@
     "AwsRegion": {
       "Value": { "Ref": "AWS::Region" }
     },
-    "BuildCluster": {
-      "Value": { "Fn::If": [ "DedicatedBuilder", { "Ref": "BuildCluster" }, { "Ref": "Cluster" } ] }
-    },
     "BuildAutoscalingGroup": {
       "Value": { "Fn::If": [ "DedicatedBuilder", { "Ref": "BuildInstances" }, { "Ref": "Instances" } ] }
+    },
+    "BuildCluster": {
+      "Value": { "Fn::If": [ "DedicatedBuilder", { "Ref": "BuildCluster" }, { "Ref": "Cluster" } ] }
     },
     "CloudformationTopic": {
       "Value": { "Ref": "CloudformationTopic" }


### PR DESCRIPTION
Matches `AutoscalingGroup` output for main cluster.

Having an output for this will allow us to automate a scaling schedule for build instances in our dev clusters without hardcoding ASG names.