### PR TITLE
add /dev/xvda mapping to BuildInstance

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -1047,6 +1047,14 @@
         "AssociatePublicIpAddress": { "Fn::If": [ "Private", false, true ] },
         "BlockDeviceMappings": [
           {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", { "Ref": "AWS::NoValue" } ] },
+              "VolumeSize": { "Ref": "RootSize" },
+              "VolumeType":"gp2"
+            }
+          },
+          {
             "DeviceName": "/dev/xvdb",
             "Ebs": {
               "Encrypted": { "Fn::If": [ "EncryptEbs", "true", { "Ref": "AWS::NoValue" } ] },


### PR DESCRIPTION
The BuildInstance root volume seems to ignore all the volume size settings, so that it is impossible to build large images (> 8GB).

This change proposes to map the root volume size of the BuildInstance to the RootSize rack parameter to fix this issue.