### PR TITLE
Move default BuildInstance type into install.go, instead of rack.json

### DIFF
--- a/cmd/convox/install.go
+++ b/cmd/convox/install.go
@@ -87,7 +87,7 @@ func init() {
 			},
 			cli.StringFlag{
 				Name:   "build-instance",
-				Value:  "",
+				Value:  "t2.small",
 				Usage:  "instance type for a dedicated build cluster",
 				EnvVar: "RACK_BUILD_INSTANCE",
 			},

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -398,7 +398,7 @@
     "BuildInstance": {
       "Type": "String",
       "Description": "Instance type for a dedicated build cluster",
-      "Default": "t2.small"
+      "Default": ""
     },
     "BuildMemory": {
       "Type": "String",


### PR DESCRIPTION
This allows the `BuildInstance` param to be overridden with `convox install --build-instance ""`.

Fixes #2699