### PR TITLE
add cli compatibility with older racks

### DIFF
--- a/cmd/convox/env.go
+++ b/cmd/convox/env.go
@@ -113,9 +113,23 @@ func EnvSet(c *stdcli.Context) error {
 
 	c.Startf(fmt.Sprintf("Setting %s", strings.Join(keys, ", ")))
 
-	r, err := provider(c).ReleaseCreate(app(c), structs.ReleaseCreateOptions{Env: options.String(env.String())})
+	var r *structs.Release
+
+	s, err := provider(c).SystemGet()
 	if err != nil {
 		return err
+	}
+
+	if s.Version <= "20180708231844" {
+		r, err = provider(c).EnvironmentSet(app(c), []byte(env.String()))
+		if err != nil {
+			return err
+		}
+	} else {
+		r, err = provider(c).ReleaseCreate(app(c), structs.ReleaseCreateOptions{Env: options.String(env.String())})
+		if err != nil {
+			return err
+		}
 	}
 
 	c.OK()
@@ -159,12 +173,12 @@ func EnvUnset(c *stdcli.Context) error {
 
 	c.Startf(fmt.Sprintf("Unsetting %s", strings.Join(keys, ", ")))
 
+	var r *structs.Release
+
 	s, err := provider(c).SystemGet()
 	if err != nil {
 		return err
 	}
-
-	var r *structs.Release
 
 	if s.Version <= "20180708231844" {
 		for _, e := range c.Args {

--- a/cmd/convox/ssl.go
+++ b/cmd/convox/ssl.go
@@ -24,9 +24,23 @@ func init() {
 }
 
 func Ssl(c *stdcli.Context) error {
-	ss, err := provider(c).ServiceList(app(c))
+	sys, err := provider(c).SystemGet()
 	if err != nil {
 		return err
+	}
+
+	var ss structs.Services
+
+	if sys.Version < "20180708231844" {
+		ss, err = provider(c).FormationGet(app(c))
+		if err != nil {
+			return err
+		}
+	} else {
+		ss, err = provider(c).ServiceList(app(c))
+		if err != nil {
+			return err
+		}
 	}
 
 	t := c.Table("ENDPOINT", "CERTIFICATE", "DOMAIN", "EXPIRES")


### PR DESCRIPTION
Adds compatibility with older racks for:
* `convox env set`
* `convox scale`
* `convox services`
* `convox ssl`