### PR TITLE
Expose service role name to extend Role's permissions

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -27,6 +27,10 @@
     "ServiceRole": {
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:ServiceRole" } },
       "Value": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] }
+    },
+    "ServiceRoleName": {
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:ServiceRole" } },
+      "Value": { "Ref": "ServiceRole" }
     }
   },
   "Parameters" : {


### PR DESCRIPTION
In addition to ServiceRole ARN it is very useful to have Service Role name as well - When creating new ManagedPolicy in Cloudformation it is required to provide Role name instead of ARN (ARN is good for usecases with S3, or other resource attached permissions). It allows to extend Task roles and add permissions for application to access various resources without using Access Keys.