### PR TITLE
include query string in websocket proxy

### DIFF
--- a/pkg/router/proxy.go
+++ b/pkg/router/proxy.go
@@ -206,7 +206,7 @@ func (p *Proxy) serveWebsocket(r *http.Request, target *url.URL) websocket.Handl
 			wst.Scheme = "ws"
 		}
 
-		wst.Path = r.URL.Path
+		wst.Path, wst.RawQuery = r.URL.Path, r.URL.RawQuery
 
 		h := r.Header
 


### PR DESCRIPTION
Phoenix passes `?vsn=2.0.0` to establish protocols in WebSocket connections.

According to the [standard](https://tools.ietf.org/id/draft-abarth-thewebsocketprotocol-00.html#rfc.section.3.1), WebSocket URLs include query parameters.