### PR TITLE
Bring back release:promote start events

### DIFF
--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -304,7 +304,8 @@ func (p *Provider) ReleasePromote(app, id string) error {
 		return err
 	}
 
-	p.EventSend("release:promote", structs.EventSendOptions{Status: "start", Data: map[string]string{"app": a.Name, "id": r.Id}})
+	releaseStatus := "start"
+	p.EventSend("release:promote", structs.EventSendOptions{Status: &releaseStatus, Data: map[string]string{"app": a.Name, "id": r.Id}})
 	go p.waitForPromotion(r)
 
 	return nil
@@ -456,7 +457,8 @@ func (p *Provider) releasePromoteGeneration1(a *structs.App, r *structs.Release)
 		return err
 	}
 
-	p.EventSend("release:promote", structs.EventSendOptions{Status: "start", Data: map[string]string{"app": a.Name, "id": r.Id}})
+	releaseStatus := "start"
+	p.EventSend("release:promote", structs.EventSendOptions{Status: &releaseStatus, Data: map[string]string{"app": a.Name, "id": r.Id}})
 	go p.waitForPromotion(r)
 
 	return nil

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -304,6 +304,7 @@ func (p *Provider) ReleasePromote(app, id string) error {
 		return err
 	}
 
+	p.EventSend("release:promote", structs.EventSendOptions{Status: "start", Data: map[string]string{"app": a.Name, "id": r.Id}})
 	go p.waitForPromotion(r)
 
 	return nil
@@ -455,6 +456,7 @@ func (p *Provider) releasePromoteGeneration1(a *structs.App, r *structs.Release)
 		return err
 	}
 
+	p.EventSend("release:promote", structs.EventSendOptions{Status: "start", Data: map[string]string{"app": a.Name, "id": r.Id}})
 	go p.waitForPromotion(r)
 
 	return nil


### PR DESCRIPTION
These were lost in The Great API Refactor of July 2018 https://github.com/convox/rack/pull/2739/files#diff-3e88de698e2d214b3e9a3822fbb7059fL88

We were using these in our build pipeline to help notify of us of the status of our Convox builds, so it'd be great to have them back