### PR TITLE
[RELEASE] 20190813

### DIFF
--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -21,7 +21,7 @@ import (
 	"github.com/convox/rack/pkg/manifest"
 	"github.com/convox/rack/pkg/manifest1"
 	"github.com/convox/rack/pkg/structs"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	shellquote "github.com/kballard/go-shellquote"
 )
 
@@ -331,7 +331,18 @@ func (p *Provider) taskProcesses(tasks []string) (structs.Processes, error) {
 			}
 
 			for _, task := range tres.Tasks {
-				ecsTasks = append(ecsTasks, task)
+				// workaround for ECS:ListTasks bug that is returning all tasks you specify even if they
+				// are not on the cluster that you specify
+				exists := false
+				for _, t := range ecsTasks {
+					if t.TaskArn != nil && task.TaskArn != nil && *t.TaskArn == *task.TaskArn {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					ecsTasks = append(ecsTasks, task)
+				}
 			}
 		}
 

--- a/provider/kaws/system.go
+++ b/provider/kaws/system.go
@@ -265,7 +265,9 @@ func (p *Provider) SystemUpdate(opts structs.SystemUpdateOptions) error {
 	template := fmt.Sprintf(cfnTemplate, helpers.DefaultString(opts.Version, p.Provider.Version))
 
 	if err := helpers.CloudformationUpdate(p.CloudFormation, p.Rack, template, nil, nil, p.EventTopic); err != nil {
-		return err
+		if !cloudformationErrorNoUpdates(err) {
+			return err
+		}
 	}
 
 	if err := p.Provider.SystemUpdate(opts); err != nil {


### PR DESCRIPTION
## Pull Requests
  - closes #3293 allow kaws rack update to proceed when stack update is noop [@ddollar]
  - closes #3295 dedupe tasks to work around bug in ECS:ListTasks [@ddollar]

## Milestone Release
- [ ] Release branch
- [ ] Pass CI
- [ ] Merge into master
- [ ] Close milestone
- [ ] Release master
- [ ] Record release number: 
- [ ] Pass CI
- [ ] Write [release notes](https://github.com/convox/rack/releases)
- [ ] Documentation review
- [ ] Publish release
- [ ] Update Homebrew
