### PR TITLE
build speed optimization

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -414,7 +414,7 @@
     "BuildVolumeSize": {
       "Type": "Number",
       "Description": "Default build disk size in GB",
-      "Default": "200"
+      "Default": "100"
     },
     "ClientId": {
       "Type": "String",
@@ -1136,7 +1136,7 @@
             "Ebs": {
               "Encrypted": { "Fn::If": [ "EncryptEbs", "true", { "Ref": "AWS::NoValue" } ] },
               "VolumeSize": { "Ref": "BuildVolumeSize" },
-              "VolumeType":"gp2"
+              "VolumeType": "gp2"
             }
           }
         ],
@@ -1184,9 +1184,16 @@
             "  - mv /etc/sysconfig/docker-tmp /etc/sysconfig/docker\n",
             "  - echo 'OPTIONS=\"--default-ulimit nofile=1024000:1024000\"' >> /etc/sysconfig/docker\n",
             { "Fn::Join": [ "", [
-              "  - echo 'OPTIONS=\"${OPTIONS} --storage-opt dm.basesize=", { "Ref": "ContainerDisk" }, "G\"' >> /etc/sysconfig/docker\n",
               "  - echo 'OPTIONS=\"${OPTIONS} --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker\n",
-              "  - echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"}' >> /etc/ecs/ecs.config\n"
+              "  - echo 'DOCKER_STORAGE_OPTIONS=\"--storage-driver=overlay2\"' > /etc/sysconfig/docker-storage\n",
+              "  - echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"}' >> /etc/ecs/ecs.config\n",
+              "  - dmsetup remove_all\n",
+              "  - vgremove --force docker\n",
+              "  - mkfs -t ext4 -L docker -i 4096 -F /dev/xvdcz\n",
+              "  - rm -rf /var/lib/docker/*\n",
+              "  - mkdir -p /var/lib/docker/overlay2\n",
+              "  - mount /dev/xvdcz /var/lib/docker/overlay2\n",
+              "  - rm -rf /var/lib/ecs/data/* /var/cache/ecs/*\n"
             ] ] },
             "  - echo 'docker image prune -a --filter=\"until=96h\" --force' > /etc/cron.daily/docker-prune\n",
             "  - chmod +x /etc/cron.daily/docker-prune\n",


### PR DESCRIPTION
Switches to the Docker overlay2 driver for dedicated build instances.

Thanks to @ndbroadbent for most of the heavy lifting here.

Benchmarks building [convox-examples/rails](https://github.com/convox-examples/rails):

### Before

| BuildInstance | Run 1 | Run 2 | Run 3 |
|---------------|-------|-------|-------|
| t2.small      | 4:17  | 3:03  | 2:59  |
| t3.small      | 3:07  | 2:44  | 2:40  |
| c5.xlarge     | 3:44  | 2:53  | 2:51  |
| c5.2xlarge    | 4:00  | 3:07  | 3:05  |

### After


| BuildInstance | Run 1 | Run 2 | Run 3 |
|---------------|-------|-------|-------|
| t2.small      | 2:33  | 1:44  | 1:39  |
| t3.small      | 2:40  | 1:40  | 1:47  |
| c5.large      | 1:48  | 1:30  | 1:27  |
| c5.2xlarge    | 1:21  | 1:22  | 1:20  |