### PR TITLE
Bumps the node runtime used for creating crontabs in g1

### DIFF
--- a/provider/aws/formation/g1/app.json.tmpl
+++ b/provider/aws/formation/g1/app.json.tmpl
@@ -701,7 +701,7 @@
       "Properties": {
         "Handler": "index.handler",
         "Role": { "Fn::GetAtt": [ "CronRole", "Arn" ] },
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs8.10",
         "Timeout": 50,
         "Code": {
           "ZipFile": { "Fn::Join": ["\n", [


### PR DESCRIPTION
This avoids issues when AWS EOLs Node 6.10. I noticed [you recently updated g2](https://github.com/convox/rack/commit/71c5a1877f9c0718a8f4ab78bca9ea56b7fe2856) to 8.10, this should get us to parity for g1 apps. 