### PR TITLE
Adds COMPOSE_FILE environment variable to start command

### DIFF
--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -27,9 +27,10 @@ func init() {
 		Action:      cmdStart,
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  "file, f",
-				Value: "",
-				Usage: "path to manifest file",
+				Name:   "file, f",
+				EnvVar: "COMPOSE_FILE",
+				Value:  "",
+				Usage:  "path to manifest file",
 			},
 			cli.StringFlag{
 				Name:  "generation, g",


### PR DESCRIPTION
I noticed the output from `convox build --help` allowed the use of the `COMPOSE_FILE` environment variable to specify a name of the docker compose manifest during build.

I figured it would also be useful for the `convox start` command.

I also noticed `convox doctor` checks for `COMPOSE_FILE`, but it uses `helpers.DetectComposeFile()` instead of the CLI flags. I left `convox doctor` as is.