### PR TITLE
allow importing of env as wildcard

### DIFF
--- a/cmd/convox-env/main.go
+++ b/cmd/convox-env/main.go
@@ -93,7 +93,7 @@ func fetchConvoxEnv() ([]string, error) {
 
 	for sc.Scan() {
 		if s := sc.Text(); s != "" {
-			if len(allowed) == 0 || allowed[strings.Split(s, "=")[0]] {
+			if allowed["*"] || allowed[strings.Split(s, "=")[0]] {
 				env = append(env, s)
 			}
 		}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - VPC=
       - VPCCIDR=
     ports:
-      - 5443:5443
+      - 443:5443
     volumes:
       - /Users/Shared/convox:/var/convox
       - /var/run/docker.sock:/var/run/docker.sock

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -78,11 +78,17 @@ func (m *Manifest) ServiceEnvironment(service string) (Environment, error) {
 
 		switch len(parts) {
 		case 1:
-			v, ok := m.Environment[parts[0]]
-			if !ok {
-				missing = append(missing, parts[0])
+			if parts[0] == "*" {
+				for k, v := range m.Environment {
+					env[k] = v
+				}
+			} else {
+				v, ok := m.Environment[parts[0]]
+				if !ok {
+					missing = append(missing, parts[0])
+				}
+				env[parts[0]] = v
 			}
-			env[parts[0]] = v
 		case 2:
 			v, ok := m.Environment[parts[0]]
 			if ok {


### PR DESCRIPTION
allows a service to import the app's entire environment by specifying `*` in the list, e.g.:

```
services:
  web:
    environment:
      - "*"
      - OTHER=override
```