### PR TITLE
dedup release envs on k8

### DIFF
--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -175,6 +175,15 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 
 		replicas := helpers.CoalesceInt(sc[s.Name], s.Scale.Count.Min)
 
+		envs := []map[string]string{senv, s.EnvironmentDefaults(), e}
+
+		renv := map[string]string{}
+		for _, me := range envs {
+			for k, v := range me {
+			    renv[k] = v
+			}
+		}
+
 		params := map[string]interface{}{
 			"App":            a,
 			"Build":          b,
@@ -190,6 +199,7 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 			"Replicas":       replicas,
 			"Service":        s,
 			"SystemEnv":      senv,
+			"ReleaseEnv":     renv,
 		}
 
 		data, err := p.RenderTemplate("service", params)

--- a/provider/k8s/template/service.yml.tmpl
+++ b/provider/k8s/template/service.yml.tmpl
@@ -83,7 +83,7 @@ spec:
         {{ end }}
         {{ end }}
         env:
-        {{ range env .SystemEnv .Service.EnvironmentDefaults .Env }}
+        {{ range env .ServiceEnv }}
         - name: {{ safe .Key }}
           value: {{ safe .Value }}
         {{ end }}


### PR DESCRIPTION
Fix the following issue:

```
[22:50:53] i:maurycy:~/src/rack> docker build -t convox/rack:dev . && convox start -a aws
...
for: "STDIN": The order in patch list:
[map[name:RACK value:test] map[name:RACK value:test1] map[value:RXPOXOKBDS name:RELEASE] map[name:BUILD value:BRWLYQWQJLA] map[value: name:BUILD_DESCRIPTION] map[value: name:PASSWORD]]
 doesn't match $setElementOrder list:
[map[name:APP] map[name:RACK] map[name:RACK_URL] map[name:RELEASE] map[name:BUILD] map[name:BUILD_DESCRIPTION] map[name:AWS_ACCESS_KEY_ID] map[name:AWS_REGION] map[name:AWS_SECRET_ACCESS_KEY] map[name:DEVELOPMENT] map[name:IMAGE] map[name:PASSWORD] map[name:PROVIDER] map[name:RACK] map[name:STORAGE] map[name:VERSION]]
[22:51:25] i:maurycy:~/src/rack> convox env -a aws
AWS_ACCESS_KEY_ID=xoxo
AWS_REGION=eu-west-1
AWS_SECRET_ACCESS_KEY=xoxo
PROVIDER=aws
RACK=test1
[23:24:37] i:maurycy:~/src/rack> git rev-parse HEAD
8ec0d8b76912bd28166b851e42b18c3ea9746b14
```