### PR TITLE
allow agents to open tcp and udp ports on each host

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -67,7 +67,7 @@ func (m *Manifest) Agents() []string {
 	a := []string{}
 
 	for _, s := range m.Services {
-		if s.Agent {
+		if s.Agent.Enabled {
 			a = append(a, s.Name)
 		}
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -44,8 +44,15 @@ func TestManifestLoad(t *testing.T) {
 					Interval: 10,
 					Timeout:  9,
 				},
-				Init:      true,
-				Port:      manifest.ServicePort{Port: 1000, Scheme: "http"},
+				Init: true,
+				Port: manifest.ServicePort{Port: 1000, Protocol: "tcp", Scheme: "http"},
+				Ports: []manifest.ServicePort{
+					{Host: 5000, Port: 5000, Protocol: "tcp", Scheme: "http"},
+					{Port: 5001, Protocol: "udp", Scheme: "http"},
+					{Host: 5002, Port: 5002, Protocol: "udp", Scheme: "http"},
+					{Host: 5003, Port: 6003, Protocol: "tcp", Scheme: "http"},
+					{Port: 5004, Protocol: "tcp", Scheme: "https"},
+				},
 				Resources: []string{"database"},
 				Scale: manifest.ServiceScale{
 					Count:  manifest.ServiceScaleCount{Min: 3, Max: 10},
@@ -69,7 +76,7 @@ func TestManifestLoad(t *testing.T) {
 				Environment: []string{
 					"SECRET",
 				},
-				Port: manifest.ServicePort{Port: 2000, Scheme: "https"},
+				Port: manifest.ServicePort{Port: 2000, Protocol: "tcp", Scheme: "https"},
 				Scale: manifest.ServiceScale{
 					Count:  manifest.ServiceScaleCount{Min: 1, Max: 1},
 					Cpu:    512,
@@ -91,7 +98,7 @@ func TestManifestLoad(t *testing.T) {
 					Path:     "/",
 					Timeout:  3,
 				},
-				Port: manifest.ServicePort{Port: 3000, Scheme: "https"},
+				Port: manifest.ServicePort{Port: 3000, Protocol: "tcp", Scheme: "https"},
 				Scale: manifest.ServiceScale{
 					Count:  manifest.ServiceScaleCount{Min: 0, Max: 0},
 					Cpu:    256,
@@ -168,7 +175,7 @@ func TestManifestLoad(t *testing.T) {
 				Environment: []string{
 					"SECRET",
 				},
-				Port: manifest.ServicePort{Port: 2000, Scheme: "https"},
+				Port: manifest.ServicePort{Port: 2000, Protocol: "tcp", Scheme: "https"},
 				Scale: manifest.ServiceScale{
 					Count:  manifest.ServiceScaleCount{Min: 1, Max: 1},
 					Cpu:    512,
@@ -197,6 +204,7 @@ func TestManifestLoad(t *testing.T) {
 		"services.api.health.interval",
 		"services.api.init",
 		"services.api.port",
+		"services.api.ports",
 		"services.api.resources",
 		"services.api.scale",
 		"services.api.test",

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -44,15 +44,8 @@ func TestManifestLoad(t *testing.T) {
 					Interval: 10,
 					Timeout:  9,
 				},
-				Init: true,
-				Port: manifest.ServicePort{Port: 1000, Protocol: "tcp", Scheme: "http"},
-				Ports: []manifest.ServicePort{
-					{Host: 5000, Port: 5000, Protocol: "tcp", Scheme: "http"},
-					{Port: 5001, Protocol: "udp", Scheme: "http"},
-					{Host: 5002, Port: 5002, Protocol: "udp", Scheme: "http"},
-					{Host: 5003, Port: 6003, Protocol: "tcp", Scheme: "http"},
-					{Port: 5004, Protocol: "tcp", Scheme: "https"},
-				},
+				Init:      true,
+				Port:      manifest.ServicePort{Port: 1000, Protocol: "tcp", Scheme: "http"},
 				Resources: []string{"database"},
 				Scale: manifest.ServiceScale{
 					Count:  manifest.ServiceScaleCount{Min: 3, Max: 10},
@@ -183,6 +176,33 @@ func TestManifestLoad(t *testing.T) {
 				},
 				Sticky: true,
 			},
+			manifest.Service{
+				Name: "agent",
+				Agent: manifest.ServiceAgent{
+					Enabled: true,
+					Ports: []manifest.ServicePort{
+						{Port: 5000, Protocol: "udp", Scheme: "http"},
+						{Port: 5001, Protocol: "tcp", Scheme: "http"},
+						{Port: 5002, Protocol: "tcp", Scheme: "http"},
+					},
+				},
+				Build: manifest.ServiceBuild{
+					Manifest: "Dockerfile",
+					Path:     ".",
+				},
+				Health: manifest.ServiceHealth{
+					Grace:    5,
+					Path:     "/",
+					Interval: 5,
+					Timeout:  4,
+				},
+				Scale: manifest.ServiceScale{
+					Count:  manifest.ServiceScaleCount{Min: 1, Max: 1},
+					Cpu:    256,
+					Memory: 512,
+				},
+				Sticky: true,
+			},
 		},
 	}
 
@@ -194,6 +214,9 @@ func TestManifestLoad(t *testing.T) {
 		"resources.database.options.size",
 		"resources.database.type",
 		"services",
+		"services.agent",
+		"services.agent.agent",
+		"services.agent.agent.ports",
 		"services.api",
 		"services.api.build",
 		"services.api.build.manifest",
@@ -204,7 +227,6 @@ func TestManifestLoad(t *testing.T) {
 		"services.api.health.interval",
 		"services.api.init",
 		"services.api.port",
-		"services.api.ports",
 		"services.api.resources",
 		"services.api.scale",
 		"services.api.test",

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -10,7 +10,7 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent       bool           `yaml:"agent,omitempty"`
+	Agent       ServiceAgent   `yaml:"agent,omitempty"`
 	Build       ServiceBuild   `yaml:"build,omitempty"`
 	Command     string         `yaml:"command,omitempty"`
 	Domains     ServiceDomains `yaml:"domain,omitempty"`
@@ -21,7 +21,6 @@ type Service struct {
 	Internal    bool           `yaml:"internal,omitempty"`
 	Links       []string       `yaml:"links,omitempty"`
 	Port        ServicePort    `yaml:"port,omitempty"`
-	Ports       []ServicePort  `yaml:"ports,omitempty"`
 	Privileged  bool           `yaml:"privileged,omitempty"`
 	Resources   []string       `yaml:"resources,omitempty"`
 	Scale       ServiceScale   `yaml:"scale,omitempty"`
@@ -32,6 +31,11 @@ type Service struct {
 }
 
 type Services []Service
+
+type ServiceAgent struct {
+	Enabled bool          `yaml:"enabled,omitempty"`
+	Ports   []ServicePort `yaml:"ports,omitempty"`
+}
 
 type ServiceBuild struct {
 	Args     []string `yaml:"args,omitempty"`
@@ -57,7 +61,6 @@ type ServiceHealth struct {
 }
 
 type ServicePort struct {
-	Host     int    `yaml:"host,omitempty"`
 	Port     int    `yaml:"port,omitempty"`
 	Protocol string `yaml:"protocol,omitempty"`
 	Scheme   string `yaml:"scheme,omitempty"`

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -21,6 +21,7 @@ type Service struct {
 	Internal    bool           `yaml:"internal,omitempty"`
 	Links       []string       `yaml:"links,omitempty"`
 	Port        ServicePort    `yaml:"port,omitempty"`
+	Ports       []ServicePort  `yaml:"ports,omitempty"`
 	Privileged  bool           `yaml:"privileged,omitempty"`
 	Resources   []string       `yaml:"resources,omitempty"`
 	Scale       ServiceScale   `yaml:"scale,omitempty"`
@@ -56,8 +57,10 @@ type ServiceHealth struct {
 }
 
 type ServicePort struct {
-	Port   int    `yaml:"port,omitempty"`
-	Scheme string `yaml:"scheme,omitempty"`
+	Host     int    `yaml:"host,omitempty"`
+	Port     int    `yaml:"port,omitempty"`
+	Protocol string `yaml:"protocol,omitempty"`
+	Scheme   string `yaml:"scheme,omitempty"`
 }
 
 type ServiceScale struct {

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -23,14 +23,6 @@ services:
     resources:
       - database
     port: 1000
-    ports:
-      - port: 5000
-        host: 5000
-      - 5001/udp
-      - host: 5002/udp
-      - host: 5003/udp
-        port: 6003
-      - https:5004
     scale: 3-10
     test: make ${BAR} test
   proxy: &proxy
@@ -75,3 +67,9 @@ services:
   inherit:
     "<<": *proxy
     command: inherit
+  agent:
+    agent:
+      ports:
+        - 5000/udp
+        - 5001
+        - 5002/tcp

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -23,6 +23,14 @@ services:
     resources:
       - database
     port: 1000
+    ports:
+      - port: 5000
+        host: 5000
+      - 5001/udp
+      - host: 5002/udp
+      - host: 5003/udp
+        port: 6003
+      - https:5004
     scale: 3-10
     test: make ${BAR} test
   proxy: &proxy

--- a/manifest/yaml.go
+++ b/manifest/yaml.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -204,56 +205,101 @@ func (v *ServicePort) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	switch t := w.(type) {
 	case map[interface{}]interface{}:
-		if port := t["port"]; port != nil {
-			switch port.(type) {
-			case int:
-				v.Port = port.(int)
-			case string:
-				ports, err := strconv.Atoi(port.(string))
-				if err != nil {
-					return err
-				}
-				v.Port = ports
-			default:
-				return fmt.Errorf("invalid port: %v", w)
+		switch u := t["host"].(type) {
+		case int:
+			p, err := parsePort(strconv.Itoa(u))
+			if err != nil {
+				return err
 			}
+			v.Host = p.Port
+			v.Port = p.Port
+			v.Protocol = p.Protocol
+			v.Scheme = p.Scheme
+		case string:
+			p, err := parsePort(u)
+			if err != nil {
+				return err
+			}
+			v.Host = p.Port
+			v.Port = p.Port
+			v.Protocol = p.Protocol
+			v.Scheme = p.Scheme
+		case nil:
+		default:
+			return fmt.Errorf("could not parse host: %s", t["host"])
 		}
-		if scheme := t["scheme"]; (scheme == nil) || (scheme.(string) == "") {
-			v.Scheme = "http"
-		} else {
+
+		switch u := t["port"].(type) {
+		case int:
+			p, err := parsePort(strconv.Itoa(u))
+			if err != nil {
+				return err
+			}
+			v.Port = p.Port
+			v.Protocol = p.Protocol
+			v.Scheme = p.Scheme
+		case string:
+			p, err := parsePort(u)
+			if err != nil {
+				return err
+			}
+			v.Port = p.Port
+			v.Protocol = p.Protocol
+			v.Scheme = p.Scheme
+		case nil:
+		default:
+			return fmt.Errorf("could not parse port: %s", t)
+		}
+
+		if scheme := t["scheme"]; scheme != nil {
 			v.Scheme = scheme.(string)
 		}
-	case string:
-		parts := strings.Split(t, ":")
 
-		switch len(parts) {
-		case 1:
-			p, err := strconv.Atoi(parts[0])
-			if err != nil {
-				return err
-			}
-
-			v.Scheme = "http"
-			v.Port = p
-		case 2:
-			p, err := strconv.Atoi(parts[1])
-			if err != nil {
-				return err
-			}
-
-			v.Scheme = parts[0]
-			v.Port = p
-		default:
-			return fmt.Errorf("invalid port: %s", t)
+		if v.Port == 0 {
+			return fmt.Errorf("could not parse port: %+v", t)
 		}
+	case string:
+		p, err := parsePort(t)
+		if err != nil {
+			return err
+		}
+		v.Port = p.Port
+		v.Protocol = p.Protocol
+		v.Scheme = p.Scheme
 	case int:
-		v.Scheme = "http"
 		v.Port = t
+		v.Protocol = "tcp"
+		v.Scheme = "http"
 	default:
 		return fmt.Errorf("invalid port: %s", t)
 	}
 
 	return nil
+}
+
+var rePortParser = regexp.MustCompile(`^((\w+):)?(\d+)(/(\w+))?$`)
+
+func parsePort(s string) (*ServicePort, error) {
+	var err error
+
+	p := &ServicePort{Protocol: "tcp", Scheme: "http"}
+
+	m := rePortParser.FindStringSubmatch(s)
+	if m == nil {
+		return nil, fmt.Errorf("could not parse port: %s", s)
+	}
+	p.Port, err = strconv.Atoi(m[3])
+	if err != nil {
+		return nil, err
+	}
+	if m[2] != "" {
+		p.Scheme = m[2]
+	}
+	if m[5] != "" {
+		p.Protocol = m[5]
+	}
+
+	return p, nil
 }
 
 func (v ServicePort) MarshalYAML() (interface{}, error) {

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -451,9 +451,22 @@
                 }
               },
               "Memory": { "Ref": "Memory" },
-              {{ if .Port.Port }}
-                "PortMappings": [ { "ContainerPort": "{{.Port.Port}}" } ],
-              {{ end }}
+              "PortMappings": [
+                {{ if .Port.Port }}
+                  {
+                    "ContainerPort": "{{.Port.Port}}",
+                    "Protocol": "{{.Port.Protocol}}"
+                  },
+                {{ end }}
+                {{ range .Ports }}
+                  {
+                    "ContainerPort": "{{.Port}}",
+                    {{ with .Host }} "HostPort": "{{.}}", {{ end }}
+                    "Protocol": "{{.Protocol}}"
+                  },
+                {{ end }}
+                { "Ref": "AWS::NoValue" }
+              ],
               "MountPoints": [
                 {{ range $i, $v := .Volumes }}
                   { "SourceVolume": "volume-{{$i}}", "ContainerPath": "{{ volumeTo $v }}" },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -359,7 +359,7 @@
         "Properties": {
           "Cluster": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } },
           "DeploymentConfiguration": {
-            {{ if .Singleton }}
+            {{ if or .Agent.Enabled .Singleton }}
               "MinimumHealthyPercent": "0", "MaximumPercent": "100"
             {{ else }}
               "MinimumHealthyPercent": "50", "MaximumPercent": "200"
@@ -393,7 +393,7 @@
             "LoadBalancers": [ { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "BalancerTargetGroup{{ if .Internal }}Internal{{ end }}" } } ],
             "Role": { "Fn::If": [ "IsolateServices", { "Ref": "AWS::NoValue" }, { "Fn::ImportValue": { "Fn::Sub": "${Rack}:ServiceRole" } } ] },
           {{ end }}
-          {{ if .Agent }}
+          {{ if .Agent.Enabled }}
             "PlacementConstraints": [
               { "Type": "distinctInstance" }
             ],
@@ -458,10 +458,10 @@
                     "Protocol": "{{.Port.Protocol}}"
                   },
                 {{ end }}
-                {{ range .Ports }}
+                {{ range .Agent.Ports }}
                   {
                     "ContainerPort": "{{.Port}}",
-                    {{ with .Host }} "HostPort": "{{.}}", {{ end }}
+                    "HostPort": "{{.Port}}",
                     "Protocol": "{{.Protocol}}"
                   },
                 {{ end }}

--- a/provider/aws/template.go
+++ b/provider/aws/template.go
@@ -110,6 +110,10 @@ func formationHelpers() template.FuncMap {
 			parts := strings.SplitN(s, ":", 2)
 
 			switch v := parts[0]; v {
+			case "/cgroup/":
+				return v
+			case "/proc/":
+				return v
 			case "/var/run/docker.sock":
 				return v
 			default:

--- a/provider/aws/workers_spotreplace.go
+++ b/provider/aws/workers_spotreplace.go
@@ -74,7 +74,6 @@ func (p *Provider) spotReplace() error {
 	log.Logf("instanceCount=%d onDemandMin=%d onDemandCount=%d spotCount=%d", ic, odmin, odc, spc)
 
 	spotDesired := ic - odmin
-	onDemandDesired := ic - spc
 
 	if spc != spotDesired {
 		log.Logf("stack=SpotInstances setDesiredCount=%d", spotDesired)
@@ -83,6 +82,8 @@ func (p *Provider) spotReplace() error {
 			return err
 		}
 	}
+
+	onDemandDesired := ic - spotDesired
 
 	if odc != onDemandDesired {
 		log.Logf("stack=Instances setDesiredCount=%d", onDemandDesired)

--- a/provider/aws/workers_spotreplace.go
+++ b/provider/aws/workers_spotreplace.go
@@ -111,15 +111,7 @@ func (p *Provider) asgResourceInstanceCount(resource string) (int, error) {
 		return 0, fmt.Errorf("resource not found: %s", resource)
 	}
 
-	count := 0
-
-	for _, ii := range res.AutoScalingGroups[0].Instances {
-		if *ii.LifecycleState == "InService" && *ii.HealthStatus == "Healthy" {
-			count++
-		}
-	}
-
-	return count, nil
+	return int(*res.AutoScalingGroups[0].DesiredCapacity), nil
 }
 
 func (p *Provider) setAsgResourceDesiredCount(resource string, count int) error {


### PR DESCRIPTION
Agents can now be specified in one of these formats:

```
agent: true
```

or

```
agent:
  ports:
    - 5000
    - 5001/tcp
    - 5002/udp
```

Using the latter format will allow your agent processes to bind to ports on each host. The protocol defaults to `tcp`.

This is useful for things like the Datadog agent, see convox-examples/dd-agent#9