### PR TITLE
custom manifest support

### DIFF
--- a/api/controllers/builds.go
+++ b/api/controllers/builds.go
@@ -23,7 +23,7 @@ func BuildCreate(rw http.ResponseWriter, r *http.Request) *httperr.Error {
 
 	opts := structs.BuildCreateOptions{
 		Cache:       options.Bool(!(r.FormValue("cache") == "false")),
-		Config:      options.String(r.FormValue("config")),
+		Manifest:    options.String(coalesce(r.FormValue("manifest"), r.FormValue("config"))),
 		Description: options.String(r.FormValue("description")),
 	}
 

--- a/api/controllers/helpers.go
+++ b/api/controllers/helpers.go
@@ -12,6 +12,16 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+func coalesce(ss ...string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+
+	return ""
+}
+
 func readChannel(r io.Reader, datach chan []byte, donech chan error) {
 	buf := make([]byte, 10*1024)
 

--- a/client/builds.go
+++ b/client/builds.go
@@ -48,7 +48,7 @@ func (c *Client) GetBuildsWithLimit(app string, limit int) (Builds, error) {
 	return builds, nil
 }
 
-func (c *Client) CreateBuildIndex(app string, index Index, cache bool, config string, description string) (*Build, error) {
+func (c *Client) CreateBuildIndex(app string, index Index, cache bool, manifest string, description string) (*Build, error) {
 	var build Build
 
 	data, err := json.Marshal(index)
@@ -58,9 +58,9 @@ func (c *Client) CreateBuildIndex(app string, index Index, cache bool, config st
 
 	params := map[string]string{
 		"cache":       fmt.Sprintf("%t", cache),
-		"config":      config,
 		"description": description,
 		"index":       string(data),
+		"manifest":    manifest,
 	}
 
 	system, err := c.GetSystem()

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -25,9 +25,9 @@ var (
 	flagApp        string
 	flagAuth       string
 	flagCache      string
-	flagConfig     string
 	flagGeneration string
 	flagID         string
+	flagManifest   string
 	flagMethod     string
 	flagPush       string
 	flagUrl        string
@@ -44,9 +44,9 @@ func main() {
 	fs.StringVar(&flagApp, "app", "example", "app name")
 	fs.StringVar(&flagAuth, "auth", "", "docker auth data (json)")
 	fs.StringVar(&flagCache, "cache", "true", "use docker cache")
-	fs.StringVar(&flagConfig, "config", "", "path to app config")
 	fs.StringVar(&flagGeneration, "generation", "", "app generation")
 	fs.StringVar(&flagID, "id", "latest", "build id")
+	fs.StringVar(&flagManifest, "manifest", "", "path to app manifest")
 	fs.StringVar(&flagMethod, "method", "", "source method")
 	fs.StringVar(&flagPush, "push", "", "push to registry")
 	fs.StringVar(&flagUrl, "url", "", "source url")
@@ -63,16 +63,16 @@ func main() {
 		flagAuth = v
 	}
 
-	if v := os.Getenv("BUILD_CONFIG"); v != "" {
-		flagConfig = v
-	}
-
 	if v := os.Getenv("BUILD_GENERATION"); v != "" {
 		flagGeneration = v
 	}
 
 	if v := os.Getenv("BUILD_ID"); v != "" {
 		flagID = v
+	}
+
+	if v := os.Getenv("BUILD_MANIFEST"); v != "" {
+		flagManifest = v
 	}
 
 	if v := os.Getenv("BUILD_PUSH"); v != "" {
@@ -83,12 +83,12 @@ func main() {
 		flagUrl = v
 	}
 
-	if flagConfig == "" {
+	if flagManifest == "" {
 		switch flagGeneration {
 		case "2":
-			flagConfig = "convox.yml"
+			flagManifest = "convox.yml"
 		default:
-			flagConfig = "docker-compose.yml"
+			flagManifest = "docker-compose.yml"
 		}
 	}
 
@@ -133,7 +133,7 @@ func execute() error {
 
 	defer os.RemoveAll(dir)
 
-	data, err := ioutil.ReadFile(filepath.Join(dir, flagConfig))
+	data, err := ioutil.ReadFile(filepath.Join(dir, flagManifest))
 	if err != nil {
 		return err
 	}
@@ -201,10 +201,10 @@ func login() error {
 }
 
 func build(dir string) error {
-	dcy := filepath.Join(dir, flagConfig)
+	dcy := filepath.Join(dir, flagManifest)
 
 	if _, err := os.Stat(dcy); os.IsNotExist(err) {
-		return fmt.Errorf("no such file: %s", flagConfig)
+		return fmt.Errorf("no such file: %s", flagManifest)
 	}
 
 	data, err := ioutil.ReadFile(dcy)
@@ -268,10 +268,10 @@ func build(dir string) error {
 }
 
 func build2(dir string) error {
-	config := filepath.Join(dir, flagConfig)
+	config := filepath.Join(dir, flagManifest)
 
 	if _, err := os.Stat(config); os.IsNotExist(err) {
-		return fmt.Errorf("no such file: %s", flagConfig)
+		return fmt.Errorf("no such file: %s", flagManifest)
 	}
 
 	data, err := ioutil.ReadFile(config)

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -862,12 +862,6 @@ func (p *AWSProvider) runBuild(build *structs.Build, method, url string, opts st
 		push = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", aid, p.Region, reg)
 	}
 
-	config := ""
-
-	if opts.Config != nil {
-		config = *opts.Config
-	}
-
 	rk, err := p.describeStack(p.Rack)
 	if err != nil {
 		return err
@@ -899,16 +893,16 @@ func (p *AWSProvider) runBuild(build *structs.Build, method, url string, opts st
 							Value: aws.String(auth),
 						},
 						{
-							Name:  aws.String("BUILD_CONFIG"),
-							Value: aws.String(config),
-						},
-						{
 							Name:  aws.String("BUILD_GENERATION"),
 							Value: aws.String(a.Tags["Generation"]),
 						},
 						{
 							Name:  aws.String("BUILD_ID"),
 							Value: aws.String(build.Id),
+						},
+						{
+							Name:  aws.String("BUILD_MANIFEST"),
+							Value: aws.String(cs(opts.Manifest, "")),
 						},
 						{
 							Name:  aws.String("BUILD_PUSH"),

--- a/provider/local/build.go
+++ b/provider/local/build.go
@@ -62,6 +62,7 @@ func (p *Provider) BuildCreate(app, method, url string, opts structs.BuildCreate
 			"BUILD_AUTH":       string(auth),
 			"BUILD_GENERATION": "2",
 			"BUILD_ID":         b.Id,
+			"BUILD_MANIFEST":   cs(opts.Manifest, "convox.yml"),
 			"BUILD_URL":        url,
 			"PROVIDER":         "local",
 		},
@@ -152,8 +153,6 @@ func (p *Provider) BuildLogs(app, id string, opts structs.LogsOptions) (io.ReadC
 	if err != nil {
 		return nil, log.Error(err)
 	}
-
-	fmt.Printf("build = %+v\n", build)
 
 	switch build.Status {
 	case "created", "running":

--- a/provider/local/helpers.go
+++ b/provider/local/helpers.go
@@ -20,6 +20,13 @@ func coalescei(ints ...int) int {
 	return 0
 }
 
+func cs(s *string, def string) string {
+	if s != nil {
+		return *s
+	}
+	return def
+}
+
 func diff(all []string, remove []string) []string {
 	f := []string{}
 

--- a/structs/build.go
+++ b/structs/build.go
@@ -23,16 +23,14 @@ type Build struct {
 
 type Builds []Build
 
-type BuildListOptions struct {
-	Count *int
+type BuildCreateOptions struct {
+	Cache       *bool   `param:"cache"`
+	Description *string `param:"description"`
+	Manifest    *string `param:"manifest"`
 }
 
-type BuildCreateOptions struct {
-	Cache       *bool
-	Config      *string
-	Description *string
-	Development *bool
-	Manifest    *string
+type BuildListOptions struct {
+	Count *int `param:"count"`
 }
 
 type BuildUpdateOptions struct {


### PR DESCRIPTION
supports use of `-f` with `convox start`, `convox build`, and `convox deploy` for both gen1 and gen2