### PR TITLE
[RELEASE] 20181010

### DIFF
--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/convox/rack/pkg/helpers"
+	"github.com/convox/rack/pkg/options"
 	"github.com/convox/rack/pkg/structs"
 	"github.com/convox/rack/sdk"
 	"github.com/convox/stdcli"
@@ -67,7 +68,7 @@ func Build(rack sdk.Interface, c *stdcli.Context) error {
 		c.Writer().Stdout = c.Writer().Stderr
 	}
 
-	b, err := build(rack, c)
+	b, err := build(rack, c, false)
 	if err != nil {
 		return err
 	}
@@ -82,8 +83,12 @@ func Build(rack sdk.Interface, c *stdcli.Context) error {
 	return nil
 }
 
-func build(rack sdk.Interface, c *stdcli.Context) (*structs.Build, error) {
+func build(rack sdk.Interface, c *stdcli.Context, development bool) (*structs.Build, error) {
 	var opts structs.BuildCreateOptions
+
+	if development {
+		opts.Development = options.Bool(true)
+	}
 
 	if err := c.Options(&opts); err != nil {
 		return nil, err

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -31,13 +31,14 @@ func New(name, version string) *Engine {
 	}
 
 	e.Writer.Tags["app"] = stdcli.RenderColors(39)
+	e.Writer.Tags["command"] = stdcli.RenderColors(244)
 	e.Writer.Tags["dir"] = stdcli.RenderColors(246)
 	e.Writer.Tags["build"] = stdcli.RenderColors(23)
 	e.Writer.Tags["fail"] = stdcli.RenderColors(160)
 	e.Writer.Tags["rack"] = stdcli.RenderColors(26)
 	e.Writer.Tags["process"] = stdcli.RenderColors(27)
 	e.Writer.Tags["release"] = stdcli.RenderColors(24)
-	e.Writer.Tags["service"] = stdcli.RenderColors(25)
+	e.Writer.Tags["service"] = stdcli.RenderColors(33)
 	e.Writer.Tags["setting"] = stdcli.RenderColors(246)
 	e.Writer.Tags["system"] = stdcli.RenderColors(15)
 

--- a/pkg/cli/deploy.go
+++ b/pkg/cli/deploy.go
@@ -25,7 +25,7 @@ func Deploy(rack sdk.Interface, c *stdcli.Context) error {
 		c.Writer().Stdout = c.Writer().Stderr
 	}
 
-	b, err := build(rack, c)
+	b, err := build(rack, c, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/fixtures_test.go
+++ b/pkg/cli/fixtures_test.go
@@ -166,7 +166,7 @@ func fxRelease() *structs.Release {
 		App:         "app1",
 		Build:       "build1",
 		Env:         "FOO=bar\nBAZ=quux",
-		Manifest:    "services:\n  web:\n    build: .",
+		Manifest:    "services:\n  web:\n    build: .\n    test: make test",
 		Created:     time.Now().UTC().Add(-49 * time.Hour),
 		Description: "description1",
 	}

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/convox/rack/pkg/helpers"
+	"github.com/convox/rack/pkg/options"
+	"github.com/convox/rack/pkg/structs"
+	"github.com/convox/rack/sdk"
+	"github.com/convox/stdcli"
+)
+
+func init() {
+	register("test", "run tests", Test, stdcli.CommandOptions{
+		Flags: []stdcli.Flag{
+			flagApp,
+			flagRack,
+			stdcli.StringFlag("release", "", "use existing release to run tests"),
+			stdcli.IntFlag("timeout", "t", "timeout"),
+		},
+		Usage:    "[dir]",
+		Validate: stdcli.ArgsMax(1),
+	})
+}
+
+func Test(rack sdk.Interface, c *stdcli.Context) error {
+	release := c.String("release")
+
+	if release == "" {
+		b, err := build(rack, c, true)
+		if err != nil {
+			return err
+		}
+
+		release = b.Release
+	}
+
+	m, _, err := helpers.ReleaseManifest(rack, app(c), release)
+	if err != nil {
+		return err
+	}
+
+	timeout := 3600
+
+	if t := c.Int("timeout"); t > 0 {
+		timeout = t
+	}
+
+	for _, s := range m.Services {
+		if s.Test == "" {
+			continue
+		}
+
+		c.Writef("Running <command>%s</command> on <service>%s</service>\n", s.Test, s.Name)
+
+		ropts := structs.ProcessRunOptions{
+			Command: options.String(fmt.Sprintf("sleep %d", timeout)),
+			Release: options.String(release),
+		}
+
+		ps, err := rack.ProcessRun(app(c), s.Name, ropts)
+		if err != nil {
+			return err
+		}
+
+		defer rack.ProcessStop(app(c), ps.Id)
+
+		if err := waitForProcessRunning(rack, c, app(c), ps.Id); err != nil {
+			return err
+		}
+
+		eopts := structs.ProcessExecOptions{
+			Entrypoint: options.Bool(true),
+		}
+
+		if w, h, err := c.TerminalSize(); err == nil {
+			eopts.Height = options.Int(h)
+			eopts.Width = options.Int(w)
+		}
+
+		if !stdcli.IsTerminal(os.Stdin) {
+			eopts.Tty = options.Bool(false)
+		}
+
+		code, err := rack.ProcessExec(app(c), ps.Id, s.Test, c, eopts)
+		if err != nil {
+			return err
+		}
+
+		if code != 0 {
+			return fmt.Errorf("exit %d", code)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cli/test_test.go
+++ b/pkg/cli/test_test.go
@@ -1,0 +1,93 @@
+package cli_test
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/convox/rack/pkg/cli"
+	mocksdk "github.com/convox/rack/pkg/mock/sdk"
+	"github.com/convox/rack/pkg/options"
+	"github.com/convox/rack/pkg/structs"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTest(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
+			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
+		})
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Development: options.Bool(true)}).Return(fxBuild(), nil)
+		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
+		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Twice()
+		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
+		i.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{Command: options.String("sleep 7200"), Release: options.String("release1")}).Return(fxProcess(), nil)
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcessPending(), nil).Twice()
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
+		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
+		i.On("ProcessExec", "app1", "pid1", "make test", mock.Anything, opts).Return(0, nil).Run(func(args mock.Arguments) {
+			data, err := ioutil.ReadAll(args.Get(3).(io.Reader))
+			require.NoError(t, err)
+			require.Equal(t, "in", string(data))
+			args.Get(3).(io.Writer).Write([]byte("out"))
+		})
+		i.On("ProcessStop", "app1", "pid1").Return(nil)
+
+		res, err := testExecute(e, "test ./testdata/httpd -a app1 -t 7200", strings.NewReader("in"))
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			"Packaging source... OK",
+			"Uploading source... OK",
+			"Starting build... OK",
+			"log1",
+			"log2",
+			"Running make test on web",
+			"out",
+		})
+	})
+}
+
+func TestTestFail(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
+			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
+		})
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Development: options.Bool(true)}).Return(fxBuild(), nil)
+		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
+		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Twice()
+		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
+		i.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{Command: options.String("sleep 7200"), Release: options.String("release1")}).Return(fxProcess(), nil)
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcessPending(), nil).Twice()
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
+		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
+		i.On("ProcessExec", "app1", "pid1", "make test", mock.Anything, opts).Return(4, nil).Run(func(args mock.Arguments) {
+			data, err := ioutil.ReadAll(args.Get(3).(io.Reader))
+			require.NoError(t, err)
+			require.Equal(t, "in", string(data))
+			args.Get(3).(io.Writer).Write([]byte("out"))
+		})
+		i.On("ProcessStop", "app1", "pid1").Return(nil)
+
+		res, err := testExecute(e, "test ./testdata/httpd -a app1 -t 7200", strings.NewReader("in"))
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		res.RequireStderr(t, []string{"ERROR: exit 4"})
+		res.RequireStdout(t, []string{
+			"Packaging source... OK",
+			"Uploading source... OK",
+			"Starting build... OK",
+			"log1",
+			"log2",
+			"Running make test on web",
+			"out",
+		})
+	})
+}

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -1,7 +1,8 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Conditions": {
-    "BlankIops": { "Fn::Equals": [ { "Ref": "Iops" }, "0" ] }
+    "BlankIops": { "Fn::Equals": [ { "Ref": "Iops" }, "0" ] },
+    "Version9": { "Fn::Equals": [ { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }, "9" ] }
   },
   "Parameters": {
     "Class": {
@@ -86,10 +87,13 @@
       "Properties": {
         "Description": { "Fn::Sub": "${AWS::StackName} parameters" },
         "Family": { "Fn::Sub": [ "postgres${Base}", {
-          "Base": { "Fn::Join": [ ".", [
-            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
-            { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
-          ] ] }
+          "Base": { "Fn::If": [ "Version9",
+            { "Fn::Join": [ ".", [
+              { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
+              { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+            ] ] },
+            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+          ] }
         } ] }
       }
     }

--- a/provider/local/process_unix.go
+++ b/provider/local/process_unix.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/convox/rack/pkg/helpers"
 	"github.com/convox/rack/pkg/structs"
@@ -43,6 +44,11 @@ func (p *Provider) processExec(app, pid, command string, rw io.ReadWriter, opts 
 	go helpers.Pipe(fd, rw)
 
 	if err := cmd.Wait(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			if ws, ok := ee.Sys().(syscall.WaitStatus); ok {
+				return ws.ExitStatus(), nil
+			}
+		}
 		return 0, errors.WithStack(log.Error(err))
 	}
 

--- a/provider/local/system_linux.go
+++ b/provider/local/system_linux.go
@@ -26,7 +26,7 @@ After=network.target
 [Service]
 Type=simple
 Environment='PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"'
-ExecStart={{ .Command }} {{ range .Args }}{{ . }} {{ end }}
+ExecStart={{ .Command }} {{ range .Args }}"{{ . }}" {{ end }}
 KillMode=control-group
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
## Pull Requests
  - closes #2974 escape command args in systemd [@ddollar]
  - closes #2976 add `convox test` for testing apps on a rack [@ddollar]
  - closes #2977 use correct postgres 10 parameter group format [@ddollar]

## Milestone Release
- [ ] Release branch
- [ ] Pass CI
- [ ] Merge into master
- [ ] Close milestone
- [ ] Release master
- [ ] Record release number: 
- [ ] Pass CI
- [ ] Update staging
- [ ] Deploy staging/console-staging
- [ ] Deploy staging/httpd
- [ ] Deploy staging/site-staging
- [ ] Write [release notes](https://github.com/convox/rack/releases)
- [ ] Documentation review
- [ ] Publish release
- [ ] Update Homebrew
