### PR TITLE
set redis password and protocol when encrypted

### DIFF
--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Conditions": {
-    "IsEncrypted": { "Fn::Equals": [{ "Ref": "Encrypted" }, "true"] }
+    "Encrypted": { "Fn::Equals": [{ "Ref": "Encrypted" }, "true"] }
   },
   "Parameters": {
     "Class": {
@@ -82,7 +82,7 @@
         "AtRestEncryptionEnabled": { "Ref": "Encrypted" },
         "AuthToken": {
           "Fn::If": [
-            "IsEncrypted",
+            "Encrypted",
             { "Ref": "Password" },
             { "Ref": "AWS::NoValue" }
           ]

--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -1,5 +1,8 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "IsEncrypted": { "Fn::Equals": [{ "Ref": "Encrypted" }, "true"] }
+  },
   "Parameters": {
     "Class": {
       "Type": "String",
@@ -8,12 +11,12 @@
     "Durable": {
       "Type": "String",
       "Default": "false",
-      "AllowedValues": [ "true", "false" ]
+      "AllowedValues": ["true", "false"]
     },
     "Encrypted": {
       "Type": "String",
       "Default": "false",
-      "AllowedValues": [ "true", "false" ]
+      "AllowedValues": ["true", "false"]
     },
     "Nodes": {
       "Type": "Number",
@@ -34,7 +37,18 @@
     }
   },
   "Outputs": {
-    "Url": { "Value": { "Fn::Sub": "redis://:${Password}@${ReplicationGroup.PrimaryEndPoint.Address}:${ReplicationGroup.PrimaryEndPoint.Port}/0" } }
+    "Url": {
+      "Value": {
+        "Fn::Sub": [
+          "${Protocol}://:${Password}@${ReplicationGroup.PrimaryEndPoint.Address}:${ReplicationGroup.PrimaryEndPoint.Port}/0",
+          {
+            "Protocol": {
+              "Fn::If": ["IsEncrypted", "rediss", "redis"]
+            }
+          }
+        ]
+      }
+    }
   },
   "Resources": {
     "SecurityGroup": {
@@ -42,7 +56,12 @@
       "Properties": {
         "GroupDescription": { "Fn::Sub": "${AWS::StackName} security group" },
         "SecurityGroupIngress": [
-          { "IpProtocol": "tcp", "FromPort": "6379", "ToPort": "6379", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "6379",
+            "ToPort": "6379",
+            "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } }
+          }
         ],
         "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
       }
@@ -61,7 +80,13 @@
       "Type": "AWS::ElastiCache::ReplicationGroup",
       "Properties": {
         "AtRestEncryptionEnabled": { "Ref": "Encrypted" },
-        "AuthToken": { "Ref": "Password" },
+        "AuthToken": {
+          "Fn::If": [
+            "IsEncrypted",
+            { "Ref": "Password" },
+            { "Ref": "AWS::NoValue" }
+          ]
+        },
         "AutomaticFailoverEnabled": { "Ref": "Durable" },
         "AutoMinorVersionUpgrade": "true",
         "CacheNodeType": { "Ref": "Class" },
@@ -71,8 +96,8 @@
         "NumCacheClusters": { "Ref": "Nodes" },
         "Port": "6379",
         "ReplicationGroupDescription": { "Ref": "AWS::StackName" },
-        "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ],
-        "TransitEncryptionEnabled": "true"
+        "SecurityGroupIds": [{ "Ref": "SecurityGroup" }],
+        "TransitEncryptionEnabled": { "Ref": "Encrypted" }
       }
     }
   }

--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -40,10 +40,13 @@
     "Url": {
       "Value": {
         "Fn::Sub": [
-          "${Protocol}://:${Password}@${ReplicationGroup.PrimaryEndPoint.Address}:${ReplicationGroup.PrimaryEndPoint.Port}/0",
+          "${Protocol}${Auth}${ReplicationGroup.PrimaryEndPoint.Address}:${ReplicationGroup.PrimaryEndPoint.Port}/0",
           {
             "Protocol": {
-              "Fn::If": ["IsEncrypted", "rediss", "redis"]
+              "Fn::If": ["Encrypted", "rediss://", "redis://"]
+            },
+            "Auth": {
+              "Fn::If": ["Encrypted", { "Fn::Sub": ":${Password}@" }, ""]
             }
           }
         ]

--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -11,12 +11,12 @@
     "Durable": {
       "Type": "String",
       "Default": "false",
-      "AllowedValues": ["true", "false"]
+      "AllowedValues": [ "true", "false" ]
     },
     "Encrypted": {
       "Type": "String",
       "Default": "false",
-      "AllowedValues": ["true", "false"]
+      "AllowedValues": [ "true", "false" ]
     },
     "Nodes": {
       "Type": "Number",
@@ -59,12 +59,7 @@
       "Properties": {
         "GroupDescription": { "Fn::Sub": "${AWS::StackName} security group" },
         "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "6379",
-            "ToPort": "6379",
-            "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } }
-          }
+          { "IpProtocol": "tcp", "FromPort": "6379", "ToPort": "6379", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
         ],
         "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
       }
@@ -99,7 +94,7 @@
         "NumCacheClusters": { "Ref": "Nodes" },
         "Port": "6379",
         "ReplicationGroupDescription": { "Ref": "AWS::StackName" },
-        "SecurityGroupIds": [{ "Ref": "SecurityGroup" }],
+        "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ],
         "TransitEncryptionEnabled": { "Ref": "Encrypted" }
       }
     }


### PR DESCRIPTION
I've never used cloudformation json before but I copied some from the other templates and came up with this.

I've also validated it this time with aws-cli:

```
$ aws cloudformation validate-template --template-body file://${PWD}/provider/aws/formation/resource/redis.json.tmpl
{
    "Parameters": [
        {
            "ParameterKey": "Rack",
            "NoEcho": false
        },
        {
            "ParameterKey": "Version",
            "DefaultValue": "2.8.24",
            "NoEcho": false
        },
        {
            "ParameterKey": "Encrypted",
            "DefaultValue": "false",
            "NoEcho": false
        },
        {
            "ParameterKey": "Durable",
            "DefaultValue": "false",
            "NoEcho": false
        },
        {
            "ParameterKey": "Class",
            "DefaultValue": "cache.t2.micro",
            "NoEcho": false
        },
        {
            "ParameterKey": "Nodes",
            "DefaultValue": "1",
            "NoEcho": false
        },
        {
            "ParameterKey": "Password",
            "NoEcho": true
        }
    ]
}
```

Fixes #2874