### PR TITLE
AWS: Parameter Store - Adds the ability to use secrets

### DIFF
--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -42,6 +42,7 @@ func TestManifestLoad(t *testing.T) {
 					"DEVELOPMENT=false",
 					"SECRET",
 				},
+				Secrets: []string{},
 				Health: manifest.ServiceHealth{
 					Grace:    10,
 					Path:     "/",
@@ -74,6 +75,7 @@ func TestManifestLoad(t *testing.T) {
 				Environment: []string{
 					"SECRET",
 				},
+				Secrets: []string{},
 				Port: manifest.ServicePort{Port: 2000, Scheme: "https"},
 				Scale: manifest.ServiceScale{
 					Count:  manifest.ServiceScaleCount{Min: 1, Max: 1},
@@ -91,6 +93,7 @@ func TestManifestLoad(t *testing.T) {
 				Command: "foo",
 				Domains: []string{"baz.example.org", "qux.example.org"},
 				Drain:   60,
+				Secrets: []string{},
 				Health: manifest.ServiceHealth{
 					Grace:    2,
 					Interval: 5,
@@ -114,6 +117,7 @@ func TestManifestLoad(t *testing.T) {
 				},
 				Command: "",
 				Drain:   30,
+				Secrets: []string{},
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Interval: 5,
@@ -135,6 +139,7 @@ func TestManifestLoad(t *testing.T) {
 				},
 				Command: "",
 				Drain:   30,
+				Secrets: []string{},
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Interval: 5,
@@ -177,6 +182,7 @@ func TestManifestLoad(t *testing.T) {
 				Environment: []string{
 					"SECRET",
 				},
+				Secrets: []string{},
 				Port: manifest.ServicePort{Port: 2000, Scheme: "https"},
 				Scale: manifest.ServiceScale{
 					Count:  manifest.ServiceScaleCount{Min: 1, Max: 1},
@@ -200,6 +206,7 @@ func TestManifestLoad(t *testing.T) {
 					Path:     ".",
 				},
 				Drain: 30,
+				Secrets: []string{},
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Path:     "/",
@@ -335,6 +342,9 @@ func TestManifestLoadSimple(t *testing.T) {
 					"REQUIRED",
 					"DEFAULT=true",
 				},
+				Secrets: manifest.Secrets{
+					"DATABASE=sql://localhost",
+				},
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Interval: 5,
@@ -351,7 +361,7 @@ func TestManifestLoadSimple(t *testing.T) {
 		},
 	}
 
-	n.SetAttributes([]string{"services", "services.web", "services.web.build", "services.web.environment"})
+	n.SetAttributes([]string{"services", "services.web", "services.web.build", "services.web.environment", "services.web.secrets"})
 	n.SetEnv(map[string]string{"REQUIRED": "test"})
 
 	// env processing that normally happens as part of load

--- a/pkg/manifest/secrets.go
+++ b/pkg/manifest/secrets.go
@@ -1,0 +1,3 @@
+package manifest
+
+type Secrets []string

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -16,6 +16,7 @@ type Service struct {
 	Domains     ServiceDomains `yaml:"domain,omitempty"`
 	Drain       int            `yaml:"drain,omitempty"`
 	Environment Environment    `yaml:"environment,omitempty"`
+	Secrets     Secrets        `yaml:"secrets,omitempty"`
 	Health      ServiceHealth  `yaml:"health,omitempty"`
 	Image       string         `yaml:"image,omitempty"`
 	Init        bool           `yaml:"init,omitempty"`
@@ -121,6 +122,24 @@ func (s Service) EnvironmentKeys() string {
 	kh := map[string]bool{}
 
 	for _, e := range s.Environment {
+		kh[strings.Split(e, "=")[0]] = true
+	}
+
+	keys := []string{}
+
+	for k := range kh {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return strings.Join(keys, ",")
+}
+
+func (s Service) SecretstKeys() string {
+	kh := map[string]bool{}
+
+	for _, e := range s.Secrets {
 		kh[strings.Split(e, "=")[0]] = true
 	}
 

--- a/pkg/manifest/testdata/env.yml
+++ b/pkg/manifest/testdata/env.yml
@@ -8,6 +8,8 @@ services:
   q-train-intent:
     environment:
       - QUEUE_NAME=train-intent
+    secrets:
+      - DATABASE=test://example/db
   q-delete-intent:
     environment:
       - QUEUE_NAME=delete-intent

--- a/pkg/manifest/testdata/simple.yml
+++ b/pkg/manifest/testdata/simple.yml
@@ -4,3 +4,5 @@ services:
     environment:
       - REQUIRED
       - DEFAULT=true
+    secrets:
+      - DATABASE=sql://localhost

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -507,6 +507,12 @@
                 { "Ref": "AWS::NoValue" }
               ],
               "Ulimits": [ { "Name": "nofile", "SoftLimit": "1024000", "HardLimit": "1024000" } ]
+              "Secrets": [
+                {{ range $k, $v := .Secrets }}
+                  { "Name": "{{$k}}", "ValueFrom": {{ safe $v }} },
+                {{ end }}
+                { "Ref": "AWS::NoValue" }
+              ]
             }
           ],
           "Cpu": { "Fn::If": [ "Fargate", { "Ref": "Cpu" }, { "Ref": "AWS::NoValue" } ] },


### PR DESCRIPTION
In order to be able to leverage Parameter Store in Systems Manager, the following must be added to the container definition in the taskdef (as in provider/aws/formation/service.json.tmpl):
```
"secrets": [
        {
          "valueFrom": "PS-Name",
          "name": "VARIABLE_NAME"
        }
]
```

Considering I have _no_ experience in Go, I'm surprised I could get the tests to pass.