### PR TITLE
AWS: Account for eventual consistency in DescribeTasks

### DIFF
--- a/provider/aws/.#processes.go
+++ b/provider/aws/.#processes.go
@@ -1,1 +1,0 @@
-travisthieman@Travis.Thieman.2344

--- a/provider/aws/.#processes.go
+++ b/provider/aws/.#processes.go
@@ -1,0 +1,1 @@
+travisthieman@Travis.Thieman.2344

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -793,8 +793,7 @@ func (p *AWSProvider) describeTasks(input *ecs.DescribeTasksInput) (*ecs.Describ
 		return nil, err
 	}
 
-	willCache := !p.SkipCache && len(res.Failures) == 0
-	if willCache {
+	if !p.SkipCache && len(res.Failures) == 0 {
 		if err := cache.Set("describeTasks", input, res, 10*time.Second); err != nil {
 			return nil, err
 		}

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -793,7 +793,8 @@ func (p *AWSProvider) describeTasks(input *ecs.DescribeTasksInput) (*ecs.Describ
 		return nil, err
 	}
 
-	if !p.SkipCache {
+	willCache := !p.SkipCache && len(res.Failures) == 0
+	if willCache {
 		if err := cache.Set("describeTasks", input, res, 10*time.Second); err != nil {
 			return nil, err
 		}

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -599,7 +599,6 @@ func (p *AWSProvider) describeTaskInner(arn string) (*ecs.Task, error) {
 		Cluster: aws.String(p.Cluster),
 		Tasks:   []*string{aws.String(arn)},
 	})
-	cache.Clear("describeTasks", input)
 
     res, err := p.describeTasks(input)
 	if err != nil {
@@ -613,18 +612,20 @@ func (p *AWSProvider) describeTaskInner(arn string) (*ecs.Task, error) {
 				Cluster: aws.String(p.BuildCluster),
 				Tasks:   []*string{aws.String(arn)},
 			}
-			cache.Clear("describeTasks", buildInput)
 
 			res, err = p.describeTasks(buildInput)
 			break
 		}
 	}
+
 	if err != nil {
 		return nil, err
 	}
+
 	if len(res.Tasks) != 1 {
 		return nil, fmt.Errorf("could not fetch process status")
 	}
+
 	return res.Tasks[0], nil
 }
 

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -595,7 +595,7 @@ func (p *AWSProvider) describeInstance(id string) (*ec2.Instance, error) {
 }
 
 func (p *AWSProvider) describeTaskInner(arn string) (*ecs.Task, error) {
-    res, err := p.describeTasks(&ecs.DescribeTasksInput{
+	res, err := p.describeTasks(&ecs.DescribeTasksInput{
 		Cluster: aws.String(p.Cluster),
 		Tasks:   []*string{aws.String(arn)},
 	})

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -598,7 +598,7 @@ func (p *AWSProvider) describeTaskInner(arn string) (*ecs.Task, error) {
 	input := &ecs.DescribeTasksInput{
 		Cluster: aws.String(p.Cluster),
 		Tasks:   []*string{aws.String(arn)},
-	})
+	}
 
     res, err := p.describeTasks(input)
 	if err != nil {

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -595,12 +595,10 @@ func (p *AWSProvider) describeInstance(id string) (*ec2.Instance, error) {
 }
 
 func (p *AWSProvider) describeTaskInner(arn string) (*ecs.Task, error) {
-	input := &ecs.DescribeTasksInput{
+    res, err := p.describeTasks(&ecs.DescribeTasksInput{
 		Cluster: aws.String(p.Cluster),
 		Tasks:   []*string{aws.String(arn)},
-	}
-
-    res, err := p.describeTasks(input)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -608,12 +606,10 @@ func (p *AWSProvider) describeTaskInner(arn string) (*ecs.Task, error) {
 	// check the build cluster too
 	for _, f := range res.Failures {
 		if f.Reason != nil && *f.Reason == "MISSING" && p.BuildCluster != p.Cluster {
-			buildInput := &ecs.DescribeTasksInput{
+			res, err = p.describeTasks(&ecs.DescribeTasksInput{
 				Cluster: aws.String(p.BuildCluster),
 				Tasks:   []*string{aws.String(arn)},
-			}
-
-			res, err = p.describeTasks(buildInput)
+			})
 			break
 		}
 	}


### PR DESCRIPTION
@ddollar cc @Pastromhaug Got a fun one here

This PR attempts to deal with two consistency problems that may be encountered when calling `describeTask`:

1. The ECS `describeTasks` endpoint itself is eventually consistent.
2. Additionally, `rack` wraps `describeTasks` in an endpoint-level cache that serves up previous API GET responses with the same parameters.

This PR implements a limited exponential retry, along with cache busting, to keep requesting fresh data from the AWS API until we get a view which includes the Task which we are trying to describe.

This problem manifested to us as a thrown [`could not fetch process status` error](https://github.com/convox/rack/blob/20180412033556/provider/aws/processes.go#L616). This was called during a `convox run` command immediately after creating the Task this function tried to describe.

This specific implementation has a lot of flaws and is presented more as a basis for discussion rather than something we should consider immediately merging. It's possible this specific hack is worth merging to address this case in the short-term, but a more comprehensive solution would be better if we can come up with one.

### Discussion Points

1. I'm not sure how to test this case using the stub pattern defined in `processes_test`. I believe I would need to change the return value of `describeTasks` between two subsequent calls to it within a single provider function call. This might require upgrading that stub framework a bit, or I might be missing something.

2. The cache might be more useful at a resource level rather than an endpoint level. In this particular example, I believe we actually have the full `Task` information after the original `RunTask` call. If we put that into a `Task` cache and had `describeCache` look for it in there, we would receive a consistent view since that data would be based on the return of the write call.

3. Is there a path towards handling the eventual consistency of the AWS APIs in a more comprehensive way? Even if we merge this, it seems likely similar issues will come up around the other endpoints we are not protecting through this PR. 