### PR TITLE
allow app-based resources to specify options

### DIFF
--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -19,6 +19,9 @@ func TestManifestLoad(t *testing.T) {
 			manifest.Resource{
 				Name: "database",
 				Type: "postgres",
+				Options: map[string]string{
+					"size": "db.t2.large",
+				},
 			},
 		},
 		Services: manifest.Services{
@@ -180,6 +183,8 @@ func TestManifestLoad(t *testing.T) {
 		"environment",
 		"resources",
 		"resources.database",
+		"resources.database.options",
+		"resources.database.options.size",
 		"resources.database.type",
 		"services",
 		"services.api",

--- a/manifest/resource.go
+++ b/manifest/resource.go
@@ -1,8 +1,9 @@
 package manifest
 
 type Resource struct {
-	Name string `yaml:"-"`
-	Type string `yaml:"type"`
+	Name    string            `yaml:"-"`
+	Type    string            `yaml:"type"`
+	Options map[string]string `yaml:"options"`
 }
 
 type Resources []Resource

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -5,6 +5,8 @@ environment:
 resources:
   database:
     type: postgres
+    options:
+      size: db.t2.large
 services:
   api:
     build:

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -157,6 +157,9 @@
       "Properties": {
         "NotificationARNs": [ "{{ $.Topic }}" ],
         "Parameters": {
+          {{ range $k, $v := (index $ (printf "ResourceParams%s" (upper .Name) ) ) }}
+            "{{$k}}": "{{$v}}",
+          {{ end }}
           "Password": { "Fn::If": [ "BlankResourcePassword",
             { "Fn::Select": [ 2, { "Fn::Split": [ "/", { "Ref": "AWS::StackId" } ] } ] },
             { "Ref": "ResourcePassword" }
@@ -168,7 +171,7 @@
           { "Key": "Name", "Value": "{{.Name}}" },
           { "Key": "Type", "Value": "resource" }
         ],
-        "TemplateURL": "https://convox.s3.amazonaws.com/release/{{$.Version}}/formation/resource/{{.Type}}.json"
+        "TemplateURL": "{{ index $ (printf "ResourceTemplate%s" (upper .Name) ) }}"
       }
     },
   {{ end }}
@@ -262,7 +265,7 @@
           { "Key": "Name", "Value": "{{ .Name }}" },
           { "Key": "Type", "Value": "service" }
         ],
-        "TemplateURL": "{{ index $ (printf "Template%s" (upper .Name) ) }}"
+        "TemplateURL": "{{ index $ (printf "ServiceTemplate%s" (upper .Name) ) }}"
       }
     },
   {{ end }}

--- a/provider/aws/formation/resource/memcached.json.tmpl
+++ b/provider/aws/formation/resource/memcached.json.tmpl
@@ -1,14 +1,26 @@
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
   "Parameters": {
+    "Class": {
+      "Type": "String",
+      "Default": "cache.t2.micro"
+    },
     "Password": {
       "MinLength": "8",
       "NoEcho": true,
       "Type": "String"
     },
+    "Nodes": {
+      "Type": "Number",
+      "Default": "1"
+    },
     "Rack": {
       "MinLength": "1",
       "Type": "String"
+    },
+    "Version": {
+      "Type": "String",
+      "Default": "1.4.34"
     }
   },
   "Outputs": {
@@ -39,11 +51,11 @@
       "Type": "AWS::ElastiCache::CacheCluster",
       "Properties": {
         "AutoMinorVersionUpgrade": true,
-        "CacheNodeType": "cache.t2.micro",
+        "CacheNodeType": { "Ref": "Class" },
         "CacheSubnetGroupName": { "Ref": "SubnetGroup" },
         "Engine": "memcached",
-        "EngineVersion": "1.4.34",
-        "NumCacheNodes": "1",
+        "EngineVersion": { "Ref": "Version" },
+        "NumCacheNodes": { "Ref": "Nodes" },
         "Port": "11211",
         "VpcSecurityGroupIds": [ { "Ref": "SecurityGroup" } ]
       }

--- a/provider/aws/formation/resource/mysql.json.tmpl
+++ b/provider/aws/formation/resource/mysql.json.tmpl
@@ -1,6 +1,22 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "BlankIops": { "Fn::Equals": [ { "Ref": "Iops" }, "0" ] }
+  },
   "Parameters": {
+    "Class": {
+      "Type": "String",
+      "Default": "db.t2.micro"
+    },
+    "Durable": {
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues": [ "true", "false" ]
+    },
+    "Iops": {
+      "Type": "Number",
+      "Default": "0"
+    },
     "Password": {
       "MinLength": "8",
       "NoEcho": true,
@@ -9,10 +25,18 @@
     "Rack": {
       "MinLength": "1",
       "Type": "String"
+    },
+    "Storage": {
+      "Type": "Number",
+      "Default": "20"
+    },
+    "Version": {
+      "Type": "String",
+      "Default": "5.7.22"
     }
   },
   "Outputs": {
-    "Url": { "Value": { "Fn::Sub": "postgres://app:${Password}@${Instance.Endpoint.Address}:${Instance.Endpoint.Port}/app" } }
+    "Url": { "Value": { "Fn::Sub": "mysql://app:${Password}@${Instance.Endpoint.Address}:${Instance.Endpoint.Port}/app" } }
   },
   "Resources": {
     "SecurityGroup": {
@@ -20,7 +44,7 @@
       "Properties": {
         "GroupDescription": { "Fn::Sub": "${AWS::StackName} security group" },
         "SecurityGroupIngress": [
-          { "IpProtocol": "tcp", "FromPort": "5432", "ToPort": "5432", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
+          { "IpProtocol": "tcp", "FromPort": "3306", "ToPort": "3306", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
         ],
         "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
       }
@@ -39,20 +63,21 @@
       "Type": "AWS::RDS::DBInstance",
       "DeletionPolicy": "Snapshot",
       "Properties": {
-        "AllocatedStorage": "10",
-        "DBInstanceClass": "db.t2.micro",
+        "AllocatedStorage": { "Ref": "Storage" },
+        "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
         "DBName": "app",
         "DBParameterGroupName": { "Ref": "ParameterGroup" },
         "DBSubnetGroupName": { "Ref": "SubnetGroup" },
-        "Engine": "postgres",
-        "EngineVersion": "9.6.6",
+        "Engine": "mysql",
+        "EngineVersion": { "Ref": "Version" },
+        "Iops": { "Fn::If": [ "BlankIops", { "Ref": "AWS::NoValue" }, { "Ref": "Iops" } ] },
         "MasterUsername": "app",
         "MasterUserPassword": { "Ref": "Password" },
-        "MultiAZ": "false",
-        "Port": "5432",
+        "MultiAZ": { "Ref": "Durable" },
+        "Port": "3306",
         "PubliclyAccessible": "false",
-        "StorageType": "gp2",
+        "StorageType": { "Fn::If": [ "BlankIops", "gp2", "io1" ] },
         "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ]
       }
     },
@@ -60,7 +85,12 @@
       "Type": "AWS::RDS::DBParameterGroup",
       "Properties": {
         "Description": { "Fn::Sub": "${AWS::StackName} parameters" },
-        "Family": "postgres9.6"
+        "Family": { "Fn::Sub": [ "mysql${Base}", {
+          "Base": { "Fn::Join": [ ".", [
+            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
+            { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+          ] ] }
+        } ] }
       }
     }
   }

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -1,6 +1,22 @@
 {
-  "AWSTemplateFormatVersion" : "2010-09-09",
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "BlankIops": { "Fn::Equals": [ { "Ref": "Iops" }, "0" ] }
+  },
   "Parameters": {
+    "Class": {
+      "Type": "String",
+      "Default": "db.t2.micro"
+    },
+    "Durable": {
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues": [ "true", "false" ]
+    },
+    "Iops": {
+      "Type": "Number",
+      "Default": "0"
+    },
     "Password": {
       "MinLength": "8",
       "NoEcho": true,
@@ -9,10 +25,18 @@
     "Rack": {
       "MinLength": "1",
       "Type": "String"
+    },
+    "Storage": {
+      "Type": "Number",
+      "Default": "20"
+    },
+    "Version": {
+      "Type": "String",
+      "Default": "9.6.6"
     }
   },
   "Outputs": {
-    "Url": { "Value": { "Fn::Sub": "mysql://app:${Password}@${Instance.Endpoint.Address}:${Instance.Endpoint.Port}/app" } }
+    "Url": { "Value": { "Fn::Sub": "postgres://app:${Password}@${Instance.Endpoint.Address}:${Instance.Endpoint.Port}/app" } }
   },
   "Resources": {
     "SecurityGroup": {
@@ -20,7 +44,7 @@
       "Properties": {
         "GroupDescription": { "Fn::Sub": "${AWS::StackName} security group" },
         "SecurityGroupIngress": [
-          { "IpProtocol": "tcp", "FromPort": "3306", "ToPort": "3306", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
+          { "IpProtocol": "tcp", "FromPort": "5432", "ToPort": "5432", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
         ],
         "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
       }
@@ -39,20 +63,21 @@
       "Type": "AWS::RDS::DBInstance",
       "DeletionPolicy": "Snapshot",
       "Properties": {
-        "AllocatedStorage": "10",
-        "DBInstanceClass": "db.t2.micro",
+        "AllocatedStorage": { "Ref": "Storage" },
+        "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
         "DBName": "app",
         "DBParameterGroupName": { "Ref": "ParameterGroup" },
         "DBSubnetGroupName": { "Ref": "SubnetGroup" },
-        "Engine": "mysql",
-        "EngineVersion": "5.7.22",
+        "Engine": "postgres",
+        "EngineVersion": { "Ref": "Version" },
+        "Iops": { "Fn::If": [ "BlankIops", { "Ref": "AWS::NoValue" }, { "Ref": "Iops" } ] },
         "MasterUsername": "app",
         "MasterUserPassword": { "Ref": "Password" },
-        "MultiAZ": "false",
-        "Port": "3306",
+        "MultiAZ": { "Ref": "Durable" },
+        "Port": "5432",
         "PubliclyAccessible": "false",
-        "StorageType": "gp2",
+        "StorageType": { "Fn::If": [ "BlankIops", "gp2", "io1" ] },
         "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ]
       }
     },
@@ -60,7 +85,12 @@
       "Type": "AWS::RDS::DBParameterGroup",
       "Properties": {
         "Description": { "Fn::Sub": "${AWS::StackName} parameters" },
-        "Family": "mysql5.7"
+        "Family": { "Fn::Sub": [ "postgres${Base}", {
+          "Base": { "Fn::Join": [ ".", [
+            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
+            { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+          ] ] }
+        } ] }
       }
     }
   }

--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -1,6 +1,19 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Parameters": {
+    "Class": {
+      "Type": "String",
+      "Default": "cache.t2.micro"
+    },
+    "Durable": {
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues": [ "true", "false" ]
+    },
+    "Nodes": {
+      "Type": "Number",
+      "Default": "1"
+    },
     "Password": {
       "MinLength": "8",
       "NoEcho": true,
@@ -9,6 +22,10 @@
     "Rack": {
       "MinLength": "1",
       "Type": "String"
+    },
+    "Version": {
+      "Type": "String",
+      "Default": "2.8.24"
     }
   },
   "Outputs": {
@@ -38,13 +55,13 @@
     "ReplicationGroup": {
       "Type": "AWS::ElastiCache::ReplicationGroup",
       "Properties": {
-        "AutomaticFailoverEnabled": "false",
+        "AutomaticFailoverEnabled": { "Ref": "Durable" },
         "AutoMinorVersionUpgrade": "true",
-        "CacheNodeType": "cache.t2.micro",
+        "CacheNodeType": { "Ref": "Class" },
         "CacheSubnetGroupName": { "Ref": "SubnetGroup" },
         "Engine": "redis",
-        "EngineVersion": "2.8.24",
-        "NumCacheClusters": "1",
+        "EngineVersion": { "Ref": "Version" },
+        "NumCacheClusters": { "Ref": "Nodes" },
         "Port": "6379",
         "ReplicationGroupDescription": { "Ref": "AWS::StackName" },
         "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ]


### PR DESCRIPTION
Generation 2 apps can now specify options to their resources:

```
resources:
  cache:
    type: redis
    options:
      class: cache.t2.micro
      durable: true
      nodes: 2
      version: 2.8.24
  database:
    type: postgres
    options:
      class: db.t2.large
      durable: true
      iops: 1000
      storage: 200
      version: 9.6.6
```
