### PR TITLE
service autoscaling

### DIFF
--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -130,6 +130,15 @@ func TestManifestLoad(t *testing.T) {
 						Cpu:      50,
 						Memory:   75,
 						Requests: 200,
+						Custom: manifest.ServiceScaleMetrics{
+							{
+								Aggregate:  "max",
+								Dimensions: map[string]string{"QueueName": "testqueue"},
+								Namespace:  "AWS/SQS",
+								Name:       "ApproximateNumberOfMessagesVisible",
+								Value:      float64(200),
+							},
+						},
 					},
 				},
 			},

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -110,6 +110,29 @@ func TestManifestLoad(t *testing.T) {
 					Memory: 512,
 				},
 			},
+			manifest.Service{
+				Name: "scaler",
+				Build: manifest.ServiceBuild{
+					Manifest: "Dockerfile",
+					Path:     ".",
+				},
+				Command: "",
+				Health: manifest.ServiceHealth{
+					Interval: 5,
+					Path:     "/",
+					Timeout:  4,
+				},
+				Scale: manifest.ServiceScale{
+					Count:  &manifest.ServiceScaleCount{Min: 1, Max: 5},
+					Cpu:    256,
+					Memory: 512,
+					Targets: manifest.ServiceScaleTargets{
+						Cpu:      50,
+						Memory:   75,
+						Requests: 200,
+					},
+				},
+			},
 		},
 	}
 

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -69,8 +69,19 @@ type ServiceScaleCount struct {
 	Max int
 }
 
+type ServiceScaleMetric struct {
+	Aggregate  string
+	Dimensions map[string]string
+	Namespace  string
+	Name       string
+	Value      float64
+}
+
+type ServiceScaleMetrics []ServiceScaleMetric
+
 type ServiceScaleTargets struct {
 	Cpu      int
+	Custom   ServiceScaleMetrics
 	Memory   int
 	Requests int
 }

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -58,14 +58,21 @@ type ServicePort struct {
 }
 
 type ServiceScale struct {
-	Count  *ServiceScaleCount
-	Cpu    int
-	Memory int
+	Count   *ServiceScaleCount
+	Cpu     int
+	Memory  int
+	Targets ServiceScaleTargets
 }
 
 type ServiceScaleCount struct {
 	Min int
 	Max int
+}
+
+type ServiceScaleTargets struct {
+	Cpu      int
+	Memory   int
+	Requests int
 }
 
 func (s Service) BuildHash() string {

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -47,3 +47,9 @@ services:
         cpu: 50
         memory: 75
         requests: 200
+        custom:
+          AWS/SQS/ApproximateNumberOfMessagesVisible:
+            aggregate: max
+            value: 200
+            dimensions:
+              QueueName: testqueue

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -40,3 +40,10 @@ services:
       port: 3000
     scale: 0
   bar:
+  scaler:
+    scale:
+      count: 1-5
+      targets:
+        cpu: 50
+        memory: 75
+        requests: 200

--- a/manifest/yaml.go
+++ b/manifest/yaml.go
@@ -308,6 +308,25 @@ func (v *ServiceScale) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+func (v *ServiceScaleMetrics) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var w map[string]ServiceScaleMetric
+
+	if err := unmarshal(&w); err != nil {
+		return err
+	}
+
+	*v = ServiceScaleMetrics{}
+
+	for wk, wv := range w {
+		parts := strings.Split(wk, "/")
+		wv.Namespace = strings.Join(parts[0:len(parts)-1], "/")
+		wv.Name = parts[len(parts)-1]
+		*v = append(*v, wv)
+	}
+
+	return nil
+}
+
 func (v *ServiceScaleCount) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var w interface{}
 

--- a/manifest/yaml.go
+++ b/manifest/yaml.go
@@ -294,6 +294,13 @@ func (v *ServiceScale) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if w, ok := t["memory"].(int); ok {
 			v.Memory = w
 		}
+		if w, ok := t["targets"].(interface{}); ok {
+			var t ServiceScaleTargets
+			if err := remarshal(w, &t); err != nil {
+				return err
+			}
+			v.Targets = t
+		}
 	default:
 		return fmt.Errorf("unknown type for service scale: %T", t)
 	}

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -270,6 +270,42 @@
 {{ end }}
 
 {{ define "service-resources" }}
+  "AutoscalingRole": {
+    "Type": "AWS::IAM::Role",
+    "Properties": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [ { "Effect": "Allow", "Principal": { "Service": [ "application-autoscaling.amazonaws.com" ] }, "Action": [ "sts:AssumeRole" ] } ],
+        "Version": "2012-10-17"
+      },
+      "Path": "/convox/",
+      "Policies": [ {
+        "PolicyName": "autoscaling",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ecs:UpdateService",
+                "ecs:DescribeServices",
+                "application-autoscaling:*",
+                "cloudwatch:DescribeAlarms",
+                "cloudwatch:GetMetricStatistics"
+              ],
+              "Resource": "*",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": { "Fn::Join": [ "", [
+                    "arn:aws:ecs:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":cluster/", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } }
+                  ] ] }
+                }
+              }
+            }
+          ]
+        }
+      } ]
+    }
+  },
   "ServiceRole": {
     "Type": "AWS::IAM::Role",
     "Properties": {
@@ -292,6 +328,72 @@
     }
   },
   {{ range .Manifest.Services }}
+    {{ if .Scale.Targets.Cpu }}
+      "Service{{ upper .Name }}AutoscalingPolicyCpu": {
+        "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+        "Properties": {
+          "PolicyName": "{{ .Name }} autoscaling cpu",
+          "PolicyType": "TargetTrackingScaling",
+          "ScalingTargetId": { "Ref": "Service{{ upper .Name }}AutoscalingTarget" },
+          "TargetTrackingScalingPolicyConfiguration": {
+            "PredefinedMetricSpecification": {
+              "PredefinedMetricType": "ECSServiceAverageCPUUtilization"
+            },
+            "ScaleInCooldown": "60",
+            "ScaleOutCooldown": "60",
+            "TargetValue": "{{ .Scale.Targets.Cpu }}"
+          }
+        }
+      },
+    {{ end }}
+    {{ if .Scale.Targets.Memory }}
+      "Service{{ upper .Name }}AutoscalingPolicyMemory": {
+        "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+        "Properties": {
+          "PolicyName": "{{ .Name }} autoscaling memory",
+          "PolicyType": "TargetTrackingScaling",
+          "ScalingTargetId": { "Ref": "Service{{ upper .Name }}AutoscalingTarget" },
+          "TargetTrackingScalingPolicyConfiguration": {
+            "PredefinedMetricSpecification": {
+              "PredefinedMetricType": "ECSServiceAverageMemoryUtilization"
+            },
+            "ScaleInCooldown": "60",
+            "ScaleOutCooldown": "60",
+            "TargetValue": "{{ .Scale.Targets.Memory }}"
+          }
+        }
+      },
+    {{ end }}
+    {{ if .Scale.Targets.Requests }}
+      "Service{{ upper .Name }}AutoscalingPolicyRequests": {
+        "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+        "Properties": {
+          "PolicyName": "{{ .Name }} autoscaling requests",
+          "PolicyType": "TargetTrackingScaling",
+          "ScalingTargetId": { "Ref": "Service{{ upper .Name }}AutoscalingTarget" },
+          "TargetTrackingScalingPolicyConfiguration": {
+            "PredefinedMetricSpecification": {
+              "PredefinedMetricType": "ALBRequestCountPerTarget",
+              "ResourceLabel": { "Fn::Sub": [ "${Balancer}/${Balancer{{ upper .Name }}TargetGroup{{ if .Internal }}Internal{{ end }}.TargetGroupFullName}", { "Balancer": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterName" } } } ] }
+            },
+            "ScaleInCooldown": "60",
+            "ScaleOutCooldown": "60",
+            "TargetValue": "{{ .Scale.Targets.Requests }}"
+          }
+        }
+      },
+    {{ end }}
+    "Service{{ upper .Name }}AutoscalingTarget": {
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+      "Properties": {
+        "MaxCapacity": "5",
+        "MinCapacity": "1",
+        "ResourceId": { "Fn::Sub": [ "service/${Cluster}/${Service{{ upper .Name }}Service.Name}", { "Cluster": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } } } ] },
+        "RoleARN": { "Fn::GetAtt": [ "AutoscalingRole", "Arn" ] },
+        "ScalableDimension": "ecs:service:DesiredCount",
+        "ServiceNamespace": "ecs"
+      }
+    },
     "Service{{ upper .Name }}Security": {
       "Condition": "FargateServices",
       "Type": "AWS::EC2::SecurityGroup",

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -327,7 +327,7 @@
       } ]
     }
   },
-  {{ range .Manifest.Services }}
+  {{ range $s := .Manifest.Services }}
     {{ if .Scale.Targets.Cpu }}
       "Service{{ upper .Name }}AutoscalingPolicyCpu": {
         "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
@@ -379,6 +379,32 @@
             "ScaleInCooldown": "60",
             "ScaleOutCooldown": "60",
             "TargetValue": "{{ .Scale.Targets.Requests }}"
+          }
+        }
+      },
+    {{ end }}
+    {{ range $i, $t := .Scale.Targets.Custom }}
+      "Service{{ upper $s.Name }}AutoscalingPolicyRequests": {
+        "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+        "Properties": {
+          "PolicyName": "{{ $s.Name }} autoscaling {{ $t.Namespace }}/{{ $t.Name }}",
+          "PolicyType": "TargetTrackingScaling",
+          "ScalingTargetId": { "Ref": "Service{{ upper $s.Name }}AutoscalingTarget" },
+          "TargetTrackingScalingPolicyConfiguration": {
+            "CustomizedMetricSpecification": {
+              "Dimensions": [
+                {{ range $k, $v := $t.Dimensions }}
+                  { "Name": "{{$k}}", "Value": "{{$v}}" },
+                {{ end }}
+                { "Ref": "AWS::NoValue" }
+              ],
+              "MetricName": "{{ $t.Name }}",
+              "Namespace": "{{ $t.Namespace }}",
+              "Statistic": "{{ statistic $t.Aggregate }}"
+            },
+            "ScaleInCooldown": "60",
+            "ScaleOutCooldown": "60",
+            "TargetValue": "{{ $t.Value }}"
           }
         }
       },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -220,6 +220,10 @@
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:RouterCertificate" } },
       "Value": { "Ref": "RouterApiCertificate" }
     },
+    "RouterName": {
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:RouterName" } },
+      "Value": { "Fn::GetAtt": [ "Router", "LoadBalancerFullName" ] }
+    },
     "RouterHost": {
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:RouterHost" } },
       "Value": { "Fn::Join": [ ".", [

--- a/provider/aws/template.go
+++ b/provider/aws/template.go
@@ -69,6 +69,19 @@ func formationHelpers() template.FuncMap {
 			sort.Strings(ss)
 			return strings.Join(ss, ",")
 		},
+		"statistic": func(s string) (string, error) {
+			switch strings.ToLower(s) {
+			case "avg":
+				return "Average", nil
+			case "max":
+				return "Maximum", nil
+			case "min":
+				return "Minimum", nil
+			case "sum":
+				return "Sum", nil
+			}
+			return "", fmt.Errorf("unknown metric statistic: %s", s)
+		},
 		"upcase": func(s string) string {
 			return strings.ToUpper(s)
 		},


### PR DESCRIPTION
```
service:
  web:
    scale:
      count: 1-10
      targets:
        cpu: 70
        memory: 90
        requests: 200
        custom:
          AWS/SQS/ApproximateNumberOfMessagesVisible:
            aggregate: max
            value: 20
            dimensions:
              QueueName: myqueue
```

The following targets are available:

* `cpu`: average cpu utilization (%) across all processes of the service
* `memory`: average memory utilization (%) across all processes of the service
* `requests`: requests per minute per process

The autoscaler will determine the number of containers required to keep the targets at their desired value. If multiple targets are specified the largest number of containers will be used after taking all targets into account.