### PR TITLE
Use the unaltered request uri including the query string for the http proxy

### DIFF
--- a/router/proxy.go
+++ b/router/proxy.go
@@ -136,13 +136,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tu := fmt.Sprintf("%s%s", target.String(), r.URL.Path)
-
-	if r.URL.RawQuery != "" {
-		tu += fmt.Sprintf("?%s", r.URL.RawQuery)
-	}
-
-	req, err := http.NewRequest(r.Method, tu, r.Body)
+	req, err := http.NewRequest(r.Method, fmt.Sprintf("%s%s", target.String(), r.RequestURI), r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), 502)
 		return


### PR DESCRIPTION
This is required to avoid unwanted decoding of requests such as:
`http://test.com/foo%2Bbar` where `%2B` becomes `+` through the http proxy
and then becomes `" "` (space) at the target, when in fact we wanted `+`.