### PR TITLE
Use a longer password for certificate generation

### DIFF
--- a/bin/gen-cert
+++ b/bin/gen-cert
@@ -7,8 +7,10 @@ set -ex
 
 mkdir -p /etc/ssl/convox
 
-openssl genrsa -des3 -passout pass:xxxx -out /etc/ssl/convox/server.pass.key 2048
-openssl rsa -passin pass:xxxx -in /etc/ssl/convox/server.pass.key -out /etc/ssl/convox/server.key
+PASSWORD=$(openssl rand -hex 16)
+
+openssl genrsa -des3 -passout pass:${PASSWORD} -out /etc/ssl/convox/server.pass.key 2048
+openssl rsa -passin pass:${PASSWORD} -in /etc/ssl/convox/server.pass.key -out /etc/ssl/convox/server.key
 
 rm /etc/ssl/convox/server.pass.key
 

--- a/bin/gen-cert
+++ b/bin/gen-cert
@@ -7,8 +7,8 @@ set -ex
 
 mkdir -p /etc/ssl/convox
 
-openssl genrsa -des3 -passout pass:x -out /etc/ssl/convox/server.pass.key 2048
-openssl rsa -passin pass:x -in /etc/ssl/convox/server.pass.key -out /etc/ssl/convox/server.key
+openssl genrsa -des3 -passout pass:xxxx -out /etc/ssl/convox/server.pass.key 2048
+openssl rsa -passin pass:xxxx -in /etc/ssl/convox/server.pass.key -out /etc/ssl/convox/server.key
 
 rm /etc/ssl/convox/server.pass.key
 

--- a/bin/gen-cert
+++ b/bin/gen-cert
@@ -8,7 +8,6 @@ set -ex
 mkdir -p /etc/ssl/convox
 
 PASSWORD=$(openssl rand -hex 16)
-
 openssl genrsa -des3 -passout pass:${PASSWORD} -out /etc/ssl/convox/server.pass.key 2048
 openssl rsa -passin pass:${PASSWORD} -in /etc/ssl/convox/server.pass.key -out /etc/ssl/convox/server.key
 


### PR DESCRIPTION
The minimum password length is 4 characters from OpenSSL 1.1.0 onwards. When trying to boot a local rack on my workstation unfortunately this stops the rack from starting.

This PR generates a random password of 16 characters in place of the 1 character `x` in the `bin/gen-cert` script.

```
$ ./bin/gen-cert                                       
+ mkdir -p /etc/ssl/convox
+ openssl genrsa -des3 -passout pass:x -out /etc/ssl/convox/server.pass.key 2048
Generating RSA private key, 2048 bit long modulus
....+++
.......+++
e is 65537 (0x010001)
139636344934848:error:28069065:UI routines:UI_set_result:result too small:crypto/ui/ui_lib.c:765:You must type in 4 to 1023 characters
139636344934848:error:28069065:UI routines:UI_set_result:result too small:crypto/ui/ui_lib.c:765:You must type in 4 to 1023 characters
139636344934848:error:0906906F:PEM routines:PEM_ASN1_write_bio:read key:crypto/pem/pem_lib.c:336:
```