### PR TITLE
Disable CloudWatchLogs debug logs

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -144,12 +144,11 @@ func (p *AWSProvider) cloudformation() *cloudformation.CloudFormation {
 }
 
 func (p *AWSProvider) cloudwatch() *cloudwatch.CloudWatch {
-	config := p.config().WithLogLevel(aws.LogOff)
-	return cloudwatch.New(session.New(), config)
+	return cloudwatch.New(session.New(), p.config())
 }
 
 func (p *AWSProvider) cloudwatchlogs() *cloudwatchlogs.CloudWatchLogs {
-	return cloudwatchlogs.New(session.New(), p.config())
+	return cloudwatchlogs.New(session.New(), p.config().WithLogLevel(aws.LogOff))
 }
 
 func (p *AWSProvider) dynamodb() *dynamodb.DynamoDB {


### PR DESCRIPTION
CloudWatch logs a _ton_ of stuff when you have debug logs enabled and are tailing your rack logs. These logs are also recursive (the logs being streamed are once again logged). This significantly impacts the usability of the debug logs.

Proposal here is to disable CloudWatch logging, even when the DEBUG environment variable is set. This could hinder any debugging efforts specifically targeting CloudWatch, but those seem relatively rare and low-priority compared to debugging calls to other AWS services like EC2, ECS, and CF.