### PR TITLE
Add AccessLoggingPolicy for g1 apps

### DIFF
--- a/provider/aws/formation/g1/app.json.tmpl
+++ b/provider/aws/formation/g1/app.json.tmpl
@@ -328,6 +328,15 @@
                 "TargetGroupArn": { "Fn::If": [ "Balancer{{ upper $e.Name }}ALB",
                   { "Ref": "{{ $manifest.BalancerResourceName $e.Name }}TargetGroup" },
                   { "Ref": "AWS::NoValue" }
+                ] },
+                "AccessLoggingPolicy": { "Fn::If": [ "BlankLogBucket",
+                  { "Ref": "AWS::NoValue" },
+                  {
+                    "EmitInterval": 5,
+                    "Enabled": true,
+                    "S3BucketName": { "Ref": "LogBucket" },
+                    "S3BucketPrefix": { "Fn::Sub": "convox/logs/${AWS::StackName}/elb/" }
+                  }
                 ] }
               }
             ],


### PR DESCRIPTION
I attempted to add the required config to do access logging for gen1 ELBs if `LogBucket` parameter is set for the app.

I'll need some help testing / validating that this was done correctly.