### PR TITLE
[RELEASE] 20180405

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -126,6 +126,8 @@ func (p *AWSProvider) config() *aws.Config {
 		config.WithLogLevel(aws.LogDebugWithHTTPBody)
 	}
 
+	config.MaxRetries = aws.Int(7)
+
 	return config
 }
 

--- a/provider/aws/formation/g1/app.json.tmpl
+++ b/provider/aws/formation/g1/app.json.tmpl
@@ -4,7 +4,7 @@
     {{ template "balancer-conditions" .Manifest }}
     {{ template "process-conditions" .Manifest }}
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
-    "BlankSecurityGroup": { "Fn::Equals": [ { "Ref": "SecurityGroup" }, "" ] },
+    "BlankSecurityGroup": { "Fn::Equals": [ { "Fn::Join": [ ",", { "Ref": "SecurityGroup" } ] }, "" ] },
     "Internal": { "Fn::Equals": [ { "Ref": "Internal" }, "Yes" ] },
     "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] }
   },
@@ -38,9 +38,9 @@
       "Description" : ""
     },
     "SecurityGroup": {
-      "Type" : "String",
+      "Type" : "CommaDelimitedList",
       "Default" : "",
-      "Description" : "The Load balancer security group for this app"
+      "Description" : "The Load balancer security groups (comma delimited) for this app"
     },
     "Subnets": {
       "Type" : "List<AWS::EC2::Subnet::Id>",
@@ -528,11 +528,11 @@
           { "Fn::Join": [ "-", [ {{ .LoadBalancerName true $app.Name }}, "n" ] ] },
           {{ .LoadBalancerName true $app.Name }}
         ] },
-        "SecurityGroups" : [{ "Fn::If" : [
+        "SecurityGroups" : { "Fn::If" : [
           "BlankSecurityGroup",
-          {"Ref" : "{{ .ResourceName }}SecurityGroup"},
+          [ {"Ref" : "{{ .ResourceName }}SecurityGroup"} ],
           {"Ref" : "SecurityGroup"}
-        ]}]
+        ]}
       }
     },
     "{{ .ResourceName }}ALB": {
@@ -557,11 +557,11 @@
           { "Fn::Join": [ "-", [ {{ .LoadBalancerName true $app.Name }}, "n" ] ] },
           {{ .LoadBalancerName true $app.Name }}
         ] },
-        "SecurityGroups" : [{ "Fn::If" : [
+        "SecurityGroups" : { "Fn::If" : [
           "BlankSecurityGroup",
-          {"Ref" : "{{ .ResourceName }}SecurityGroup"},
+          [ {"Ref" : "{{ .ResourceName }}SecurityGroup"} ],
           {"Ref" : "SecurityGroup"}
-        ]}]
+        ]}
       }
     },
     "{{ .ResourceName }}TargetGroup": {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -14,7 +14,7 @@
     "BlankInternetGateway": { "Fn::Equals": [ { "Ref": "InternetGateway"}, "" ] },
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
-    "BlankRouterSecurityGroup": { "Fn::Equals": [ {"Ref": "RouterSecurityGroup" }, "" ]},
+    "BlankRouterSecurityGroup": { "Fn::Equals": [ { "Fn::Join": [ ",", {"Ref": "RouterSecurityGroup" } ] }, "" ]},
     "DedicatedBuilder": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstance" }, "" ] } ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
     "EncryptEbs" : { "Fn::Equals": [ { "Ref": "EncryptEbs" }, "Yes" ] },
@@ -521,8 +521,8 @@
     },
     "RouterSecurityGroup": {
       "Default": "",
-      "Description": "The security group to assign to the rack router.",
-      "Type": "String"
+      "Description": "The security groups (comma delimited) to assign to the rack router.",
+      "Type": "CommaDelimitedList"
     },
     "SpotInstanceBid": {
       "Default": "",
@@ -1895,7 +1895,7 @@
           { "Ref": "Subnet1" },
           { "Fn::If": [ "ThirdAvailabilityZone", { "Ref": "Subnet2" }, { "Ref": "AWS::NoValue" } ] }
         ],
-        "SecurityGroups": [ { "Fn::If": [ "BlankRouterSecurityGroup", { "Ref": "RouterSecurity" }, { "Ref": "RouterSecurityGroup" } ] } ]
+        "SecurityGroups": { "Fn::If": [ "BlankRouterSecurityGroup", [ { "Ref": "RouterSecurity" } ], { "Ref": "RouterSecurityGroup" } ] }
       }
     },
     "RouterSecurity": {


### PR DESCRIPTION
## Pull Requests
  - closes #2512 Added possibility to specify multiple Security Groups in gen1 [@radekl]
  - closes #2584 Increase MaxRetries for AWS clients from 3 to 7 [@thieman]
  - closes #2585 Added support for multiple security groups for rack router [@radekl]

## Milestone Release
- [ ] Release branch
- [ ] Pass CI
- [ ] Code review
- [ ] Merge into master
- [ ] Close milestone
- [ ] Release master
- [ ] Record release number: 
- [ ] Pass CI
- [ ] Update staging
- [ ] Deploy staging/console-staging
- [ ] Deploy staging/httpd
- [ ] Deploy staging/site-staging
- [ ] Write [release notes](https://github.com/convox/rack/releases)
- [ ] Documentation review
- [ ] Publish release
- [ ] Update Homebrew
