### PR TITLE
pkg/cli: Fix dropped error

### DIFF
--- a/pkg/cli/logs.go
+++ b/pkg/cli/logs.go
@@ -36,5 +36,5 @@ func Logs(rack sdk.Interface, c *stdcli.Context) error {
 
 	_, err = io.Copy(c, r)
 
-	return nil
+	return err
 }


### PR DESCRIPTION
This PR fixes a dropped error in `cli`.