### PR TITLE
fix typo in redis resource options help docs

### DIFF
--- a/provider/aws/templates/resource/redis.tmpl
+++ b/provider/aws/templates/resource/redis.tmpl
@@ -9,7 +9,7 @@
       "AutomaticFailoverEnabled": {
         "Type": "String",
         "Default": "false",
-        "Description": "Indicates whether Multi-AZ is enabled. Must be accompanied with InstanceType=cache.m3.medium or higher and NumCacheCluster=2 or higher."
+        "Description": "Indicates whether Multi-AZ is enabled. Must be accompanied with InstanceType=cache.m3.medium or higher and NumCacheClusters=2 or higher."
       },
       "Database": {
         "Type" : "String",


### PR DESCRIPTION
`NumCacheCluster` -> `NumCacheClusters`