### PR TITLE
enable system volume for ecs-optimized amazon linux 2.

### DIFF
--- a/provider/aws/template.go
+++ b/provider/aws/template.go
@@ -112,6 +112,8 @@ func formationHelpers() template.FuncMap {
 			switch v := parts[0]; v {
 			case "/cgroup/":
 				return v
+			case "/sys/fs/cgroup/":
+				return v
 			case "/proc/":
 				return v
 			case "/var/run/docker.sock":


### PR DESCRIPTION
Support Amazon Linux 2 cgroup volume for datadog agent.