### PR TITLE
fall back to rack log group for stack logs

### DIFF
--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -785,7 +785,7 @@ func (p *Provider) stackResource(stack, resource string) (*cloudformation.StackR
 		}
 	}
 
-	return nil, log.Error(fmt.Errorf("resource not found: %s", resource))
+	return nil, fmt.Errorf("resource not found: %s", resource)
 }
 
 func (p *Provider) appResources(app string) (map[string]string, error) {

--- a/provider/aws/resource.go
+++ b/provider/aws/resource.go
@@ -495,9 +495,10 @@ func (p *Provider) createResource(s *structs.Resource) (*cloudformation.CreateSt
 	}
 
 	req := &cloudformation.CreateStackInput{
-		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
-		StackName:    aws.String(fmt.Sprintf("%s-%s", p.Rack, s.Name)),
-		TemplateBody: aws.String(formation),
+		Capabilities:     []*string{aws.String("CAPABILITY_IAM")},
+		NotificationARNs: []*string{aws.String(p.CloudformationTopic)},
+		StackName:        aws.String(fmt.Sprintf("%s-%s", p.Rack, s.Name)),
+		TemplateBody:     aws.String(formation),
 	}
 
 	return req, nil


### PR DESCRIPTION
Will allow rack-level resources to have their CloudFormation events logged to the rack logs.