### PR TITLE
add auth token and encryption to redis resource

### DIFF
--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -62,6 +62,7 @@
         "Engine": "redis",
         "EngineVersion": { "Ref": "Version" },
         "NumCacheClusters": { "Ref": "Nodes" },
+        "AuthToken": { "Ref": "Password" },
         "Port": "6379",
         "ReplicationGroupDescription": { "Ref": "AWS::StackName" },
         "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ]

--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -10,6 +10,11 @@
       "Default": "false",
       "AllowedValues": [ "true", "false" ]
     },
+    "Encrypted": {
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues": [ "true", "false" ]
+    },
     "Nodes": {
       "Type": "Number",
       "Default": "1"
@@ -55,6 +60,7 @@
     "ReplicationGroup": {
       "Type": "AWS::ElastiCache::ReplicationGroup",
       "Properties": {
+        "AtRestEncryptionEnabled": { "Ref": "Encrypted" },
         "AutomaticFailoverEnabled": { "Ref": "Durable" },
         "AutoMinorVersionUpgrade": "true",
         "CacheNodeType": { "Ref": "Class" },
@@ -65,7 +71,8 @@
         "AuthToken": { "Ref": "Password" },
         "Port": "6379",
         "ReplicationGroupDescription": { "Ref": "AWS::StackName" },
-        "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ]
+        "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ],
+        "TransitEncryptionEnabled": "true",
       }
     }
   }

--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -61,6 +61,7 @@
       "Type": "AWS::ElastiCache::ReplicationGroup",
       "Properties": {
         "AtRestEncryptionEnabled": { "Ref": "Encrypted" },
+        "AuthToken": { "Ref": "Password" },
         "AutomaticFailoverEnabled": { "Ref": "Durable" },
         "AutoMinorVersionUpgrade": "true",
         "CacheNodeType": { "Ref": "Class" },
@@ -68,7 +69,6 @@
         "Engine": "redis",
         "EngineVersion": { "Ref": "Version" },
         "NumCacheClusters": { "Ref": "Nodes" },
-        "AuthToken": { "Ref": "Password" },
         "Port": "6379",
         "ReplicationGroupDescription": { "Ref": "AWS::StackName" },
         "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ],


### PR DESCRIPTION
without this i just get an error (`ERR Client sent AUTH, but no password is set`) while trying to connect to the `REDIS_URL` linked from the resource as the redis instance does not actually have a password set.

`TransitEncryptionEnabled` was required to use authtoken and then i added the `Encrypted` parameter as it seemed like a common thing to set