### PR TITLE
lock and unlock apps for termination protection

### DIFF
--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -234,7 +234,7 @@ func TestAppsExport(t *testing.T) {
 
 		data, err := ioutil.ReadFile(filepath.Join(tmp, "app.json"))
 		require.NoError(t, err)
-		require.Equal(t, "{\"generation\":\"2\",\"name\":\"app1\",\"release\":\"release1\",\"sleep\":false,\"status\":\"running\",\"parameters\":{\"ParamFoo\":\"value1\",\"ParamOther\":\"value2\"}}", string(data))
+		require.Equal(t, "{\"generation\":\"2\",\"locked\":false,\"name\":\"app1\",\"release\":\"release1\",\"sleep\":false,\"status\":\"running\",\"parameters\":{\"ParamFoo\":\"value1\",\"ParamOther\":\"value2\"}}", string(data))
 
 		data, err = ioutil.ReadFile(filepath.Join(tmp, "env"))
 		require.NoError(t, err)
@@ -368,10 +368,11 @@ func TestAppsInfo(t *testing.T) {
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{
-			"Name     app1",
-			"Status   running",
-			"Gen      2",
-			"Release  release1",
+			"Name        app1",
+			"Status      running",
+			"Generation  2",
+			"Locked      false",
+			"Release     release1",
 		})
 
 		res, err = testExecute(e, "apps info -a app1", nil)
@@ -379,10 +380,11 @@ func TestAppsInfo(t *testing.T) {
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{
-			"Name     app1",
-			"Status   running",
-			"Gen      2",
-			"Release  release1",
+			"Name        app1",
+			"Status      running",
+			"Generation  2",
+			"Locked      false",
+			"Release     release1",
 		})
 	})
 }

--- a/pkg/structs/app.go
+++ b/pkg/structs/app.go
@@ -2,6 +2,7 @@ package structs
 
 type App struct {
 	Generation string `json:"generation,omitempty"`
+	Locked     bool   `json:"locked"`
 	Name       string `json:"name"`
 	Release    string `json:"release"`
 	Sleep      bool   `json:"sleep"`
@@ -19,6 +20,7 @@ type AppCreateOptions struct {
 }
 
 type AppUpdateOptions struct {
+	Lock       *bool             `param:"lock"`
 	Parameters map[string]string `param:"parameters"`
 	Sleep      *bool             `param:"sleep"`
 }

--- a/provider/local/app.go
+++ b/provider/local/app.go
@@ -188,6 +188,10 @@ func (p *Provider) AppRegistry(app string) (*structs.Registry, error) {
 func (p *Provider) AppUpdate(app string, opts structs.AppUpdateOptions) error {
 	log := p.logger("AppUpdate").Append("app=%q", app)
 
+	if opts.Lock != nil {
+		return fmt.Errorf("locking not supported on local racks")
+	}
+
 	if opts.Sleep != nil {
 		a, err := p.AppGet(app)
 		if err != nil {


### PR DESCRIPTION
Use `convox apps lock <app>` to enable termination protection on an application and its services/resources.