### PR TITLE
Add Build.Manifest to BuildHash

### DIFF
--- a/manifest/service.go
+++ b/manifest/service.go
@@ -67,7 +67,7 @@ type ServiceScaleCount struct {
 }
 
 func (s Service) BuildHash() string {
-	return fmt.Sprintf("%x", sha1.Sum([]byte(fmt.Sprintf("build[path=%q, args=%v] image=%q", s.Build.Path, s.Build.Args, s.Image))))
+	return fmt.Sprintf("%x", sha1.Sum([]byte(fmt.Sprintf("build[path=%q, manifest=%q, args=%v] image=%q", s.Build.Path, s.Build.Manifest, s.Build.Args, s.Image))))
 }
 
 func (s Service) Domain() string {


### PR DESCRIPTION
Two builds with the same path and different manifests (Dockerfiles)
are not equivalent and should not share a hash.

This fixes a bug with https://github.com/convox/rack/pull/2415