### PR TITLE
Ubuntu 18 compatibility fixes for Local rack installation.

### DIFF
--- a/router/dns_linux.go
+++ b/router/dns_linux.go
@@ -6,6 +6,47 @@ import (
 )
 
 func (d *DNS) setupResolver(domain string, ip net.IP) error {
+	version, err := linuxRelease()
+
+	if err != nil {
+		return err
+	}
+
+	switch version {
+	case "ubuntu-18.04":
+		if err := setupResolverUbuntu1804(domain, ip); err != nil {
+			return err
+		}
+	default:
+		if err := setupResolverGenericLinux(domain, ip); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setupResolverUbuntu1804(domain string, ip net.IP) error {
+	data := []byte(fmt.Sprintf("[Resolve]\nDNS=%s\nDomains=~%s", ip, domain))
+
+	if err := writeFile("/usr/lib/systemd/resolved.conf.d/convox.conf", data); err != nil {
+		return err
+	}
+
+	if err := execute("systemctl", "daemon-reload"); err != nil {
+		return err
+	}
+
+	if err := execute("systemctl", "restart", "systemd-networkd"); err != nil {
+		return err
+	}
+
+	if err := execute("systemctl", "restart", "systemd-resolved"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupResolverGenericLinux(domain string, ip net.IP) error {
 	data := []byte("[main]\ndns=dnsmasq\n")
 
 	if err := writeFile("/etc/NetworkManager/conf.d/convox.conf", data); err != nil {
@@ -21,6 +62,5 @@ func (d *DNS) setupResolver(domain string, ip net.IP) error {
 	if err := execute("systemctl", "restart", "NetworkManager"); err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/router/helpers_linux.go
+++ b/router/helpers_linux.go
@@ -1,0 +1,35 @@
+package router
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+)
+
+var kvpair = regexp.MustCompile(`\s*(\w+)\s*=\s*"?([^"]*)`)
+
+func linuxReleaseAttributes() (map[string]string, error) {
+	attrs := map[string]string{}
+	data, err := ioutil.ReadFile("/etc/os-release")
+	if err != nil {
+		return nil, err
+	}
+	s := bufio.NewScanner(bytes.NewReader(data))
+	for s.Scan() {
+		p := kvpair.FindStringSubmatch(s.Text())
+		if len(p) == 3 {
+			attrs[p[1]] = p[2]
+		}
+	}
+	return attrs, nil
+}
+
+func linuxRelease() (string, error) {
+	attrs, err := linuxReleaseAttributes()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s", attrs["ID"], attrs["VERSION_ID"]), nil
+}


### PR DESCRIPTION
Adds in an OS check and breaks Linux installation of the local rack's router into two functions, one specific to Ubuntu 18.04 and one as a generic Linux installation. Ubuntu 18 no longer uses NetworkManager as it's default networking platform. This fix installs a configuration file for systemd-resolv/resolved which allows the convox router to act as a pass through DNS server which in turn handles .convox address resolution without effecting existing external DNS resolution.