### PR TITLE
Added export for NatIPs

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -171,6 +171,7 @@
       }
     },
     "NatIPs": {
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NatIPs" } },
       "Value": {
         "Fn::If": [
           "Private",


### PR DESCRIPTION
Exported NAT IPs are useful if you want to use those values in other CloudFormation Stacks. 

Personally we use it to create `security-group` and want to allow access from Private Rack (NATed)