### PR TITLE
allow convox-env to pass through signals

### DIFF
--- a/cmd/convox-env/exec_default.go
+++ b/cmd/convox-env/exec_default.go
@@ -1,0 +1,43 @@
+// +build !linux,!darwin
+
+package main
+
+import (
+	"os"
+	osexec "os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+func exec(command string, args, env []string) error {
+	cmd := osexec.Command(command, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = env
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan)
+
+	if err := cmd.Start(); err != nil {
+		return errors.Wrap(err, "Failed to start command")
+	}
+
+	go func() {
+		for {
+			sig := <-sigChan
+			cmd.Process.Signal(sig)
+		}
+	}()
+
+	if err := cmd.Wait(); err != nil {
+		cmd.Process.Signal(os.Kill)
+		return errors.Wrap(err, "Failed to wait for command termination")
+	}
+
+	waitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	os.Exit(waitStatus.ExitStatus())
+	return nil
+}

--- a/cmd/convox-env/exec_unix.go
+++ b/cmd/convox-env/exec_unix.go
@@ -1,0 +1,21 @@
+// +build linux darwin
+
+package main
+
+import (
+	osexec "os/exec"
+	"syscall"
+)
+
+func exec(command string, args, env []string) error {
+	argv0, err := osexec.LookPath(command)
+	if err != nil {
+		return err
+	}
+
+	argv := make([]string, 0, 1+len(args))
+	argv = append(argv, command)
+	argv = append(argv, args...)
+
+	return syscall.Exec(argv0, argv, env)
+}

--- a/cmd/convox-env/main.go
+++ b/cmd/convox-env/main.go
@@ -11,9 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,32 +26,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	cmd := exec.Command(os.Args[1], os.Args[2:]...)
-
 	cenv, err := fetchConvoxEnv()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: could not fetch convox env: %s\n", err)
 		os.Exit(1)
 	}
 
-	cmd.Env = append(os.Environ(), cenv...)
+	env := append(os.Environ(), cenv...)
 
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	err = exec(os.Args[1], os.Args[2:], env)
 
-	err = cmd.Run()
-
-	switch t := err.(type) {
-	case *exec.ExitError:
-		if ws, ok := t.Sys().(syscall.WaitStatus); ok {
-			os.Exit(ws.ExitStatus())
-		} else {
-			os.Exit(1)
-		}
-	case nil:
-		os.Exit(0)
-	default:
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Make `convox-env` forward signals correctly to the wrapped command. Without this, if ECS sends a `SIGTERM` to your container, `convox-env` would get the signal but wouldn't give it to the `CMD`, which means that your application wouldn't be able to gracefully shutdown.

I'm still fairly new to golang, so any and all feedback would be appreciated!