### PR TITLE
allow disabling local racks in cli

### DIFF
--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -183,6 +183,10 @@ func localRackRunning(c *stdcli.Context) bool {
 }
 
 func localRacks(c *stdcli.Context) ([]rack, error) {
+	if os.Getenv("CONVOX_LOCAL") == "disable" {
+		return []rack{}, nil
+	}
+
 	racks := []rack{}
 
 	data, err := c.Execute("kubectl", "get", "ns", "--selector=system=convox,type=rack", "--output=name")

--- a/pkg/cli/racks_test.go
+++ b/pkg/cli/racks_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -49,6 +50,48 @@ func TestRacks(t *testing.T) {
 			"test/foo    running ",
 			"test/other  updating",
 		})
+
+		me.AssertExpectations(t)
+	})
+}
+
+func TestRacksLocalDisable(t *testing.T) {
+	orig := os.Getenv("CONVOX_LOCAL")
+	os.Setenv("CONVOX_LOCAL", "disable")
+	defer os.Setenv("CONVOX_LOCAL", orig)
+
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		r := mux.NewRouter()
+
+		r.HandleFunc("/racks", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`[
+				{"name":"foo","organization":{"name":"test"},"status":"running"},
+				{"name":"other","organization":{"name":"test"},"status":"updating"}
+			]`))
+		}).Methods("GET")
+
+		ts := httptest.NewTLSServer(r)
+
+		tsu, err := url.Parse(ts.URL)
+		require.NoError(t, err)
+
+		err = ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
+		require.NoError(t, err)
+
+		me := &mockstdcli.Executor{}
+		e.Executor = me
+
+		res, err := testExecute(e, "racks", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			"NAME        STATUS  ",
+			"test/foo    running ",
+			"test/other  updating",
+		})
+
+		me.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
Set the local environment variable `CONVOX_LOCAL=disable` to disable using/searching for local Rack.