### PR TITLE
add parameter to run timers in fargate

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - DYNAMO_BUILDS=
       - DYNAMO_RELEASES=
       - ENCRYPTION_KEY=
+      - FARGATE=
       - IMAGE=
       - INTERNAL=
       - LOG_BUCKET=

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -47,6 +47,7 @@ type AWSProvider struct {
 	DynamoBuilds        string
 	DynamoReleases      string
 	EncryptionKey       string
+	Fargate             bool
 	Internal            bool
 	LogBucket           string
 	NotificationHost    string
@@ -78,6 +79,7 @@ func FromEnv() *AWSProvider {
 		DynamoBuilds:        os.Getenv("DYNAMO_BUILDS"),
 		DynamoReleases:      os.Getenv("DYNAMO_RELEASES"),
 		EncryptionKey:       os.Getenv("ENCRYPTION_KEY"),
+		Fargate:             os.Getenv("FARGATE") == "Yes",
 		Internal:            os.Getenv("INTERNAL") == "Yes",
 		LogBucket:           os.Getenv("LOG_BUCKET"),
 		NotificationHost:    os.Getenv("NOTIFICATION_HOST"),

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -375,7 +375,7 @@
             "    launchType: 'FARGATE',",
             "    networkConfiguration: {",
             "      awsvpcConfiguration: {",
-            "        assignPublicIp: 'DISABLED',",
+            "        assignPublicIp: 'ENABLED',",
             "        subnets: [",
             { "Fn::Join": [ "", [ "          '", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet0" } }, "'," ] ] },
             { "Fn::Join": [ "", [ "          '", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet1" } }, "'" ] ] },
@@ -446,16 +446,33 @@
         "Name": { "Fn::Sub": "${AWS::StackName}-timer-{{.Name}}" },
         "ScheduleExpression": "cron({{.Schedule}} *)",
         "Targets": [ {
-          "Arn": { "Fn::Join": [ "", [
-            "arn:aws:ecs:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":cluster/", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } }
-          ] ] },
-          "EcsParameters": {
-            "TaskCount": "1",
-            "TaskDefinitionArn": { "Ref": "Timer{{ upper .Name }}Tasks" }
-          },
+          "Arn": { "Fn::If": [ "FargateTimers",
+            { "Fn::GetAtt": [ "TimerLauncher", "Arn" ] },
+            { "Fn::Join": [ "", [ "arn:aws:ecs:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":cluster/", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } } ] ] }
+          ] },
+          "EcsParameters": { "Fn::If": [ "FargateTimers",
+            { "Ref": "AWS::NoValue" },
+            { "TaskCount": "1", "TaskDefinitionArn": { "Ref": "Timer{{ upper .Name }}Tasks" } }
+          ] },
           "Id": "{{.Name}}",
-          "RoleArn": { "Fn::GetAtt": [ "TimerRole", "Arn" ] }
+          "Input": { "Fn::If": [ "FargateTimers",
+            { "Fn::Join": [ "", [ "{ \"cluster\": \"", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } }, "\", \"taskDefinition\": \"", { "Ref": "Timer{{ upper .Name }}Tasks" }, "\" }" ] ] },
+            { "Ref": "AWS::NoValue" }
+          ] },
+          "RoleArn": { "Fn::If": [ "FargateTimers",
+            { "Ref": "AWS::NoValue" },
+            { "Fn::GetAtt": [ "TimerRole", "Arn" ] }
+          ] }
         } ]
+      }
+    },
+    "{{ upper .Name }}TimerLauncherPermission": {
+      "Type" : "AWS::Lambda::Permission",
+      "Properties" : {
+        "Action" : "lambda:InvokeFunction",
+        "FunctionName" : { "Fn::GetAtt": [ "TimerLauncher", "Arn" ] },
+        "Principal" : "events.amazonaws.com",
+        "SourceArn" : { "Fn::GetAtt": [ "{{ upper .Name }}Timer", "Arn" ] }
       }
     },
     "Timer{{ upper .Name }}Tasks": {

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -2,7 +2,8 @@
   "AWSTemplateFormatVersion" : "2010-09-09",
   "Conditions": {
     "BlankIamPolicy": { "Fn::Equals": [ { "Ref": "IamPolicy" }, "" ] },
-    "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] }
+    "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
+    "FargateTimers": { "Fn::Equals": [ { "Ref": "FargateTimers" }, "Yes" ] }
   },
   "Outputs": {
     {{ template "balancer-outputs" . }}
@@ -27,6 +28,11 @@
   "Parameters" : {
     {{ template "service-params" .Manifest }}
 
+    "FargateTimers": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ]
+    },
     "IamPolicy": {
       "Type": "String",
       "Default": ""
@@ -48,6 +54,17 @@
 
     {{ template "state" }}
 
+    "ExecutionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [ { "Effect": "Allow", "Principal": { "Service": [ "ecs-tasks.amazonaws.com" ] }, "Action": [ "sts:AssumeRole" ] } ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [ "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy" ],
+        "Path": "/convox/"
+      }
+    },
     "LogGroup": {
       "Type": "AWS::Logs::LogGroup"
     },
@@ -340,17 +357,52 @@
 
 {{ define "timer-resources" }}
   {{ if .Manifest.Timers }}
+    "TimerLauncher": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": { "Fn::GetAtt": [ "TimerRole", "Arn" ] },
+        "Runtime": "nodejs4.3",
+        "Timeout": 60,
+        "Code": {
+          "ZipFile": { "Fn::Join": [ "\n", [
+            "exports.handler = function(event, context, cb) {",
+            "  console.log('event', event);",
+            "  var params = {",
+            "    cluster: event.cluster,",
+            "    taskDefinition: event.taskDefinition,",
+            "    count: 1,",
+            "    launchType: 'FARGATE',",
+            "    networkConfiguration: {",
+            "      awsvpcConfiguration: {",
+            "        assignPublicIp: 'DISABLED',",
+            "        subnets: [",
+            { "Fn::Join": [ "", [ "          '", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet0" } }, "'," ] ] },
+            { "Fn::Join": [ "", [ "          '", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet1" } }, "'" ] ] },
+            "        ]",
+            "      }",
+            "    }",
+            "  };",
+            "  var aws = require('aws-sdk');",
+            "  var ecs = new aws.ECS({maxRetries:10});",
+            "  ecs.runTask(params, function (err, res) {",
+            "    console.log('err', err);",
+            "    console.log('res', res);",
+            "    cb(err);",
+            "  });",
+            "};"
+          ] ] }
+        }
+      }
+    },
     "TimerRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": { "Service": [ "events.amazonaws.com" ] },
-              "Action": [ "sts:AssumeRole" ]
-            }
+            { "Effect": "Allow", "Action": [ "sts:AssumeRole" ], "Principal": { "Service": [ "events.amazonaws.com" ] } },
+            { "Effect": "Allow", "Action": [ "sts:AssumeRole" ], "Principal": { "Service": [ "lambda.amazonaws.com" ] } }
           ]
         },
         "Path": "/convox/",
@@ -371,6 +423,14 @@
                       ] ] }
                     }
                   }
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [ "iam:PassRole" ],
+                  "Resource": [
+                    { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
+                    { "Fn::GetAtt": [ "ServiceRole", "Arn" ] }
+                  ]
                 }
               ]
             }
@@ -439,7 +499,12 @@
             }
           {{ end }}
         ],
+        "Cpu": { "Fn::Select": [ 1, { "Ref": "{{ upper ($.Manifest.Service .Service).Name }}Formation" } ] },
+        "ExecutionRoleArn": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
         "Family": { "Fn::Sub": "${AWS::StackName}-timer-{{.Name}}" },
+        "Memory": { "Fn::Select": [ 2, { "Ref": "{{ upper ($.Manifest.Service .Service).Name }}Formation" } ] },
+        "NetworkMode": { "Fn::If": [ "FargateTimers", "awsvpc", { "Ref": "AWS::NoValue" } ] },
+        "RequiresCompatibilities": [ { "Fn::If": [ "FargateTimers", "FARGATE", { "Ref": "AWS::NoValue" } ] } ],
         "TaskRoleArn": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
         "Volumes": [
           {{ range $i, $v := ($.Manifest.Service .Service).Volumes }}

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -54,21 +54,21 @@
   },
   "Mappings": {
     "RegionConfig": {
-      "ap-northeast-1": { "Ami": "ami-68ef940e", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "582318560864" },
-      "ap-northeast-2": { "Ami": "ami-a5dd70cb", "EFS": "No",  "ThirdAvailabilityZone": "No",  "ELBAccountId": "600734575887" },
-      "ap-south-1":     { "Ami": "ami-2e461a41", "EFS": "No",  "ThirdAvailabilityZone": "No",  "ELBAccountId": "718504428378" },
-      "ap-southeast-1": { "Ami": "ami-0a622c76", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "114774131450" },
-      "ap-southeast-2": { "Ami": "ami-ee884f8c", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "783225319266" },
-      "ca-central-1":   { "Ami": "ami-5ac94e3e", "EFS": "No",  "ThirdAvailabilityZone": "No",  "ELBAccountId": "985666609251" },
-      "eu-central-1":   { "Ami": "ami-0799fa68", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "054676820928" },
-      "eu-west-1":      { "Ami": "ami-0693ed7f", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "156460612806" },
-      "eu-west-2":      { "Ami": "ami-f4e20693", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "652711504416" },
-      "eu-west-3":      { "Ami": "ami-698b3d14", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "009996457667" },
-      "sa-east-1":      { "Ami": "ami-d44008b8", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "507241528517" },
-      "us-east-1":      { "Ami": "ami-a7a242da", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "127311923021" },
-      "us-east-2":      { "Ami": "ami-b86a5ddd", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "033677994240" },
-      "us-west-1":      { "Ami": "ami-9ad4dcfa", "EFS": "No",  "ThirdAvailabilityZone": "No",  "ELBAccountId": "027434742980" },
-      "us-west-2":      { "Ami": "ami-92e06fea", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "797873946194" }
+      "ap-northeast-1": { "Ami": "ami-68ef940e", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "582318560864", "Fargate": "No"  },
+      "ap-northeast-2": { "Ami": "ami-a5dd70cb", "EFS": "No",  "ThirdAvailabilityZone": "No",  "ELBAccountId": "600734575887", "Fargate": "No"  },
+      "ap-south-1":     { "Ami": "ami-2e461a41", "EFS": "No",  "ThirdAvailabilityZone": "No",  "ELBAccountId": "718504428378", "Fargate": "No"  },
+      "ap-southeast-1": { "Ami": "ami-0a622c76", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "114774131450", "Fargate": "No"  },
+      "ap-southeast-2": { "Ami": "ami-ee884f8c", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "783225319266", "Fargate": "No"  },
+      "ca-central-1":   { "Ami": "ami-5ac94e3e", "EFS": "No",  "ThirdAvailabilityZone": "No",  "ELBAccountId": "985666609251", "Fargate": "No"  },
+      "eu-central-1":   { "Ami": "ami-0799fa68", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "054676820928", "Fargate": "No"  },
+      "eu-west-1":      { "Ami": "ami-0693ed7f", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "156460612806", "Fargate": "No"  },
+      "eu-west-2":      { "Ami": "ami-f4e20693", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "652711504416", "Fargate": "No"  },
+      "eu-west-3":      { "Ami": "ami-698b3d14", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "009996457667", "Fargate": "No"  },
+      "sa-east-1":      { "Ami": "ami-d44008b8", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "507241528517", "Fargate": "No"  },
+      "us-east-1":      { "Ami": "ami-a7a242da", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "127311923021", "Fargate": "Yes" },
+      "us-east-2":      { "Ami": "ami-b86a5ddd", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "033677994240", "Fargate": "No"  },
+      "us-west-1":      { "Ami": "ami-9ad4dcfa", "EFS": "No",  "ThirdAvailabilityZone": "Yes", "ELBAccountId": "027434742980", "Fargate": "No"  },
+      "us-west-2":      { "Ami": "ami-92e06fea", "EFS": "Yes", "ThirdAvailabilityZone": "Yes", "ELBAccountId": "797873946194", "Fargate": "No"  }
     }
   },
   "Outputs": {
@@ -129,6 +129,9 @@
         { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "Router", "DNSName" ] } ] } ] },
         "convox.site"
       ] ] }
+    },
+    "Fargate": {
+      "Value": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] }
     },
     "Gateway": {
       "Condition": "BlankExistingVpc",
@@ -2295,6 +2298,7 @@
               { "Name": "DYNAMO_BUILDS", "Value": { "Ref": "DynamoBuilds" } },
               { "Name": "DYNAMO_RELEASES", "Value": { "Ref": "DynamoReleases" } },
               { "Name": "ENCRYPTION_KEY", "Value": { "Ref": "EncryptionKey" } },
+              { "Name": "FARGATE", "Value": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] } },
               { "Name": "HTTP_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "HTTPS_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "INTERNAL", "Value": { "Ref": "Internal" } },


### PR DESCRIPTION
Adds a `FargateTimers` parameter to gen2 apps to run scheduled timers in Fargate instead of on-cluster.