### PR TITLE
Update redis description - cache.t2 may now be clustered

### DIFF
--- a/provider/aws/templates/resource/redis.tmpl
+++ b/provider/aws/templates/resource/redis.tmpl
@@ -9,7 +9,7 @@
       "AutomaticFailoverEnabled": {
         "Type": "String",
         "Default": "false",
-        "Description": "Indicates whether Multi-AZ is enabled. Must be accompanied with InstanceType=cache.m3.medium or higher and NumCacheClusters=2 or higher."
+        "Description": "Indicates whether Multi-AZ is enabled. Must be accompanied with NumCacheClusters=2 or higher."
       },
       "Database": {
         "Type" : "String",


### PR DESCRIPTION
This updates the Redis description - t2 instances may now have auto-failover.

[Amazon ElastiCache for Redis adds auto-failover and backup/restore support for T2 nodes](https://aws.amazon.com/about-aws/whats-new/2018/11/amazon_elasticache_for_redis_adds_auto-failover_and_backup_restore_support_for_t2_nodes/
)
