### PR TITLE
[RELEASE] 20181115

### DIFF
--- a/pkg/cli/resources.go
+++ b/pkg/cli/resources.go
@@ -53,7 +53,7 @@ func init() {
 		Validate: stdcli.Args(1),
 	})
 
-	register("resources proxy", "get information about a resource", ResourcesProxy, stdcli.CommandOptions{
+	register("resources proxy", "proxy a local port to a rack resource", ResourcesProxy, stdcli.CommandOptions{
 		Flags: []stdcli.Flag{
 			flagRack,
 			stdcli.IntFlag("port", "p", "local port"),

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -223,6 +223,10 @@ func (m *Manifest) ApplyDefaults() error {
 			m.Services[i].Build.Manifest = "Dockerfile"
 		}
 
+		if s.Drain == 0 {
+			m.Services[i].Drain = 30
+		}
+
 		if s.Health.Path == "" {
 			m.Services[i].Health.Path = "/"
 		}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -31,8 +31,9 @@ func TestManifestLoad(t *testing.T) {
 					Manifest: "Dockerfile2",
 					Path:     "api",
 				},
-				Domains: []string{"foo.example.org"},
 				Command: "",
+				Domains: []string{"foo.example.org"},
+				Drain:   30,
 				Environment: []string{
 					"DEFAULT=test",
 					"DEVELOPMENT=false",
@@ -59,6 +60,7 @@ func TestManifestLoad(t *testing.T) {
 				Name:    "proxy",
 				Command: "bash",
 				Domains: []string{"bar.example.org", "*.example.org"},
+				Drain:   30,
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Path:     "/auth",
@@ -85,6 +87,7 @@ func TestManifestLoad(t *testing.T) {
 				},
 				Command: "foo",
 				Domains: []string{"baz.example.org", "qux.example.org"},
+				Drain:   60,
 				Health: manifest.ServiceHealth{
 					Grace:    2,
 					Interval: 5,
@@ -107,6 +110,7 @@ func TestManifestLoad(t *testing.T) {
 					Path:     ".",
 				},
 				Command: "",
+				Drain:   30,
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Interval: 5,
@@ -127,6 +131,7 @@ func TestManifestLoad(t *testing.T) {
 					Path:     ".",
 				},
 				Command: "",
+				Drain:   30,
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Interval: 5,
@@ -158,6 +163,7 @@ func TestManifestLoad(t *testing.T) {
 				Name:    "inherit",
 				Command: "inherit",
 				Domains: []string{"bar.example.org", "*.example.org"},
+				Drain:   30,
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Path:     "/auth",
@@ -190,6 +196,7 @@ func TestManifestLoad(t *testing.T) {
 					Manifest: "Dockerfile",
 					Path:     ".",
 				},
+				Drain: 30,
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Path:     "/",
@@ -234,6 +241,7 @@ func TestManifestLoad(t *testing.T) {
 		"services.foo",
 		"services.foo.command",
 		"services.foo.domain",
+		"services.foo.drain",
 		"services.foo.health",
 		"services.foo.health.grace",
 		"services.foo.health.timeout",
@@ -317,6 +325,7 @@ func TestManifestLoadSimple(t *testing.T) {
 					Manifest: "Dockerfile",
 					Path:     ".",
 				},
+				Drain: 30,
 				Environment: manifest.Environment{
 					"REQUIRED",
 					"DEFAULT=true",

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -14,6 +14,7 @@ type Service struct {
 	Build       ServiceBuild   `yaml:"build,omitempty"`
 	Command     string         `yaml:"command,omitempty"`
 	Domains     ServiceDomains `yaml:"domain,omitempty"`
+	Drain       int            `yaml:"drain,omitempty"`
 	Environment Environment    `yaml:"environment,omitempty"`
 	Health      ServiceHealth  `yaml:"health,omitempty"`
 	Image       string         `yaml:"image,omitempty"`

--- a/pkg/manifest/testdata/full.yml
+++ b/pkg/manifest/testdata/full.yml
@@ -41,6 +41,7 @@ services:
   foo:
     command: foo
     domain: baz.example.org, qux.example.org
+    drain: 60
     health:
       grace: 2
       timeout: 3

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -157,7 +157,7 @@
             "Protocol": "{{ upcase .Port.Scheme }}",
             "TargetGroupAttributes": [
               { "Key": "stickiness.enabled", "Value": "{{.Sticky}}" },
-              { "Key": "deregistration_delay.timeout_seconds", "Value": "30" }
+              { "Key": "deregistration_delay.timeout_seconds", "Value": "{{.Drain}}" }
             ],
             "Tags": [
               { "Key": "App", "Value": "{{$.App}}" },

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -785,7 +785,7 @@ func (p *Provider) stackResource(stack, resource string) (*cloudformation.StackR
 		}
 	}
 
-	return nil, log.Error(fmt.Errorf("resource not found: %s", resource))
+	return nil, fmt.Errorf("resource not found: %s", resource)
 }
 
 func (p *Provider) appResources(app string) (map[string]string, error) {

--- a/provider/aws/resource.go
+++ b/provider/aws/resource.go
@@ -495,9 +495,10 @@ func (p *Provider) createResource(s *structs.Resource) (*cloudformation.CreateSt
 	}
 
 	req := &cloudformation.CreateStackInput{
-		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
-		StackName:    aws.String(fmt.Sprintf("%s-%s", p.Rack, s.Name)),
-		TemplateBody: aws.String(formation),
+		Capabilities:     []*string{aws.String("CAPABILITY_IAM")},
+		NotificationARNs: []*string{aws.String(p.CloudformationTopic)},
+		StackName:        aws.String(fmt.Sprintf("%s-%s", p.Rack, s.Name)),
+		TemplateBody:     aws.String(formation),
 	}
 
 	return req, nil

--- a/provider/aws/template.go
+++ b/provider/aws/template.go
@@ -112,6 +112,8 @@ func formationHelpers() template.FuncMap {
 			switch v := parts[0]; v {
 			case "/cgroup/":
 				return v
+			case "/sys/fs/cgroup/":
+				return v
 			case "/proc/":
 				return v
 			case "/var/run/docker.sock":


### PR DESCRIPTION
## Pull Requests
  - closes #3018 fix cli help for resources proxy [@ddollar]
  - closes #3019 enable system volume for ecs-optimized amazon linux 2. [@ffjia]
  - closes #3020 fall back to rack log group for stack logs [@ddollar]
  - closes #3021 make draining timeout configurable for gen2 [@ddollar]

## Milestone Release
- [ ] Release branch
- [ ] Pass CI
- [ ] Merge into master
- [ ] Close milestone
- [ ] Release master
- [ ] Record release number: 
- [ ] Pass CI
- [ ] Update staging
- [ ] Deploy staging/console-staging
- [ ] Deploy staging/httpd
- [ ] Deploy staging/site-staging
- [ ] Write [release notes](https://github.com/convox/rack/releases)
- [ ] Documentation review
- [ ] Publish release
- [ ] Update Homebrew
