### PR TITLE
Added tag with process name to App's Target Group (gen2)

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -240,6 +240,9 @@
             { "Key": "deregistration_delay.timeout_seconds", "Value": "30" },
             { "Key": "stickiness.enabled", "Value": "true" }
           ],
+          "Tags": [
+            { "Key": "ProcessName", "Value": "{{ upper .Name }}" }
+          ],
           "TargetType": { "Fn::If": [ "FargateServices", "ip", "instance" ] },
           "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
         }
@@ -459,7 +462,7 @@
           "DesiredCount": { "Fn::Select": [ 0, { "Ref": "{{ upper .Name }}Formation" } ] },
         {{ end }}
         "LaunchType": { "Fn::If": [ "FargateServices", "FARGATE", { "Ref": "AWS::NoValue" } ] },
-        "NetworkConfiguration": { "Fn::If": [ "FargateServices", 
+        "NetworkConfiguration": { "Fn::If": [ "FargateServices",
           {
             "AwsvpcConfiguration": {
               "AssignPublicIp": { "Fn::If": [ "Private", "DISABLED", "ENABLED" ] },


### PR DESCRIPTION
This allows us to use tags in our dashboards and charts instead of target group names (which are random, changing and hard to set up in general) to filter out metrics. In our case we are using datadog and it's supporting tags out of the box, this feature is really useful because we are using in some application multiple processes and want to check each of them separately - currently only possible for whole application (including all subtasks).