### PR TITLE
No blocking http requests in router

### DIFF
--- a/pkg/router/http.go
+++ b/pkg/router/http.go
@@ -58,11 +58,11 @@ func (h *HTTP) Serve() error {
 
 func (h *HTTP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.Handler != nil {
-		h.Handler(w, r)
+		go h.Handler(w, r)
 		return
 	}
 
-	h.ServeRequest(w, r)
+	go h.ServeRequest(w, r)
 }
 
 func (h *HTTP) ServeRequest(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
While inspecting why the local k8s rack on gen2 is still unusable for us I might have a new theory.

It seems like when our next.js dev server is compiling, which sometimes can take up to a minute, it blocks the router. This in turn makes all the healthchecks fail in kubernetes which causes everything to restart and behave generally bad. Next request is the same as the cache is now cleared because of the restart etc...

Is it possible that this PR could fix it?