### PR TITLE
allow network isolation of app services

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -10,6 +10,9 @@
     "FargateServices": { "Fn::Equals": [ { "Ref": "FargateServices" }, "Yes" ] },
     "FargateTimers": { "Fn::Equals": [ { "Ref": "FargateTimers" }, "Yes" ] },
     "InternalDomains": { "Fn::Equals": [ { "Ref": "InternalDomains" }, "Yes" ] },
+    "Isolate": { "Fn::Equals": [ { "Ref": "Isolate" }, "Yes" ] },
+    "IsolateServices": { "Fn::Or": [ { "Condition": "FargateServices" }, { "Condition": "Isolate" } ] },
+    "IsolateTimers": { "Fn::Or": [ { "Condition": "FargateTimers" }, { "Condition": "Isolate" } ] },
     "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] }
   },
   "Outputs": {
@@ -56,6 +59,11 @@
     "InternalDomains": {
       "Type": "String",
       "Default": "Yes",
+      "AllowedValues": [ "Yes", "No" ]
+    },
+    "Isolate": {
+      "Type": "String",
+      "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
     },
     "LogBucket": {
@@ -252,6 +260,7 @@
           "Fargate": { "Fn::If": [ "Service{{ upper .Name }}Fargate", "Yes", "No" ] },
           "LogGroup": { "Ref": "LogGroup" },
           "InternalDomains": { "Ref": "InternalDomains" },
+          "Isolate": { "Fn::If": [ "IsolateServices", "Yes", "No" ] },
           "Memory": { "Fn::Select": [ 2, { "Ref": "{{ upper .Name }}Formation" } ] },
           "Private": { "Ref": "Private" },
           "Rack": { "Ref": "Rack" },
@@ -289,13 +298,27 @@
             "    cluster: event.cluster,",
             "    taskDefinition: event.taskDefinition,",
             "    count: 1,",
-            "    launchType: 'FARGATE',",
+            { "Fn::If": [ "FargateTimers",
+              "    launchType: 'FARGATE',",
+              "    launchType: 'EC2',"
+            ] },
             "    networkConfiguration: {",
             "      awsvpcConfiguration: {",
-            "        assignPublicIp: 'ENABLED',",
+            { "Fn::If": [ "FargateTimers",
+              "        assignPublicIp: 'ENABLED',",
+              { "Ref": "AWS::NoValue" }
+            ] },
             "        subnets: [",
-            { "Fn::Join": [ "", [ "          '", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet0" } }, "'," ] ] },
-            { "Fn::Join": [ "", [ "          '", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet1" } }, "'" ] ] },
+            { "Fn::Sub": [ "          \"${Subnet0}\", \"${Subnet1}\"", {
+              "Subnet0": { "Fn::If": [ "Private",
+                { "Fn::ImportValue": { "Fn::Sub": "${Rack}:SubnetPrivate0" } },
+                { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet0" } }
+              ] },
+              "Subnet1": { "Fn::If": [ "Private",
+                { "Fn::ImportValue": { "Fn::Sub": "${Rack}:SubnetPrivate1" } },
+                { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet1" } }
+              ] }
+            } ] },
             "        ]",
             "      }",
             "    }",
@@ -303,6 +326,7 @@
             "  var aws = require('aws-sdk');",
             "  var ecs = new aws.ECS({maxRetries:10});",
             "  ecs.runTask(params, function (err, res) {",
+            "    console.log('res', res);",
             "    cb(err);",
             "  });",
             "};"
@@ -320,6 +344,7 @@
             { "Effect": "Allow", "Action": [ "sts:AssumeRole" ], "Principal": { "Service": [ "lambda.amazonaws.com" ] } }
           ]
         },
+        "ManagedPolicyArns": [ "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole" ],
         "Path": "/convox/",
         "Policies": [
           {
@@ -361,20 +386,20 @@
         "Name": { "Fn::Sub": "${AWS::StackName}-timer-{{.Name}}" },
         "ScheduleExpression": "cron({{.Cron}})",
         "Targets": [ {
-          "Arn": { "Fn::If": [ "FargateTimers",
+          "Arn": { "Fn::If": [ "IsolateTimers",
             { "Fn::GetAtt": [ "TimerLauncher", "Arn" ] },
             { "Fn::Join": [ "", [ "arn:aws:ecs:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":cluster/", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } } ] ] }
           ] },
-          "EcsParameters": { "Fn::If": [ "FargateTimers",
+          "EcsParameters": { "Fn::If": [ "IsolateTimers",
             { "Ref": "AWS::NoValue" },
             { "TaskCount": "1", "TaskDefinitionArn": { "Ref": "Timer{{ upper .Name }}Tasks" } }
           ] },
           "Id": "{{.Name}}",
-          "Input": { "Fn::If": [ "FargateTimers",
+          "Input": { "Fn::If": [ "IsolateTimers",
             { "Fn::Join": [ "", [ "{ \"cluster\": \"", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } }, "\", \"taskDefinition\": \"", { "Ref": "Timer{{ upper .Name }}Tasks" }, "\" }" ] ] },
             { "Ref": "AWS::NoValue" }
           ] },
-          "RoleArn": { "Fn::If": [ "FargateTimers",
+          "RoleArn": { "Fn::If": [ "IsolateTimers",
             { "Ref": "AWS::NoValue" },
             { "Fn::GetAtt": [ "TimerRole", "Arn" ] }
           ] }
@@ -443,7 +468,7 @@
         "ExecutionRoleArn": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
         "Family": { "Fn::Sub": "${AWS::StackName}-timer-{{.Name}}" },
         "Memory": { "Fn::If": [ "FargateTimers", { "Fn::Select": [ 2, { "Ref": "{{ upper ($.Manifest.Service .Service).Name }}Formation" } ] }, { "Ref": "AWS::NoValue" } ] },
-        "NetworkMode": { "Fn::If": [ "FargateTimers", "awsvpc", { "Ref": "AWS::NoValue" } ] },
+        "NetworkMode": { "Fn::If": [ "IsolateTimers", "awsvpc", { "Ref": "AWS::NoValue" } ] },
         "RequiresCompatibilities": [ { "Fn::If": [ "FargateTimers", "FARGATE", { "Ref": "AWS::NoValue" } ] } ],
         "TaskRoleArn": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
         "Volumes": [

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -10,9 +10,8 @@
     "FargateServices": { "Fn::Equals": [ { "Ref": "FargateServices" }, "Yes" ] },
     "FargateTimers": { "Fn::Equals": [ { "Ref": "FargateTimers" }, "Yes" ] },
     "InternalDomains": { "Fn::Equals": [ { "Ref": "InternalDomains" }, "Yes" ] },
-    "Isolate": { "Fn::Equals": [ { "Ref": "Isolate" }, "Yes" ] },
+    "Isolate": { "Fn::And": [ { "Condition": "Private" }, { "Fn::Equals": [ { "Ref": "Isolate" }, "Yes" ] } ] },
     "IsolateServices": { "Fn::Or": [ { "Condition": "FargateServices" }, { "Condition": "Isolate" } ] },
-    "IsolateTimers": { "Fn::Or": [ { "Condition": "FargateTimers" }, { "Condition": "Isolate" } ] },
     "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] }
   },
   "Outputs": {
@@ -386,20 +385,20 @@
         "Name": { "Fn::Sub": "${AWS::StackName}-timer-{{.Name}}" },
         "ScheduleExpression": "cron({{.Cron}})",
         "Targets": [ {
-          "Arn": { "Fn::If": [ "IsolateTimers",
+          "Arn": { "Fn::If": [ "FargateTimers",
             { "Fn::GetAtt": [ "TimerLauncher", "Arn" ] },
             { "Fn::Join": [ "", [ "arn:aws:ecs:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":cluster/", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } } ] ] }
           ] },
-          "EcsParameters": { "Fn::If": [ "IsolateTimers",
+          "EcsParameters": { "Fn::If": [ "FargateTimers",
             { "Ref": "AWS::NoValue" },
             { "TaskCount": "1", "TaskDefinitionArn": { "Ref": "Timer{{ upper .Name }}Tasks" } }
           ] },
           "Id": "{{.Name}}",
-          "Input": { "Fn::If": [ "IsolateTimers",
+          "Input": { "Fn::If": [ "FargateTimers",
             { "Fn::Join": [ "", [ "{ \"cluster\": \"", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } }, "\", \"taskDefinition\": \"", { "Ref": "Timer{{ upper .Name }}Tasks" }, "\" }" ] ] },
             { "Ref": "AWS::NoValue" }
           ] },
-          "RoleArn": { "Fn::If": [ "IsolateTimers",
+          "RoleArn": { "Fn::If": [ "FargateTimers",
             { "Ref": "AWS::NoValue" },
             { "Fn::GetAtt": [ "TimerRole", "Arn" ] }
           ] }
@@ -468,7 +467,7 @@
         "ExecutionRoleArn": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
         "Family": { "Fn::Sub": "${AWS::StackName}-timer-{{.Name}}" },
         "Memory": { "Fn::If": [ "FargateTimers", { "Fn::Select": [ 2, { "Ref": "{{ upper ($.Manifest.Service .Service).Name }}Formation" } ] }, { "Ref": "AWS::NoValue" } ] },
-        "NetworkMode": { "Fn::If": [ "IsolateTimers", "awsvpc", { "Ref": "AWS::NoValue" } ] },
+        "NetworkMode": { "Fn::If": [ "FargateTimers", "awsvpc", { "Ref": "AWS::NoValue" } ] },
         "RequiresCompatibilities": [ { "Fn::If": [ "FargateTimers", "FARGATE", { "Ref": "AWS::NoValue" } ] } ],
         "TaskRoleArn": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
         "Volumes": [

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -10,12 +10,12 @@
     },
     "BlankInstanceBootCommand": { "Fn::Equals": [ { "Ref": "InstanceBootCommand" }, "" ] },
     "BlankInstanceRunCommand": { "Fn::Equals": [ { "Ref": "InstanceRunCommand" }, "" ] },
-    "BlankInstanceSecurityGroup": { "Fn::Equals": [ {"Ref": "InstanceSecurityGroup" }, "" ]},
+    "BlankInstanceSecurityGroup": { "Fn::Equals": [ {"Ref": "InstanceSecurityGroup" }, "" ] },
     "BlankInternetGateway": { "Fn::Equals": [ { "Ref": "InternetGateway"}, "" ] },
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
     "BlankLogRetention": { "Fn::Equals": [ { "Ref": "LogRetention" }, "" ] },
-    "BlankRouterSecurityGroup": { "Fn::Equals": [ { "Fn::Join": [ ",", {"Ref": "RouterSecurityGroup" } ] }, "" ]},
+    "BlankRouterSecurityGroup": { "Fn::Equals": [ { "Fn::Join": [ ",", { "Ref": "RouterSecurityGroup" } ] }, "" ] },
     "BlankSslPolicy": { "Fn::Equals": [ { "Ref": "SslPolicy" }, "" ] },
     "DedicatedBuilder": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstance" }, "" ] } ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
@@ -50,8 +50,8 @@
     ] },
     "ThirdAvailabilityZoneAndNotExistingVpcAndBlankInternetGateway": {
       "Fn::And": [
-        { "Condition": "ThirdAvailabilityZone"},
-        { "Condition": "NotExistingVpcAndBlankInternetGateway"}
+        { "Condition": "ThirdAvailabilityZone" },
+        { "Condition": "NotExistingVpcAndBlankInternetGateway" }
       ]
     }
   },
@@ -259,6 +259,10 @@
       "Condition": "Internal",
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:RouterInternalName" } },
       "Value": { "Fn::GetAtt": [ "RouterInternal", "LoadBalancerFullName" ] }
+    },
+    "RouterSecurityGroup": {
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:RouterSecurityGroup" } },
+      "Value": { "Fn::If": [ "BlankRouterSecurityGroup", { "Ref": "RouterSecurity" }, { "Fn::Select": [ 0, { "Ref": "RouterSecurityGroup" } ] } ] }
     },
     "RouteTablePublic": {
       "Condition": "NotExistingVpcAndBlankInternetGateway",

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -4,6 +4,7 @@
     "Conditions": {
       "Fargate": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
       "InternalDomains": { "Fn::Equals": [ { "Ref": "InternalDomains" }, "Yes" ] },
+      "Isolate": { "Fn::Or": [ { "Condition": "Fargate" }, { "Fn::Equals": [ { "Ref": "Isolate" }, "Yes" ] } ] },
       "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] }
     },
     "Outputs": {
@@ -43,6 +44,11 @@
       "InternalDomains": {
         "Type": "String",
         "Default": "Yes",
+        "AllowedValues": [ "Yes", "No" ]
+      },
+      "Isolate": {
+        "Type": "String",
+        "Default": "No",
         "AllowedValues": [ "Yes", "No" ]
       },
       "LogGroup": {
@@ -145,7 +151,7 @@
               { "Key": "App", "Value": "{{$.App}}" },
               { "Key": "Service", "Value": "{{.Name}}" }
             ],
-            "TargetType": { "Fn::If": [ "Fargate", "ip", "instance" ] },
+            "TargetType": { "Fn::If": [ "Isolate", "ip", "instance" ] },
             "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
           }
         },
@@ -331,13 +337,13 @@
         },
       {{ end }}
       "Security": {
-        "Condition": "Fargate",
+        "Condition": "Isolate",
         "Type": "AWS::EC2::SecurityGroup",
         "Properties": {
           "GroupDescription": { "Fn::Sub": "${AWS::StackName} service" },
           "SecurityGroupIngress": [
             {{ if .Port.Port }}
-              { "IpProtocol": "tcp", "FromPort": "{{.Port.Port}}", "ToPort": "{{.Port.Port}}", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
+              { "IpProtocol": "tcp", "FromPort": "{{.Port.Port}}", "ToPort": "{{.Port.Port}}", "SourceSecurityGroupId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterSecurityGroup" } } }
             {{ end }}
           ],
           "Tags": [ { "Key": "Name", "Value": { "Fn::Sub": "${AWS::StackName}-service" } } ],
@@ -368,7 +374,7 @@
             "DesiredCount": { "Ref": "Count" },
           {{ end }}
           "LaunchType": { "Fn::If": [ "Fargate", "FARGATE", { "Ref": "AWS::NoValue" } ] },
-          "NetworkConfiguration": { "Fn::If": [ "Fargate",
+          "NetworkConfiguration": { "Fn::If": [ "Isolate",
             {
               "AwsvpcConfiguration": {
                 "AssignPublicIp": { "Fn::If": [ "Private", "DISABLED", "ENABLED" ] },
@@ -384,7 +390,7 @@
           {{ if .Port.Port }}
             "HealthCheckGracePeriodSeconds": "{{.Health.Grace}}",
             "LoadBalancers": [ { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "BalancerTargetGroup{{ if .Internal }}Internal{{ end }}" } } ],
-            "Role": { "Fn::If": [ "Fargate", { "Ref": "AWS::NoValue" }, { "Fn::ImportValue": { "Fn::Sub": "${Rack}:ServiceRole" } } ] },
+            "Role": { "Fn::If": [ "Isolate", { "Ref": "AWS::NoValue" }, { "Fn::ImportValue": { "Fn::Sub": "${Rack}:ServiceRole" } } ] },
           {{ end }}
           {{ if .Agent }}
             "PlacementConstraints": [
@@ -460,7 +466,7 @@
           "ExecutionRoleArn": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
           "Family": { "Fn::Sub": "${AWS::StackName}-service-{{.Name}}" },
           "Memory": { "Fn::If": [ "Fargate", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },
-          "NetworkMode": { "Fn::If": [ "Fargate", "awsvpc", { "Ref": "AWS::NoValue" } ] },
+          "NetworkMode": { "Fn::If": [ "Isolate", "awsvpc", { "Ref": "AWS::NoValue" } ] },
           "RequiresCompatibilities": [ { "Fn::If": [ "Fargate", "FARGATE", { "Ref": "AWS::NoValue" } ] } ],
           "TaskRoleArn": { "Ref": "Role" },
           "Volumes": [

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -4,7 +4,8 @@
     "Conditions": {
       "Fargate": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
       "InternalDomains": { "Fn::Equals": [ { "Ref": "InternalDomains" }, "Yes" ] },
-      "Isolate": { "Fn::Or": [ { "Condition": "Fargate" }, { "Fn::Equals": [ { "Ref": "Isolate" }, "Yes" ] } ] },
+      "Isolate": { "Fn::And": [ { "Condition": "Private" }, { "Fn::Equals": [ { "Ref": "Isolate" }, "Yes" ] } ] },
+      "IsolateServices": { "Fn::Or": [ { "Condition": "FargateServices" }, { "Condition": "Isolate" } ] },
       "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] }
     },
     "Outputs": {
@@ -151,7 +152,7 @@
               { "Key": "App", "Value": "{{$.App}}" },
               { "Key": "Service", "Value": "{{.Name}}" }
             ],
-            "TargetType": { "Fn::If": [ "Isolate", "ip", "instance" ] },
+            "TargetType": { "Fn::If": [ "IsolateServices", "ip", "instance" ] },
             "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
           }
         },
@@ -337,7 +338,7 @@
         },
       {{ end }}
       "Security": {
-        "Condition": "Isolate",
+        "Condition": "IsolateServices",
         "Type": "AWS::EC2::SecurityGroup",
         "Properties": {
           "GroupDescription": { "Fn::Sub": "${AWS::StackName} service" },
@@ -374,7 +375,7 @@
             "DesiredCount": { "Ref": "Count" },
           {{ end }}
           "LaunchType": { "Fn::If": [ "Fargate", "FARGATE", { "Ref": "AWS::NoValue" } ] },
-          "NetworkConfiguration": { "Fn::If": [ "Isolate",
+          "NetworkConfiguration": { "Fn::If": [ "IsolateServices",
             {
               "AwsvpcConfiguration": {
                 "AssignPublicIp": { "Fn::If": [ "Private", "DISABLED", "ENABLED" ] },
@@ -390,7 +391,7 @@
           {{ if .Port.Port }}
             "HealthCheckGracePeriodSeconds": "{{.Health.Grace}}",
             "LoadBalancers": [ { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "BalancerTargetGroup{{ if .Internal }}Internal{{ end }}" } } ],
-            "Role": { "Fn::If": [ "Isolate", { "Ref": "AWS::NoValue" }, { "Fn::ImportValue": { "Fn::Sub": "${Rack}:ServiceRole" } } ] },
+            "Role": { "Fn::If": [ "IsolateServices", { "Ref": "AWS::NoValue" }, { "Fn::ImportValue": { "Fn::Sub": "${Rack}:ServiceRole" } } ] },
           {{ end }}
           {{ if .Agent }}
             "PlacementConstraints": [
@@ -466,7 +467,7 @@
           "ExecutionRoleArn": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
           "Family": { "Fn::Sub": "${AWS::StackName}-service-{{.Name}}" },
           "Memory": { "Fn::If": [ "Fargate", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },
-          "NetworkMode": { "Fn::If": [ "Isolate", "awsvpc", { "Ref": "AWS::NoValue" } ] },
+          "NetworkMode": { "Fn::If": [ "IsolateServices", "awsvpc", { "Ref": "AWS::NoValue" } ] },
           "RequiresCompatibilities": [ { "Fn::If": [ "Fargate", "FARGATE", { "Ref": "AWS::NoValue" } ] } ],
           "TaskRoleArn": { "Ref": "Role" },
           "Volumes": [

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -5,7 +5,7 @@
       "Fargate": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
       "InternalDomains": { "Fn::Equals": [ { "Ref": "InternalDomains" }, "Yes" ] },
       "Isolate": { "Fn::And": [ { "Condition": "Private" }, { "Fn::Equals": [ { "Ref": "Isolate" }, "Yes" ] } ] },
-      "IsolateServices": { "Fn::Or": [ { "Condition": "FargateServices" }, { "Condition": "Isolate" } ] },
+      "IsolateServices": { "Fn::Or": [ { "Condition": "Fargate" }, { "Condition": "Isolate" } ] },
       "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] }
     },
     "Outputs": {


### PR DESCRIPTION
Adds a new app parameter `Isolate`. When set to `Yes` will configure all app services to use `awsvpc` networking mode and only allow incoming traffic from the Rack's ALB.

Notes:
* This parameter only changes service behavior when the rack is `Private=Yes`
* In this mode each container requires a new ENI so you will want to use an instance type for your Rack with enough ENI capacity.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI