### PR TITLE
Moving lambda to VPC when Rack is private

### DIFF
--- a/provider/aws/resource.go
+++ b/provider/aws/resource.go
@@ -174,6 +174,11 @@ func (p *Provider) SystemResourceCreate(kind string, opts structs.ResourceCreate
 	case "syslog":
 		req, err = p.createResourceURL(s, "tcp", "tcp+tls", "udp")
 	case "webhook":
+		s.Parameters["Rack"] = p.Rack
+		if p.Private {
+			s.Parameters["Private"] = "Yes" // Default is No
+		}
+
 		req, err = p.createResourceURL(s, "http", "https")
 	default:
 		err = fmt.Errorf("invalid resource type: %s", s.Type)

--- a/provider/aws/templates/resource/webhook.tmpl
+++ b/provider/aws/templates/resource/webhook.tmpl
@@ -5,10 +5,21 @@
     "NotificationTopic": {
       "Type": "String"
     },
+    "Private": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ]
+    },
+    "Rack": {
+      "Type": "String"
+    },
     "Url": {
       "Type": "String",
       "Description": "Webhook URL"
     }
+  },
+  "Conditions": {
+    "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] }
   },
   "Resources": {
     "Forwarder": {
@@ -31,7 +42,16 @@
         "Handler": "index.handler",
         "Role": { "Fn::GetAtt": [ "ForwarderRole", "Arn" ] },
         "Runtime": "nodejs6.10",
-        "Timeout": "10"
+        "Timeout": "10",
+        "VpcConfig": { "Fn::If": [ "Private", {
+            "SubnetIds": [
+              { "Fn::ImportValue": { "Fn::Sub": "${Rack}:SubnetPrivate0" } },
+              { "Fn::ImportValue": { "Fn::Sub": "${Rack}:SubnetPrivate1" } }
+            ],
+            "SecurityGroupIds": [ { "Fn::ImportValue": { "Fn::Sub": "${Rack}:InstancesSecurityGroup" } } ]
+          },
+          { "Ref": "AWS::NoValue" } ]
+        }
       }
     },
     "ForwarderPermission": {
@@ -50,7 +70,10 @@
           "Version": "2012-10-17",
           "Statement": [ { "Effect": "Allow", "Principal": { "Service": [ "lambda.amazonaws.com" ] }, "Action": "sts:AssumeRole" } ]
         },
-        "ManagedPolicyArns": [ "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole" ],
+        "ManagedPolicyArns": [
+            "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+            { "Fn::If": [ "Private", "arn:aws:iam::aws:policy/service-role/AWSLambdaENIManagementAccess", { "Ref": "AWS::NoValue" } ] }
+        ],
         "Path": "/convox/"
       }
     },


### PR DESCRIPTION
This is, I hope, first step to hide Enterprise Convox console.

Those changes allows webhooks resources to be sent from NAT IPs.
