### PR TITLE
Removed port 80 from ELB security group

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2408,25 +2408,6 @@
               { "Ref": "AWS::NoValue" }
             ] },
             "IpProtocol": "tcp",
-            "FromPort": "80",
-            "ToPort": "80"
-          },
-          {
-            "CidrIp": { "Fn::If": [ "PrivateApi",
-              { "Fn::If": [ "BlankPrivateApiSecurityGroup",
-                { "Ref": "VPCCIDR" },
-                { "Ref": "AWS::NoValue" }
-              ] },
-              "0.0.0.0/0"
-            ] },
-            "SourceSecurityGroupId": { "Fn::If": [ "PrivateApi",
-              { "Fn::If": [ "BlankPrivateApiSecurityGroup",
-                { "Ref": "AWS::NoValue" },
-                { "Ref": "PrivateApiSecurityGroup" }
-              ] },
-              { "Ref": "AWS::NoValue" }
-            ] },
-            "IpProtocol": "tcp",
             "FromPort": "443",
             "ToPort": "443"
           }


### PR DESCRIPTION
TrustedAdvisor is reporting that the security groups for the rack ELBs have ingress rules that don't match the listener ports. The ELBs only listen for 443 but the security group allows both 80 and 443.

I'm not really sure what the ELB is even used for in the rack, as I thought ALBs were used for application routing, so I don't know if it is configured like this for a reason. But if it's just an oversight, this PR just removes the 80 port from the SG. 