### PR TITLE
make release descriptions more useful

### DIFF
--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/convox/rack/pkg/helpers"
@@ -92,6 +94,14 @@ func build(rack sdk.Interface, c *stdcli.Context, development bool) (*structs.Bu
 
 	if err := c.Options(&opts); err != nil {
 		return nil, err
+	}
+
+	if opts.Description == nil {
+		if err := exec.Command("git", "diff", "--quiet").Run(); err == nil {
+			if data, err := exec.Command("git", "log", "-n", "1", "--pretty=%h %s", "--abbrev=10").CombinedOutput(); err == nil {
+				opts.Description = options.String(fmt.Sprintf("build %s", strings.TrimSpace(string(data))))
+			}
+		}
 	}
 
 	c.Startf("Packaging source")

--- a/pkg/cli/builds_test.go
+++ b/pkg/cli/builds_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/convox/rack/pkg/cli"
 	mocksdk "github.com/convox/rack/pkg/mock/sdk"
+	"github.com/convox/rack/pkg/options"
 	"github.com/convox/rack/pkg/structs"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -20,13 +21,13 @@ func TestBuild(t *testing.T) {
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
 		})
-		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{}).Return(fxBuild(), nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil).Once()
 		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
 		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
 
-		res, err := testExecute(e, "build ./testdata/httpd -a app1", nil)
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo", nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
@@ -48,13 +49,13 @@ func TestBuildFinalizeLogs(t *testing.T) {
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
 		})
-		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{}).Return(fxBuild(), nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil).Once()
 		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
 		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogsLonger()), nil)
 
-		res, err := testExecute(e, "build ./testdata/httpd -a app1", nil)
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo", nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
@@ -77,9 +78,9 @@ func TestBuildError(t *testing.T) {
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
 		})
-		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{}).Return(nil, fmt.Errorf("err1"))
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(nil, fmt.Errorf("err1"))
 
-		res, err := testExecute(e, "build ./testdata/httpd -a app1", nil)
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo", nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, res.Code)
 		res.RequireStderr(t, []string{"ERROR: err1"})
@@ -94,12 +95,12 @@ func TestBuildError(t *testing.T) {
 func TestBuildClassic(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(fxSystemClassic(), nil)
-		i.On("BuildCreateUpload", "app1", mock.Anything, structs.BuildCreateOptions{}).Return(fxBuild(), nil)
+		i.On("BuildCreateUpload", "app1", mock.Anything, structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
 		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
 		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
 
-		res, err := testExecute(e, "build ./testdata/httpd -a app1", nil)
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo", nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})

--- a/pkg/cli/deploy_test.go
+++ b/pkg/cli/deploy_test.go
@@ -19,14 +19,14 @@ func TestDeploy(t *testing.T) {
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
 		})
-		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{}).Return(fxBuild(), nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
 		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
 		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
 		i.On("AppGet", "app1").Return(fxApp(), nil)
 		i.On("ReleasePromote", "app1", "release1", structs.ReleasePromoteOptions{}).Return(nil)
 
-		res, err := testExecute(e, "deploy ./testdata/httpd -a app1", nil)
+		res, err := testExecute(e, "deploy ./testdata/httpd -a app1 -d foo", nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
@@ -47,14 +47,14 @@ func TestDeployError(t *testing.T) {
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
 		})
-		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{}).Return(fxBuild(), nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
 		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
 		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
 		i.On("AppGet", "app1").Return(fxApp(), nil)
 		i.On("ReleasePromote", "app1", "release1", structs.ReleasePromoteOptions{}).Return(fmt.Errorf("err1"))
 
-		res, err := testExecute(e, "deploy ./testdata/httpd -a app1", nil)
+		res, err := testExecute(e, "deploy ./testdata/httpd -a app1 -d foo", nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, res.Code)
 		res.RequireStderr(t, []string{"ERROR: err1"})
@@ -75,7 +75,7 @@ func TestDeployWait(t *testing.T) {
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
 		})
-		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{}).Return(fxBuild(), nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
 		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
 		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
@@ -86,7 +86,7 @@ func TestDeployWait(t *testing.T) {
 		opts := structs.LogsOptions{Prefix: options.Bool(true), Since: options.Duration(5 * time.Second)}
 		i.On("AppLogs", "app1", opts).Return(testLogs(fxLogsSystem()), nil)
 
-		res, err := testExecute(e, "deploy ./testdata/httpd -a app1 --wait", nil)
+		res, err := testExecute(e, "deploy ./testdata/httpd -a app1 -d foo --wait", nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -16,6 +16,7 @@ func init() {
 		Flags: []stdcli.Flag{
 			flagApp,
 			flagRack,
+			stdcli.StringFlag("description", "d", "description"),
 			stdcli.StringFlag("release", "", "use existing release to run tests"),
 			stdcli.IntFlag("timeout", "t", "timeout"),
 		},

--- a/pkg/cli/test_test.go
+++ b/pkg/cli/test_test.go
@@ -20,7 +20,7 @@ func TestTest(t *testing.T) {
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
 		})
-		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Development: options.Bool(true)}).Return(fxBuild(), nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Development: options.Bool(true), Description: options.String("foo")}).Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
 		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
 		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
@@ -37,7 +37,7 @@ func TestTest(t *testing.T) {
 		})
 		i.On("ProcessStop", "app1", "pid1").Return(nil)
 
-		res, err := testExecute(e, "test ./testdata/httpd -a app1 -t 7200", strings.NewReader("in"))
+		res, err := testExecute(e, "test ./testdata/httpd -a app1 -d foo -t 7200", strings.NewReader("in"))
 		require.NoError(t, err)
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
@@ -59,7 +59,7 @@ func TestTestFail(t *testing.T) {
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
 		})
-		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Development: options.Bool(true)}).Return(fxBuild(), nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Development: options.Bool(true), Description: options.String("foo")}).Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
 		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
 		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
@@ -76,7 +76,7 @@ func TestTestFail(t *testing.T) {
 		})
 		i.On("ProcessStop", "app1", "pid1").Return(nil)
 
-		res, err := testExecute(e, "test ./testdata/httpd -a app1 -t 7200", strings.NewReader("in"))
+		res, err := testExecute(e, "test ./testdata/httpd -a app1 -d foo -t 7200", strings.NewReader("in"))
 		require.NoError(t, err)
 		require.Equal(t, 1, res.Code)
 		res.RequireStderr(t, []string{"ERROR: exit 4"})

--- a/pkg/helpers/env.go
+++ b/pkg/helpers/env.go
@@ -1,0 +1,62 @@
+package helpers
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/convox/rack/pkg/structs"
+)
+
+func EnvDiff(a, b string) (string, error) {
+	ae := structs.Environment{}
+	be := structs.Environment{}
+
+	if err := ae.Load([]byte(strings.TrimSpace(a))); err != nil {
+		return "", err
+	}
+
+	if err := be.Load([]byte(strings.TrimSpace(b))); err != nil {
+		return "", err
+	}
+
+	adds := []string{}
+	changes := []string{}
+	removes := []string{}
+
+	for k := range be {
+		if v, ok := ae[k]; ok {
+			if be[k] != v {
+				changes = append(changes, k)
+			}
+		} else {
+			adds = append(adds, k)
+		}
+	}
+
+	for k := range ae {
+		if _, ok := be[k]; !ok {
+			removes = append(removes, k)
+		}
+	}
+
+	sort.Strings(adds)
+	sort.Strings(changes)
+	sort.Strings(removes)
+
+	desc := ""
+
+	for _, k := range adds {
+		desc = fmt.Sprintf("%s add:%s", desc, k)
+	}
+
+	for _, k := range changes {
+		desc = fmt.Sprintf("%s change:%s", desc, k)
+	}
+
+	for _, k := range removes {
+		desc = fmt.Sprintf("%s remove:%s", desc, k)
+	}
+
+	return strings.TrimSpace(desc), nil
+}

--- a/pkg/structs/release.go
+++ b/pkg/structs/release.go
@@ -17,8 +17,9 @@ type Release struct {
 type Releases []Release
 
 type ReleaseCreateOptions struct {
-	Build *string `param:"build"`
-	Env   *string `param:"env"`
+	Build       *string `param:"build"`
+	Description *string `param:"description"`
+	Env         *string `param:"env"`
 }
 
 type ReleaseListOptions struct {

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -1072,11 +1072,6 @@ func (p *Provider) putLogEvents(req *cloudwatchlogs.PutLogEventsInput) (string, 
 			continue
 		}
 		if awsError(err) == "InvalidSequenceTokenException" {
-			fmt.Println("sequence token error")
-			if ae, ok := err.(awserr.Error); ok {
-				fmt.Printf("ae = %#v\n", ae)
-			}
-
 			sres, err := p.cloudwatchlogs().DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
 				LogGroupName:        req.LogGroupName,
 				LogStreamNamePrefix: req.LogStreamName,

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -41,17 +41,28 @@ func (p *Provider) ReleaseCreate(app string, opts structs.ReleaseCreateOptions) 
 		r.Build = *opts.Build
 	}
 
-	if opts.Env != nil {
-		r.Env = *opts.Env
-	}
-
 	if r.Build != "" {
 		b, err := p.BuildGet(app, r.Build)
 		if err != nil {
 			return nil, err
 		}
+
 		r.Description = b.Description
 		r.Manifest = b.Manifest
+	}
+
+	if opts.Env != nil {
+		desc, err := helpers.EnvDiff(r.Env, *opts.Env)
+		if err != nil {
+			return nil, err
+		}
+
+		r.Description = fmt.Sprintf("env %s", desc)
+		r.Env = *opts.Env
+	}
+
+	if opts.Description != nil {
+		r.Description = *opts.Description
 	}
 
 	if err := p.releaseSave(r); err != nil {

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -26,10 +26,6 @@ func (p *Provider) ReleaseCreate(app string, opts structs.ReleaseCreateOptions) 
 		r.Build = *opts.Build
 	}
 
-	if opts.Env != nil {
-		r.Env = *opts.Env
-	}
-
 	if r.Build != "" {
 		b, err := p.BuildGet(app, r.Build)
 		if err != nil {
@@ -37,6 +33,20 @@ func (p *Provider) ReleaseCreate(app string, opts structs.ReleaseCreateOptions) 
 		}
 
 		r.Manifest = b.Manifest
+	}
+
+	if opts.Env != nil {
+		desc, err := helpers.EnvDiff(r.Env, *opts.Env)
+		if err != nil {
+			return nil, err
+		}
+
+		r.Description = fmt.Sprintf("env %s", desc)
+		r.Env = *opts.Env
+	}
+
+	if opts.Description != nil {
+		r.Description = *opts.Description
 	}
 
 	ro, err := p.releaseCreate(r)


### PR DESCRIPTION
When building from a directory with a git repository with a clean working tree:

`build 7329df90c1 this is my commit message`

When updating environment variables, gives a summary of changes:

`env add:FOO change:BAR remove:BAZ`
