### PR TITLE
reduce service-level stack output count

### DIFF
--- a/provider/aws/apps_test.go
+++ b/provider/aws/apps_test.go
@@ -31,6 +31,7 @@ func TestAppCancel(t *testing.T) {
 func TestAppGet(t *testing.T) {
 	provider := StubAwsProvider(
 		cycleAppDescribeStacks,
+		cycleDescribeAppStackResources,
 	)
 	defer provider.Close()
 

--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -140,7 +140,9 @@ func TestBuildExport(t *testing.T) {
 	provider := StubAwsProvider(
 		cycleBuildGetItem,
 		cycleBuildDescribeStacks,
+		cycleDescribeAppStackResources,
 		cycleBuildDescribeStacks,
+		cycleDescribeAppStackResources,
 		cycleBuildDescribeRepositories,
 		cycleBuildGetAuthorizationToken,
 	)

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -116,16 +116,6 @@
 }
 
 {{ define "balancer-outputs" }}
-  {{ range .Manifest.Services }}
-    {{ if .Port.Port }}
-      "Service{{ upper .Name }}Certificate": {
-        "Value": { "Fn::GetAtt": [ "Service{{ upper .Name }}", "Outputs.Certificate" ] }
-      },
-      "Service{{ upper .Name }}Endpoint": {
-        "Value": { "Fn::GetAtt": [ "Service{{ upper .Name }}", "Outputs.Endpoint" ] }
-      },
-    {{ end }}
-  {{ end }}
 {{ end }}
 
 {{ define "balancer-resources" }}
@@ -193,9 +183,6 @@
 
 {{ define "service-outputs" }}
   {{ range .Services }}
-    "Service{{ upper .Name }}Fargate": {
-      "Value": { "Fn::GetAtt": [ "Service{{ upper .Name }}", "Outputs.Fargate" ] }
-    },
     "Service{{ upper .Name }}Service": {
       "Value": { "Fn::GetAtt": [ "Service{{ upper .Name }}", "Outputs.Service" ] }
     },

--- a/provider/aws/processes_test.go
+++ b/provider/aws/processes_test.go
@@ -40,6 +40,7 @@ func TestProcessExec(t *testing.T) {
 		cycleProcessDescribeContainerInstances,
 		cycleProcessDescribeInstances,
 		cycleProcessDescribeStacks,
+		cycleProcessDescribeStackResources,
 	)
 	defer provider.Close()
 
@@ -215,7 +216,9 @@ func TestProcessRunDetached(t *testing.T) {
 	provider := StubAwsProvider(
 		cycleProcessReleaseGetItem,
 		cycleProcessDescribeStacks,
+		cycleProcessDescribeStackResources,
 		cycleProcessDescribeStacks,
+		cycleProcessDescribeStackResources,
 		cycleProcessReleaseGetItem,
 		cycleProcessReleaseListStackResources,
 		cycleProcessReleaseEnvironmentGet,

--- a/provider/aws/releases_test.go
+++ b/provider/aws/releases_test.go
@@ -36,6 +36,7 @@ func TestReleaseGet(t *testing.T) {
 func TestReleaseList(t *testing.T) {
 	provider := StubAwsProvider(
 		cycleReleaseDescribeStacks,
+		cycleDescribeAppStackResources,
 		cycleReleaseQuery,
 	)
 	defer provider.Close()

--- a/provider/aws/resource_test.go
+++ b/provider/aws/resource_test.go
@@ -13,6 +13,7 @@ func TestResourceList(t *testing.T) {
 		cycleServiceDescribeStacksList,
 		cycleResourceDescribeStacks,
 		cycleAppDescribeStacks,
+		cycleDescribeAppStackResources,
 	)
 	defer provider.Close()
 
@@ -37,6 +38,7 @@ func TestResourceGet(t *testing.T) {
 		cycleResourceDescribeStacks,
 		cycleResourceDescribeStacks,
 		cycleAppDescribeStacks,
+		cycleDescribeAppStackResources,
 	)
 	defer provider.Close()
 

--- a/provider/aws/service.go
+++ b/provider/aws/service.go
@@ -52,7 +52,7 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 	ss := structs.Services{}
 
 	for _, ms := range m.Services {
-		cert := a.Outputs[fmt.Sprintf("Service%sCertificate", upperName(ms.Name))]
+		cert := coalesces(a.Outputs[fmt.Sprintf("Service%s.Certificate", upperName(ms.Name))], a.Outputs[fmt.Sprintf("Service%sCertificate", upperName(ms.Name))])
 		cid := ""
 
 		for _, c := range cs {
@@ -63,7 +63,7 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 
 		s := structs.Service{
 			Name:   ms.Name,
-			Domain: a.Outputs[fmt.Sprintf("Service%sEndpoint", upperName(ms.Name))],
+			Domain: coalesces(a.Outputs[fmt.Sprintf("Service%s.Endpoint", upperName(ms.Name))], a.Outputs[fmt.Sprintf("Service%sEndpoint", upperName(ms.Name))]),
 		}
 
 		if s.Domain != "" {


### PR DESCRIPTION
reduces per-service app stack output count from 4 to 1