### PR TITLE
Update Postgres template parameters

### DIFF
--- a/provider/aws/formation/resource/mysql.json.tmpl
+++ b/provider/aws/formation/resource/mysql.json.tmpl
@@ -8,6 +8,10 @@
       "Type": "String",
       "Default": "db.t2.micro"
     },
+    "Database": {
+      "Type": "String",
+      "Default": "app"
+    },
     "Durable": {
       "Type": "String",
       "Default": "false",
@@ -35,13 +39,17 @@
       "Type": "Number",
       "Default": "20"
     },
+    "Username": {
+      "Type": "String",
+      "Default": "app"
+    },
     "Version": {
       "Type": "String",
       "Default": "5.7"
     }
   },
   "Outputs": {
-    "Url": { "Value": { "Fn::Sub": "mysql://app:${Password}@${Instance.Endpoint.Address}:${Instance.Endpoint.Port}/app" } }
+    "Url": { "Value": { "Fn::Sub": "mysql://${Username}:${Password}@${Instance.Endpoint.Address}:${Instance.Endpoint.Port}/${Database}" } }
   },
   "Resources": {
     "SecurityGroup": {
@@ -69,15 +77,16 @@
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "AllocatedStorage": { "Ref": "Storage" },
+        "BackupRetentionPeriod": "30",
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
-        "DBName": "app",
+        "DBName": { "Ref": "Database" },
         "DBParameterGroupName": { "Ref": "ParameterGroup" },
         "DBSubnetGroupName": { "Ref": "SubnetGroup" },
         "Engine": "mysql",
         "EngineVersion": { "Ref": "Version" },
         "Iops": { "Fn::If": [ "BlankIops", { "Ref": "AWS::NoValue" }, { "Ref": "Iops" } ] },
-        "MasterUsername": "app",
+        "MasterUsername": { "Ref": "Username" },
         "MasterUserPassword": { "Ref": "Password" },
         "MultiAZ": { "Ref": "Durable" },
         "Port": "3306",

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -5,10 +5,6 @@
     "Version9": { "Fn::Equals": [ { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }, "9" ] }
   },
   "Parameters": {
-    "BackupRetentionPeriod": {
-      "Type": "String",
-      "Default": "1"
-    },
     "Class": {
       "Type": "String",
       "Default": "db.t2.micro"
@@ -82,7 +78,7 @@
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "AllocatedStorage": { "Ref": "Storage" },
-        "BackupRetentionPeriod": { "Ref": "BackupRetentionPeriod" }
+        "BackupRetentionPeriod": "30"
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
         "DBName": { "Ref": "Database" },

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -40,7 +40,7 @@
       "Type": "Number",
       "Default": "20"
     },
-    "MasterUsername": {
+    "Username": {
       "Type": "String",
       "Default": "app"
     }
@@ -87,7 +87,7 @@
         "Engine": "postgres",
         "EngineVersion": { "Ref": "Version" },
         "Iops": { "Fn::If": [ "BlankIops", { "Ref": "AWS::NoValue" }, { "Ref": "Iops" } ] },
-        "MasterUsername": { "Ref": "MasterUsername" },
+        "MasterUsername": { "Ref": "Username" },
         "MasterUserPassword": { "Ref": "Password" },
         "MultiAZ": { "Ref": "Durable" },
         "Port": "5432",

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -44,6 +44,10 @@
       "Type": "Number",
       "Default": "20"
     },
+    "MasterUsername": {
+      "Type": "String",
+      "Default": "app"
+    }
     "Version": {
       "Type": "String",
       "Default": "9.6"
@@ -87,7 +91,7 @@
         "Engine": "postgres",
         "EngineVersion": { "Ref": "Version" },
         "Iops": { "Fn::If": [ "BlankIops", { "Ref": "AWS::NoValue" }, { "Ref": "Iops" } ] },
-        "MasterUsername": "app",
+        "MasterUsername": { "Ref": "MasterUsername" },
         "MasterUserPassword": { "Ref": "Password" },
         "MultiAZ": { "Ref": "Durable" },
         "Port": "5432",

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -50,7 +50,7 @@
     }
   },
   "Outputs": {
-    "Url": { "Value": { "Fn::Sub": "postgres://app:${Password}@${Instance.Endpoint.Address}:${Instance.Endpoint.Port}/${Database}" } }
+    "Url": { "Value": { "Fn::Sub": "postgres://${Username}:${Password}@${Instance.Endpoint.Address}:${Instance.Endpoint.Port}/${Database}" } }
   },
   "Resources": {
     "SecurityGroup": {
@@ -78,7 +78,7 @@
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "AllocatedStorage": { "Ref": "Storage" },
-        "BackupRetentionPeriod": "30"
+        "BackupRetentionPeriod": "30",
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
         "DBName": { "Ref": "Database" },

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -5,9 +5,17 @@
     "Version9": { "Fn::Equals": [ { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }, "9" ] }
   },
   "Parameters": {
+    "BackupRetentionPeriod": {
+      "Type": "String",
+      "Default": "1"
+    },
     "Class": {
       "Type": "String",
       "Default": "db.t2.micro"
+    },
+    "Database": {
+      "Type": "String",
+      "Default": "app"
     },
     "Durable": {
       "Type": "String",
@@ -42,7 +50,7 @@
     }
   },
   "Outputs": {
-    "Url": { "Value": { "Fn::Sub": "postgres://app:${Password}@${Instance.Endpoint.Address}:${Instance.Endpoint.Port}/app" } }
+    "Url": { "Value": { "Fn::Sub": "postgres://app:${Password}@${Instance.Endpoint.Address}:${Instance.Endpoint.Port}/${Database}" } }
   },
   "Resources": {
     "SecurityGroup": {
@@ -70,9 +78,10 @@
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "AllocatedStorage": { "Ref": "Storage" },
+        "BackupRetentionPeriod": { "Ref": "BackupRetentionPeriod" }
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
-        "DBName": "app",
+        "DBName": { "Ref": "Database" },
         "DBParameterGroupName": { "Ref": "ParameterGroup" },
         "DBSubnetGroupName": { "Ref": "SubnetGroup" },
         "Engine": "postgres",

--- a/provider/local/template/resource/mysql.yml.tmpl
+++ b/provider/local/template/resource/mysql.yml.tmpl
@@ -7,10 +7,12 @@ metadata:
     system: convox
     rack: {{.Rack}}
     app: {{.App}}
+    database: {{.Database}}
     type: resource
     resource: {{.Name}}
+    username: {{.Username}}
 data:
-  URL: "mysql://root:{{.Password}}@resource-{{.Name}}.{{.Namespace}}.svc.cluster.local:3306/app"
+  URL: "mysql://{{.Username}}:{{.Password}}@resource-{{.Name}}.{{.Namespace}}.svc.cluster.local:3306/{{.Database}}"
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -21,7 +23,9 @@ metadata:
     system: convox
     rack: {{.Rack}}
     app: {{.App}}
+    database: {{.Database}}
     resource: {{.Name}}
+    username: {{.Username}}
 spec:
   accessModes:
   - ReadWriteOnce
@@ -38,16 +42,20 @@ metadata:
     system: convox
     rack: {{.Rack}}
     app: {{.App}}
+    database: {{.Database}}
     type: resource
     kind: mysql
     resource: {{.Name}}
+    username: {{.Username}}
 spec:
   selector:
     matchLabels:
       system: convox
       rack: {{.Rack}}
       app: {{.App}}
+      database: {{.Database}}
       resource: {{.Name}}
+      username: {{.Username}}
   replicas: 1
   template:
     metadata:
@@ -55,8 +63,10 @@ spec:
         system: convox
         rack: {{.Rack}}
         app: {{.App}}
+        database: {{.Database}}
         type: resource
         resource: {{.Name}}
+        username: {{.Username}}
     spec:
       containers:
       - name: mysql
@@ -66,8 +76,12 @@ spec:
         - containerPort: 3306
         env:
         - name: MYSQL_DATABASE
-          value: app
+          value: "{{.Database}}"
         - name: MYSQL_ROOT_PASSWORD
+          value: "{{.Password}}"
+        - name: MYSQL_USER
+          value: "{{.Username}}"
+        - name: MYSQL_PASSWORD
           value: "{{.Password}}"
         volumeMounts:
         - mountPath: /var/lib/mysql
@@ -86,8 +100,10 @@ metadata:
     system: convox
     rack: {{.Rack}}
     app: {{.App}}
+    database: {{.Database}}
     type: resource
     resource: {{.Name}}
+    username: {{.Username}}
 spec:
   type: NodePort
   ports:
@@ -96,4 +112,6 @@ spec:
     system: convox
     rack: {{.Rack}}
     app: {{.App}}
+    database: {{.Database}}
     resource: {{.Name}}
+    username: {{.Username}}

--- a/provider/local/template/resource/postgres.yml.tmpl
+++ b/provider/local/template/resource/postgres.yml.tmpl
@@ -7,10 +7,12 @@ metadata:
     system: convox
     rack: {{.Rack}}
     app: {{.App}}
+    database: {{.Database}}
     type: resource
     resource: {{.Name}}
+    username: {{.Username}}
 data:
-  URL: "postgres://app:{{.Password}}@resource-{{.Name}}.{{.Namespace}}.svc.cluster.local:5432/app"
+  URL: "postgres://{{.Username}}:{{.Password}}@resource-{{.Name}}.{{.Namespace}}.svc.cluster.local:5432/{{.Database}}"
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -47,7 +49,9 @@ spec:
       system: convox
       rack: {{.Rack}}
       app: {{.App}}
+      database: {{.Database}}
       resource: {{.Name}}
+      username: {{.Username}}
   replicas: 1
   template:
     metadata:
@@ -55,8 +59,10 @@ spec:
         system: convox
         rack: {{.Rack}}
         app: {{.App}}
+        database: {{.Database}}
         type: resource
         resource: {{.Name}}
+        username: {{.Username}}
     spec:
       containers:
       - name: postgres
@@ -66,9 +72,9 @@ spec:
         - containerPort: 5432
         env:
         - name: POSTGRES_DB
-          value: app
+          value: "{{.Database}}"
         - name: POSTGRES_USER
-          value: app
+          value: "{{.Username}}"
         - name: POSTGRES_PASSWORD
           value: "{{.Password}}"
         volumeMounts:
@@ -88,8 +94,10 @@ metadata:
     system: convox
     rack: {{.Rack}}
     app: {{.App}}
+    database: {{.Database}}
     type: resource
     resource: {{.Name}}
+    username: {{.Username}}
 spec:
   type: NodePort
   ports:
@@ -98,4 +106,6 @@ spec:
     system: convox
     rack: {{.Rack}}
     app: {{.App}}
+    database: {{.Database}}
     resource: {{.Name}}
+    username: {{.Username}}


### PR DESCRIPTION
Previously we have been able to specify the database name and backup retention like here:
https://github.com/convox/rack/blob/6f95ee8c1e3a03642340ff0e8b42088253bbcd5f/provider/aws/templates/resource/postgres.tmpl#L16-L20

We wish to add the same ability to describe a postgres database via the `convox.yml`.

```
resources:
  event-db:
    type: postgres
    options:
      database: events
      class: db.t2.xlarge
      storage: 150
      durabilty: True
      version: 9.6.10
      backup_retention_period: "30"
      master_username: auser
```

## Change
* Add parameter `Database` that maps to `DBName`
* Add parameter `BackupRetentionPeriod`
* Add parameter `MasterUsername`

## Consideration
We map the `Database` to `DBName` because we did it that way in the previous template (linked above). So this naming was to be consistent with that.

Haven't been able to test this in a development environment so I hope this is all we need.