### PR TITLE
don't block on streaming build logs

### DIFF
--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -149,7 +149,9 @@ func build(rack sdk.Interface, c *stdcli.Context, development bool) (*structs.Bu
 		return nil, err
 	}
 
-	io.Copy(c, r)
+	go io.Copy(c, r)
+
+	time.Sleep(1 * time.Second)
 
 	for {
 		b, err = rack.BuildGet(app(c), b.Id)


### PR DESCRIPTION
As mentioned in [this Slack post](https://convox-public.slack.com/archives/C08HXR97Z/p1547328024404600), it looks like there's currently a regression with how the websocket connection to fetch build logs from console.convox.com doesn't terminate the connection once the streaming is finished. This results in the build successfully being created (and its status set to `completed`), but the locally running `convox build` never terminates because `io.Copy(c, r)` never completes. This break CI workflows by causing them to timeout because it seems like the build is taking too long, when in reality, it's just the `convox` CLI.

While this doesn't change anything regarding the websocket termination (since I believe that lives in a separate repo), this modifies the `convox build` command to decouple the streaming of the logs from the checking of the build status. The action that determines whether or not the build is complete isn't related to the streaming of the logs, so it shouldn't be dependent on it.

The `time.Sleep(1 * time.Second)` is necessary for builds that run very quickly (e.g. a 100% cached build) so the time it takes to establish the log stream is longer than the time it takes to mark the build as completed.

Open to other suggestions on how to structure this! This is fairly urgent for us since it's preventing our production CI deployments from completing successfully (since the `convox build` command takes too long).