### PR TITLE
Don't use minor version in Postgres EngineVersion

### DIFF
--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -33,7 +33,7 @@
     },
     "Version": {
       "Type": "String",
-      "Default": "9.6.6"
+      "Default": "9.6"
     }
   },
   "Outputs": {

--- a/provider/aws/templates/resource/postgres.tmpl
+++ b/provider/aws/templates/resource/postgres.tmpl
@@ -41,7 +41,7 @@
       },
       "EngineVersion": {
         "Description": "Version of Postgres",
-        "Default": "9.6.3",
+        "Default": "9.6",
         "Type": "String"
       },
       "Family": {


### PR DESCRIPTION
Having a minor version that is not regularly updated could make systems open to vulnerabilities. People should immediately update a `9.6.3` instance. 

I would err on the side of auto-update unless there is a specific reason to pin to a version. Maybe this issue of automatic minor version updates can be highlighted in the docs so that people understand the risks? 

 * this will default to latest minor version
  * people may not be aware that this minor version requires immediate updating
  * people need to be aware that this can trigger automatic version updates
    * with single instances (not multi-az) this can cause unexpected outage

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-engineversion

> To prevent automatic upgrades, be sure to specify the full version number (for example, 5.6.13). If the default version for the database engine changes and you specify only the major version (for example, 5.6), your DB instance will be upgraded to use the latest default version. 