### PR TITLE
Rack param: ImagePullBehavior

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -502,6 +502,12 @@
       "Type": "String",
       "Default": ""
     },
+    "ImagePullBehavior": {
+      "Type": "String",
+      "Description": "The behavior used to customize the pull image process for your container instances. See ECS_IMAGE_PULL_BEHAVIOR https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html",
+      "Default": "default",
+      "AllowedValues": ["default", "always", "once", "prefer-cached"]
+    },
     "Internal": {
       "Type": "String",
       "Description": "Support applications that are only accessible inside the VPC",
@@ -1280,6 +1286,7 @@
               { "Ref": "AWS::NoValue" }
             ] },
             "  - echo ECS_CLUSTER=", { "Ref": "BuildCluster" }, " >> /etc/ecs/ecs.config\n",
+            "  - echo ECS_IMAGE_PULL_BEHAVIOR=", { "Ref": "ImagePullBehavior" }, " >> /etc/ecs/ecs.config\n",
             "  - echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config\n",
             "  - echo 'ECS_INSTANCE_ATTRIBUTES={\"asg\":\"build\"}' >> /etc/ecs/ecs.config\n",
             "  - echo HTTP_PROXY=", { "Ref": "HttpProxy" }, " >> /etc/ecs/ecs.config\n",


### PR DESCRIPTION
Allow racks to configure ECS_IMAGE_PULL_BEHAVIOR for the ECS agent. https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html

I can't think of a reason not to do this. The default behavior is to pull the image every time but since image tags are NOT reused in Convox, it's safe to use the cache. Leaving the cache behavior as "opt-in" so there are no surprises but I'd encourage folks with large images to make the switch.