### PR TITLE
configurable ssl negotiation policy

### DIFF
--- a/provider/aws/formation/g1/app.json.tmpl
+++ b/provider/aws/formation/g1/app.json.tmpl
@@ -5,7 +5,7 @@
     {{ template "process-conditions" .Manifest }}
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
     "BlankSecurityGroup": { "Fn::Equals": [ { "Fn::Join": [ ",", { "Ref": "SecurityGroup" } ] }, "" ] },
-    "BlankSslNegotiationPolicy": { "Fn::Equals": [ { "Ref": "SslNegotiationPolicy" }, "" ] },
+    "BlankSslPolicy": { "Fn::Equals": [ { "Ref": "SslPolicy" }, "" ] },
     "Internal": { "Fn::Equals": [ { "Ref": "Internal" }, "Yes" ] },
     "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] }
   },
@@ -43,7 +43,7 @@
       "Default" : "",
       "Description" : "The Load balancer security groups (comma delimited) for this app"
     },
-    "SslNegotiationPolicy": {
+    "SslPolicy": {
       "Type": "String",
       "Default": "",
       "Description": "Override the default SSL negotiation policy of the load balancer"
@@ -509,7 +509,7 @@
               "InstancePort": { "Fn::Select": [ 0, { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Listener" } ] },
               "PolicyNames": [ { "Fn::If": [ "BlankBalancer{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Certificate",
                 { "Ref": "AWS::NoValue" },
-                { "Fn::If": [ "BlankSslNegotiationPolicy", { "Ref": "AWS::NoValue" }, "NegotiationPolicy" ] }
+                { "Fn::If": [ "BlankSslPolicy", { "Ref": "AWS::NoValue" }, "SslPolicy" ] }
               ] } ],
               "SSLCertificateId": { "Fn::If": [ "BlankBalancer{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Certificate",
                 { "Ref": "AWS::NoValue" },
@@ -520,12 +520,12 @@
           { "Ref": "AWS::NoValue" }
         ],
         "Policies": [
-          { "Fn::If": [ "BlankSslNegotiationPolicy",
+          { "Fn::If": [ "BlankSslPolicy",
             { "Ref": "AWS::NoValue" },
             {
-              "PolicyName": "NegotiationPolicy",
+              "PolicyName": "SslPolicy",
               "PolicyType": "SSLNegotiationPolicyType",
-              "Attributes": [ { "Name": "Reference-Security-Policy", "Value": { "Ref": "SslNegotiationPolicy" } } ]
+              "Attributes": [ { "Name": "Reference-Security-Policy", "Value": { "Ref": "SslPolicy" } } ]
             }
           ] },
           {{ range .PortMappings }}

--- a/provider/aws/formation/g1/app.json.tmpl
+++ b/provider/aws/formation/g1/app.json.tmpl
@@ -5,6 +5,7 @@
     {{ template "process-conditions" .Manifest }}
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
     "BlankSecurityGroup": { "Fn::Equals": [ { "Fn::Join": [ ",", { "Ref": "SecurityGroup" } ] }, "" ] },
+    "BlankSslNegotiationPolicy": { "Fn::Equals": [ { "Ref": "SslNegotiationPolicy" }, "" ] },
     "Internal": { "Fn::Equals": [ { "Ref": "Internal" }, "Yes" ] },
     "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] }
   },
@@ -41,6 +42,11 @@
       "Type" : "CommaDelimitedList",
       "Default" : "",
       "Description" : "The Load balancer security groups (comma delimited) for this app"
+    },
+    "SslNegotiationPolicy": {
+      "Type": "String",
+      "Default": "",
+      "Description": "Override the default SSL negotiation policy of the load balancer"
     },
     "Subnets": {
       "Type" : "List<AWS::EC2::Subnet::Id>",
@@ -501,6 +507,10 @@
               "LoadBalancerPort": "{{ .Balancer }}",
               "InstanceProtocol": "{{ $balancer.InstanceProtocol . }}",
               "InstancePort": { "Fn::Select": [ 0, { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Listener" } ] },
+              "PolicyNames": [ { "Fn::If": [ "BlankBalancer{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Certificate",
+                { "Ref": "AWS::NoValue" },
+                { "Fn::If": [ "BlankSslNegotiationPolicy", { "Ref": "AWS::NoValue" }, "NegotiationPolicy" ] }
+              ] } ],
               "SSLCertificateId": { "Fn::If": [ "BlankBalancer{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Certificate",
                 { "Ref": "AWS::NoValue" },
                 { "Fn::Select": [ 1, { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Listener" } ] }
@@ -510,6 +520,14 @@
           { "Ref": "AWS::NoValue" }
         ],
         "Policies": [
+          { "Fn::If": [ "BlankSslNegotiationPolicy",
+            { "Ref": "AWS::NoValue" },
+            {
+              "PolicyName": "NegotiationPolicy",
+              "PolicyType": "SSLNegotiationPolicyType",
+              "Attributes": [ { "Name": "Reference-Security-Policy", "Value": { "Ref": "SslNegotiationPolicy" } } ]
+            }
+          ] },
           {{ range .PortMappings }}
             {{ if $balancer.ProxyProtocol . }}
               {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -16,6 +16,7 @@
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
     "BlankLogRetention": { "Fn::Equals": [ { "Ref": "LogRetention" }, "" ] },
     "BlankRouterSecurityGroup": { "Fn::Equals": [ { "Fn::Join": [ ",", {"Ref": "RouterSecurityGroup" } ] }, "" ]},
+    "BlankSslPolicy": { "Fn::Equals": [ { "Ref": "SslPolicy" }, "" ] },
     "DedicatedBuilder": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstance" }, "" ] } ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
     "EncryptEbs" : { "Fn::Equals": [ { "Ref": "EncryptEbs" }, "Yes" ] },
@@ -282,6 +283,10 @@
     },
     "SpotInstances": {
       "Value": { "Fn::If": [ "SpotInstances", "true", "false" ] }
+    },
+    "SslPolicy": {
+      "Type": "String",
+      "Default": ""
     },
     "Subnets": {
       "Value": {
@@ -1940,7 +1945,8 @@
         "DefaultActions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "RouterApiTargetGroup" } } ],
         "LoadBalancerArn": { "Ref" : "Router" },
         "Port": "443",
-        "Protocol": "HTTPS"
+        "Protocol": "HTTPS",
+        "SslPolicy": { "Fn::If": [ "BlankSslPolicy", { "Ref": "AWS::NoValue" }, { "Ref": "SslPolicy" } ] }
       }
     },
     "RouterApiCertificate": {
@@ -2033,7 +2039,8 @@
         "DefaultActions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "RouterInternalApiTargetGroup" } } ],
         "LoadBalancerArn": { "Ref" : "RouterInternal" },
         "Port": "443",
-        "Protocol": "HTTPS"
+        "Protocol": "HTTPS",
+        "SslPolicy": { "Fn::If": [ "BlankSslPolicy", { "Ref": "AWS::NoValue" }, { "Ref": "SslPolicy" } ] }
       }
     },
     "RouterInternalCertificate": {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -284,10 +284,6 @@
     "SpotInstances": {
       "Value": { "Fn::If": [ "SpotInstances", "true", "false" ] }
     },
-    "SslPolicy": {
-      "Type": "String",
-      "Default": ""
-    },
     "Subnets": {
       "Value": {
         "Fn::Join": [
@@ -542,6 +538,11 @@
     "SpotInstanceBid": {
       "Default": "",
       "Description": "Bid price for spot instances",
+      "Type": "String"
+    },
+    "SslPolicy": {
+      "Default": "",
+      "Description": "SSL policy for rack load balancer",
       "Type": "String"
     },
     "Subnet0CIDR": {


### PR DESCRIPTION
For Generation 1 apps:

    $ convox apps params set SslPolicy=ELBSecurityPolicy-TLS-1-2-2017-01

For Generation 2 (affects all Generation 2 apps on the Rack):

    $ convox rack params set SslPolicy=ELBSecurityPolicy-TLS-1-2-2017-01