### PR TITLE
reduce noise from healthchecks for convox start

### DIFF
--- a/pkg/start/gen2.go
+++ b/pkg/start/gen2.go
@@ -328,6 +328,9 @@ func (opts Options2) healthCheck(ctx context.Context, pw prefix.Writer, s manife
 		},
 	}
 
+	// previous status code
+	var ps int
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -338,13 +341,12 @@ func (opts Options2) healthCheck(ctx context.Context, pw prefix.Writer, s manife
 				pw.Writef("convox", "health check <service>%s</service>: <fail>%s</fail>\n", s.Name, err.Error())
 				continue
 			}
-
 			if res.StatusCode < 200 || res.StatusCode > 399 {
 				pw.Writef("convox", "health check <service>%s</service>: <fail>%d</fail>\n", s.Name, res.StatusCode)
-				continue
+			} else if res.StatusCode != ps {
+				pw.Writef("convox", "health check <service>%s</service>: <ok>%d</ok>\n", s.Name, res.StatusCode)
 			}
-
-			pw.Writef("convox", "health check <service>%s</service>: <ok>%d</ok>\n", s.Name, res.StatusCode)
+			ps = res.StatusCode
 		}
 	}
 }

--- a/pkg/start/testdata/httpd/convox3.yml
+++ b/pkg/start/testdata/httpd/convox3.yml
@@ -1,0 +1,6 @@
+services:
+  web:
+    build: .
+    port: 80
+    health:
+      interval: 1


### PR DESCRIPTION
a PR for #3013 

the test is pretty slow as the shortest healhcheck i could get running was with 1s interval and since i wanted to test the transition from and to ok status it takes a few attempts.

