### PR TITLE
expose RELEASE as a task environment variable

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -297,6 +297,7 @@
               {{ end }}
               { "Name": "AWS_REGION", "Value": { "Ref": "AWS::Region" } },
               { "Name": "APP", "Value": "{{$.App}}" },
+              { "Name": "RELEASE", "Value": "{{$.Release.Id}}" },
               { "Name": "RACK", "Value": { "Ref": "Rack" } },
               { "Name": "CONVOX_ENV_KEY", "Value": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:EncryptionKey" } } },
               { "Name": "CONVOX_ENV_URL", "Value": { "Fn::Sub": "s3://${Settings}/releases/{{$.Release.Id}}/env" } },
@@ -412,6 +413,7 @@
                 {{ end }}
                 { "Name": "AWS_REGION", "Value": { "Ref": "AWS::Region" } },
                 { "Name": "APP", "Value": "{{$.App}}" },
+                { "Name": "RELEASE", "Value": "{{$.Release.Id}}" },
                 { "Name": "RACK", "Value": { "Ref": "Rack" } },
                 { "Name": "CONVOX_ENV_KEY", "Value": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:EncryptionKey" } } },
                 { "Name": "CONVOX_ENV_URL", "Value": { "Fn::Sub": "s3://${Settings}/releases/{{$.Release.Id}}/env" } },


### PR DESCRIPTION
In generation 1, we had access to the `RELEASE` environment variable so that we can send it along with metrics/error reports so that we can identify the version of code that introduced any issues. This brings that env back.