### PR TITLE
[RELEASE] 20180307

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .env
 .git
 coverage.txt
+profile.out
 docker-compose.yml
 cmd/changes/changes
 cmd/convox/convox

--- a/api/controllers/processes.go
+++ b/api/controllers/processes.go
@@ -119,16 +119,24 @@ func ProcessRunAttached(ws *websocket.Conn) *httperr.Error {
 		opts.Command = options.String(v)
 	}
 
-	if v := h.Get("Release"); v != "" {
-		opts.Release = options.String(v)
-	}
-
 	if v := h.Get("Height"); v != "" {
 		i, err := strconv.Atoi(v)
 		if err != nil {
 			return httperr.Server(fmt.Errorf("height must be numeric"))
 		}
 		opts.Height = aws.Int(i)
+	}
+
+	if v := h.Get("Release"); v != "" {
+		opts.Release = options.String(v)
+	}
+
+	if v := h.Get("Timeout"); v != "" {
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return httperr.Server(fmt.Errorf("timeout must be numeric"))
+		}
+		opts.Timeout = aws.Int(i)
 	}
 
 	if v := h.Get("Width"); v != "" {

--- a/api/controllers/system.go
+++ b/api/controllers/system.go
@@ -54,10 +54,10 @@ func SystemUpdate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 		}
 
 		switch {
-		case os.Getenv("AUTOSCALE") == "true":
-			return httperr.Errorf(403, "scaling count prohibited when autoscale enabled")
 		case c == -1:
 			// -1 indicates no change
+		case os.Getenv("AUTOSCALE") == "true":
+			return httperr.Errorf(403, "scaling count prohibited when autoscale enabled")
 		case c <= 2:
 			return httperr.Errorf(403, "count must be greater than 2")
 		default:

--- a/client/processes.go
+++ b/client/processes.go
@@ -80,7 +80,7 @@ func (c *Client) ExecProcessAttached(app, pid, command string, in io.Reader, out
 	return code, nil
 }
 
-func (c *Client) RunProcessAttached(app, process, command, release string, height, width int, in io.Reader, out io.WriteCloser) (int, error) {
+func (c *Client) RunProcessAttached(app, process, command, release string, height, width, timeout int, in io.Reader, out io.WriteCloser) (int, error) {
 	r, w := io.Pipe()
 
 	defer r.Close()
@@ -94,6 +94,7 @@ func (c *Client) RunProcessAttached(app, process, command, release string, heigh
 		"Command": command,
 		"Release": release,
 		"Height":  strconv.Itoa(height),
+		"Timeout": strconv.Itoa(timeout),
 		"Width":   strconv.Itoa(width),
 	}
 

--- a/cmd/convox/run.go
+++ b/cmd/convox/run.go
@@ -27,7 +27,12 @@ func init() {
 			},
 			cli.StringFlag{
 				Name:  "release, r",
-				Usage: "release name (defaults to current release)",
+				Usage: "release id",
+			},
+			cli.IntFlag{
+				Name:  "timeout, t",
+				Usage: "timeout for attached process",
+				Value: 3600,
 			},
 		},
 	})
@@ -56,7 +61,9 @@ func cmdRun(c *cli.Context) error {
 
 	release := c.String("release")
 
-	code, err := runAttached(c, app, ps, args, release)
+	timeout := c.Int("timeout")
+
+	code, err := runAttached(c, app, ps, args, release, timeout)
 	if err != nil {
 		return stdcli.Error(err)
 	}
@@ -92,7 +99,7 @@ func cmdRunDetached(c *cli.Context) error {
 	return nil
 }
 
-func runAttached(c *cli.Context, app, ps, args, release string) (int, error) {
+func runAttached(c *cli.Context, app, ps, args, release string, timeout int) (int, error) {
 	fd := os.Stdin.Fd()
 
 	var w, h int
@@ -111,7 +118,7 @@ func runAttached(c *cli.Context, app, ps, args, release string) (int, error) {
 		}
 	}
 
-	code, err := rackClient(c).RunProcessAttached(app, ps, args, release, h, w, os.Stdin, os.Stdout)
+	code, err := rackClient(c).RunProcessAttached(app, ps, args, release, h, w, timeout, os.Stdin, os.Stdout)
 	if err != nil {
 		return -1, err
 	}

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -1054,7 +1054,6 @@
           {
             "DeviceName": "/dev/xvda",
             "Ebs": {
-              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", { "Ref": "AWS::NoValue" } ] },
               "VolumeSize": { "Ref": "RootSize" },
               "VolumeType":"gp2"
             }
@@ -1511,7 +1510,6 @@
           {
             "DeviceName": "/dev/xvda",
             "Ebs": {
-              "Encrypted": { "Fn::If": [ "EncryptEbs", "true", { "Ref": "AWS::NoValue" } ] },
               "VolumeSize": { "Ref": "RootSize" },
               "VolumeType":"gp2"
             }

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -1052,6 +1052,12 @@ func (p *AWSProvider) processRunAttached(app string, opts structs.ProcessRunOpti
 		return "", err
 	}
 
+	timeout := "3600"
+
+	if opts.Timeout != nil {
+		timeout = strconv.Itoa(*opts.Timeout)
+	}
+
 	req := &ecs.RunTaskInput{
 		Cluster:        aws.String(p.Cluster),
 		Count:          aws.Int64(1),
@@ -1066,7 +1072,7 @@ func (p *AWSProvider) processRunAttached(app string, opts structs.ProcessRunOpti
 					Name: aws.String(*opts.Service),
 					Command: []*string{
 						aws.String("sleep"),
-						aws.String("3600"),
+						aws.String(timeout),
 					},
 					Environment: []*ecs.KeyValuePair{
 						&ecs.KeyValuePair{Name: aws.String("COMMAND"), Value: aws.String(*opts.Command)},

--- a/structs/process.go
+++ b/structs/process.go
@@ -48,6 +48,7 @@ type ProcessRunOptions struct {
 	Release     *string
 	Service     *string
 	Stream      io.ReadWriter
+	Timeout     *int
 	Volumes     map[string]string
 	Width       *int
 }


### PR DESCRIPTION
## Pull Requests
  - closes #2522 do not attempt to encrypt root volume as it is incompatible with ecs ami [@ddollar]
  - closes #2523 optionally specify timeout for attached runs [@ddollar]
  - closes #2524 autoscale should not block a type-only rack scale change [@ddollar]

## Milestone Release
- [x] Release branch
- [x] Pass CI
- [x] Code review
- [ ] Merge into master
- [ ] Close milestone
- [ ] Release master
- [ ] Record release number: 
- [ ] Pass CI
- [ ] Update staging
- [ ] Deploy staging/console-staging
- [ ] Deploy staging/httpd
- [ ] Deploy staging/site-staging
- [ ] Write [release notes](https://github.com/convox/rack/releases)
- [ ] Documentation review
- [ ] Publish release
