### PR TITLE
fix invalid json in redis resource template

### DIFF
--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -72,7 +72,7 @@
         "Port": "6379",
         "ReplicationGroupDescription": { "Ref": "AWS::StackName" },
         "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ],
-        "TransitEncryptionEnabled": "true",
+        "TransitEncryptionEnabled": "true"
       }
     }
   }


### PR DESCRIPTION
i noticed this just now when i was about to deploy and got this error:

```
ERROR: json syntax error: line 75 pos 6: invalid character '}' looking for beginning of object key string:       }
```