### PR TITLE
read parameters overrides from convox.yml

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -18,6 +18,7 @@ var (
 
 type Manifest struct {
 	Environment Environment `yaml:"environment,omitempty"`
+	Params      Params      `yaml:"params,omitempty"`
 	Resources   Resources   `yaml:"resources,omitempty"`
 	Services    Services    `yaml:"services,omitempty"`
 	Timers      Timers      `yaml:"timers,omitempty"`

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -15,6 +15,9 @@ func TestManifestLoad(t *testing.T) {
 			"GLOBAL=true",
 			"OTHERGLOBAL",
 		},
+		Params: manifest.Params{
+			"Foo": "bar",
+		},
 		Resources: manifest.Resources{
 			manifest.Resource{
 				Name: "database",
@@ -215,6 +218,8 @@ func TestManifestLoad(t *testing.T) {
 
 	attrs := []string{"services.proxy.environment",
 		"environment",
+		"params",
+		"params.Foo",
 		"resources",
 		"resources.database",
 		"resources.database.options",

--- a/pkg/manifest/params.go
+++ b/pkg/manifest/params.go
@@ -1,0 +1,3 @@
+package manifest
+
+type Params map[string]string

--- a/pkg/manifest/testdata/full.yml
+++ b/pkg/manifest/testdata/full.yml
@@ -2,6 +2,8 @@ environment:
   - DEVELOPMENT=true
   - GLOBAL=true
   - OTHERGLOBAL
+params:
+  Foo: bar
 resources:
   database:
     type: postgres

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -343,6 +343,12 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		"Private":   private,
 	}
 
+	if m.Params != nil {
+		for k, v := range m.Params {
+			updates[k] = v
+		}
+	}
+
 	tags := map[string]string{
 		"Version": p.Version,
 	}


### PR DESCRIPTION
Allows setting parameter overrides inside `convox.yml`

```
params:
  RedirectHttps: no
services:
  web:
    build: .
    port: 3000
```

**Note: Parameters specified in this way will be applied during every release promotion, potentially changing any values you have set manually with `convox apps params set`**