### PR TITLE
add shared environment section to manifest

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -276,7 +276,7 @@ func build2(dir string) error {
 		return err
 	}
 
-	m, err := manifest.Load(data, manifest.Environment(env))
+	m, err := manifest.Load(data, env)
 	if err != nil {
 		return err
 	}
@@ -303,7 +303,7 @@ func build2(dir string) error {
 	prefix := fmt.Sprintf("%s/%s", flagRack, flagApp)
 
 	err = m.Build(prefix, flagID, manifest.BuildOptions{
-		Env:    manifest.Environment(env),
+		Env:    env,
 		Push:   flagPush,
 		Root:   dir,
 		Stdout: w,

--- a/cmd/convox/start.go
+++ b/cmd/convox/start.go
@@ -244,7 +244,7 @@ func startGeneration2(opts startOptions) error {
 		return err
 	}
 
-	m, err := manifest.Load(data, manifest.Environment(env))
+	m, err := manifest.Load(data, env)
 	if err != nil {
 		return err
 	}

--- a/helpers/provider.go
+++ b/helpers/provider.go
@@ -65,7 +65,7 @@ func ReleaseManifest(p structs.Provider, app, release string) (*manifest.Manifes
 		return nil, nil, err
 	}
 
-	m, err := manifest.Load([]byte(r.Manifest), manifest.Environment(env))
+	m, err := manifest.Load([]byte(r.Manifest), env)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/manifest/build.go
+++ b/manifest/build.go
@@ -19,7 +19,7 @@ import (
 type BuildOptions struct {
 	Cache       string
 	Development bool
-	Env         Environment
+	Env         map[string]string
 	Push        string
 	Root        string
 	Stdout      io.Writer

--- a/manifest/environment.go
+++ b/manifest/environment.go
@@ -1,5 +1,3 @@
 package manifest
 
 type Environment []string
-
-// type Environment map[string]string

--- a/manifest/environment.go
+++ b/manifest/environment.go
@@ -1,19 +1,5 @@
 package manifest
 
-import (
-	"regexp"
-)
+type Environment []string
 
-var (
-	regexpInterpolation = regexp.MustCompile(`\$\{([^}]*?)\}`)
-)
-
-type Environment map[string]string
-
-func interpolate(data []byte, env Environment) ([]byte, error) {
-	p := regexpInterpolation.ReplaceAllFunc(data, func(m []byte) []byte {
-		return []byte(env[string(m)[2:len(m)-1]])
-	})
-
-	return p, nil
-}
+// type Environment map[string]string

--- a/manifest/helpers.go
+++ b/manifest/helpers.go
@@ -1,5 +1,7 @@
 package manifest
 
+import "regexp"
+
 func coalesce(ss ...string) string {
 	for _, s := range ss {
 		if s != "" {
@@ -8,4 +10,14 @@ func coalesce(ss ...string) string {
 	}
 
 	return ""
+}
+
+var regexpInterpolation = regexp.MustCompile(`\$\{([^}]*?)\}`)
+
+func interpolate(data []byte, env map[string]string) ([]byte, error) {
+	p := regexpInterpolation.ReplaceAllFunc(data, func(m []byte) []byte {
+		return []byte(env[string(m)[2:len(m)-1]])
+	})
+
+	return p, nil
 }

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -10,21 +10,21 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent       bool               `yaml:"agent,omitempty"`
-	Build       ServiceBuild       `yaml:"build,omitempty"`
-	Command     string             `yaml:"command,omitempty"`
-	Domains     ServiceDomains     `yaml:"domain,omitempty"`
-	Environment ServiceEnvironment `yaml:"environment,omitempty"`
-	Health      ServiceHealth      `yaml:"health,omitempty"`
-	Image       string             `yaml:"image,omitempty"`
-	Internal    bool               `yaml:"internal,omitempty"`
-	Links       []string           `yaml:"links,omitempty"`
-	Port        ServicePort        `yaml:"port,omitempty"`
-	Privileged  bool               `yaml:"privileged,omitempty"`
-	Resources   []string           `yaml:"resources,omitempty"`
-	Scale       ServiceScale       `yaml:"scale,omitempty"`
-	Test        string             `yaml:"test,omitempty"`
-	Volumes     []string           `yaml:"volumes,omitempty"`
+	Agent       bool           `yaml:"agent,omitempty"`
+	Build       ServiceBuild   `yaml:"build,omitempty"`
+	Command     string         `yaml:"command,omitempty"`
+	Domains     ServiceDomains `yaml:"domain,omitempty"`
+	Environment Environment    `yaml:"environment,omitempty"`
+	Health      ServiceHealth  `yaml:"health,omitempty"`
+	Image       string         `yaml:"image,omitempty"`
+	Internal    bool           `yaml:"internal,omitempty"`
+	Links       []string       `yaml:"links,omitempty"`
+	Port        ServicePort    `yaml:"port,omitempty"`
+	Privileged  bool           `yaml:"privileged,omitempty"`
+	Resources   []string       `yaml:"resources,omitempty"`
+	Scale       ServiceScale   `yaml:"scale,omitempty"`
+	Test        string         `yaml:"test,omitempty"`
+	Volumes     []string       `yaml:"volumes,omitempty"`
 }
 
 type Services []Service
@@ -43,7 +43,7 @@ type ServiceCommand struct {
 
 type ServiceDomains []string
 
-type ServiceEnvironment []string
+// type ServiceEnvironment []string
 
 type ServiceHealth struct {
 	Grace    int

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -1,3 +1,6 @@
+environment:
+  - GLOBAL=true
+  - OTHERGLOBAL
 resources:
   database:
     type: postgres

--- a/manifest/yaml.go
+++ b/manifest/yaml.go
@@ -21,6 +21,34 @@ type NameSetter interface {
 	SetName(name string) error
 }
 
+func (v *Environment) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var w interface{}
+
+	if err := unmarshal(&w); err != nil {
+		return err
+	}
+
+	switch t := w.(type) {
+	case []interface{}:
+		for _, s := range t {
+			switch st := s.(type) {
+			case []interface{}:
+				for _, stv := range st {
+					if sv, ok := stv.(string); ok {
+						*v = append(*v, sv)
+					}
+				}
+			case string:
+				*v = append(*v, st)
+			}
+		}
+	default:
+		return fmt.Errorf("unknown type for service environment: %T", t)
+	}
+
+	return nil
+}
+
 func (v Resources) MarshalYAML() (interface{}, error) {
 	return marshalMapSlice(v)
 }
@@ -132,34 +160,6 @@ func (v *ServiceDomains) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		}
 	default:
 		return fmt.Errorf("unknown type for service domain: %T", t)
-	}
-
-	return nil
-}
-
-func (v *ServiceEnvironment) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var w interface{}
-
-	if err := unmarshal(&w); err != nil {
-		return err
-	}
-
-	switch t := w.(type) {
-	case []interface{}:
-		for _, s := range t {
-			switch st := s.(type) {
-			case []interface{}:
-				for _, stv := range st {
-					if sv, ok := stv.(string); ok {
-						*v = append(*v, sv)
-					}
-				}
-			case string:
-				*v = append(*v, st)
-			}
-		}
-	default:
-		return fmt.Errorf("unknown type for service environment: %T", t)
 	}
 
 	return nil

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -106,7 +106,7 @@ func (p *AWSProvider) BuildExport(app, id string, w io.Writer) error {
 			return err
 		}
 
-		m, err := manifest.Load([]byte(build.Manifest), manifest.Environment(env))
+		m, err := manifest.Load([]byte(build.Manifest), env)
 		if err != nil {
 			log.Error(err)
 			return err

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -991,7 +991,7 @@ func (p *AWSProvider) generateTaskDefinition2(app string, opts structs.ProcessRu
 		return nil, err
 	}
 
-	m, err := manifest.Load([]byte(r.Manifest), manifest.Environment(env))
+	m, err := manifest.Load([]byte(r.Manifest), env)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -181,7 +181,7 @@ func (p *AWSProvider) ReleasePromote(app, id string) error {
 		return err
 	}
 
-	m, err := manifest.Load([]byte(r.Manifest), manifest.Environment(env))
+	m, err := manifest.Load([]byte(r.Manifest), env)
 	if err != nil {
 		return err
 	}

--- a/provider/aws/service.go
+++ b/provider/aws/service.go
@@ -39,7 +39,7 @@ func (p *AWSProvider) ServiceList(app string) (structs.Services, error) {
 		return nil, err
 	}
 
-	m, err := manifest.Load([]byte(r.Manifest), manifest.Environment(env))
+	m, err := manifest.Load([]byte(r.Manifest), env)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
adds a new `environment:` section to the manifest which defines env vars which are shared by all services on the app:

```
environment:
  - REQUIRED
  - DEFAULT=value
services:
  web:
    environment:
      - REQUIRED=override
      - DEFAULT=override
```