### PR TITLE
Fix panic: runtime error: index out of range - Continue if there are no parts after skipping --options to ADD/COPY

### DIFF
--- a/manifest1/service.go
+++ b/manifest1/service.go
@@ -212,6 +212,10 @@ func (s *Service) SyncPaths() (map[string]string, error) {
 			}
 		}
 
+		if len(parts) < 1 {
+			continue
+		}
+
 		switch parts[0] {
 		case "ENV":
 			if len(parts) >= 3 {


### PR DESCRIPTION
Fixes #2508

There was a bug introduced in b643371844a929423ddccdf04019efd476c1990c - This check used to make sure that `parts` had at least one element:

```
		if len(parts) < 1 {
			continue
		}
```

Another check needs to be added below the code that filters out the `--options` to ADD/COPY