### PR TITLE
AWS: Defer marking build as complete until we have release info

### DIFF
--- a/cmd/convox/deploy.go
+++ b/cmd/convox/deploy.go
@@ -62,13 +62,13 @@ func cmdDeploy(c *cli.Context) error {
 	output.Write([]byte(fmt.Sprintf("Deploying %s\n", app)))
 
 	// build
-	_, release, err := executeBuild(c, dir, app, c.String("file"), c.String("description"), output)
+	build, release, err := executeBuild(c, dir, app, c.String("file"), c.String("description"), output)
 	if err != nil {
 		return stdcli.Error(err)
 	}
 
 	if release == "" {
-		return nil
+		return stdcli.Error(fmt.Errorf("build %s is completed but missing release information", build))
 	}
 
 	output.Write([]byte(fmt.Sprintf("Release: %s\n", release)))

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -356,7 +356,6 @@ func (p *AWSProvider) BuildImport(app string, r io.Reader) (*structs.Build, erro
 	// set up the new build
 	targetBuild := structs.NewBuild(app)
 	targetBuild.Started = time.Now()
-	targetBuild.Status = "complete"
 
 	if p.IsTest() {
 		targetBuild.Id = "B12345"
@@ -491,6 +490,7 @@ func (p *AWSProvider) BuildImport(app string, r io.Reader) (*structs.Build, erro
 		return nil, log.Error(err)
 	}
 
+	targetBuild.Status = "complete"
 	targetBuild.Release = rr.Id
 
 	if err := p.buildSave(targetBuild); err != nil {


### PR DESCRIPTION
This PR corrects an issue where the AWS provider could save a "complete" build during import that did not have a release ID. The release ID would then be saved onto the build in a subsequent save, but this opened up a window where the constraint that all completed builds should have release IDs was violated.

This manifested to us as a premature non-error return inside `cmd/convox/deploy.go`. In addition to fixing the race condition, this PR throws an error in this case to assist in reporting/debugging should this issue occur again in the future.

As @ddollar pointed out to me on Slack, here are some earlier commits relating to similar issues:

https://github.com/convox/rack/commit/57b4caea071a0dde14e585c95e8da4c3000de0dd
https://github.com/convox/rack/commit/a887e64948803406c32d49a5833969725fcd6ec1