### PR TITLE
Add trailing slash to s3 log file prefix

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -769,7 +769,7 @@
         { "Ref": "AWS::NoValue" },
         {
           "DestinationBucketName": { "Ref": "LogBucket" },
-          "LogFilePrefix": { "Fn::Sub": "convox/logs/${AWS::StackName}/s3" }
+          "LogFilePrefix": { "Fn::Sub": "convox/logs/${AWS::StackName}/s3/" }
         }
       ] },
       "Tags": [

--- a/provider/aws/formation/g1/app.json.tmpl
+++ b/provider/aws/formation/g1/app.json.tmpl
@@ -865,7 +865,7 @@
         { "Ref": "AWS::NoValue" },
         {
           "DestinationBucketName": { "Ref": "LogBucket" },
-          "LogFilePrefix": { "Fn::Sub": "convox/logs/${AWS::StackName}/s3" }
+          "LogFilePrefix": { "Fn::Sub": "convox/logs/${AWS::StackName}/s3/" }
         }
       ] },
       "Tags": [

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2558,7 +2558,7 @@
         "AccessControl": "Private",
         "LoggingConfiguration": {
           "DestinationBucketName": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
-          "LogFilePrefix": { "Fn::Sub": "convox/logs/${AWS::StackName}/s3" }
+          "LogFilePrefix": { "Fn::Sub": "convox/logs/${AWS::StackName}/s3/" }
         },
         "Tags": [
           { "Key": "System", "Value": "convox" },


### PR DESCRIPTION
This should fix the layout of the s3 logs from convox:

![](https://s3.amazonaws.com/mwarkentin-snaps/S3_Management_Console_2018-06-15_16-33-44.png)