### PR TITLE
Disable auth for external registries when PrivateBuild is enabled

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -65,6 +65,7 @@ type Provider struct {
 	OnDemandMinCount    int
 	Password            string
 	Private             bool
+	PrivateBuild        bool
 	Rack                string
 	SecurityGroup       string
 	SettingsBucket      string
@@ -153,7 +154,8 @@ func (p *Provider) loadParams() error {
 	p.LogBucket = labels["rack.LogBucket"]
 	p.NotificationTopic = labels["rack.NotificationTopic"]
 	p.OnDemandMinCount = intParam(labels["rack.OnDemandMinCount"], 2)
-	p.Private = labels["Private"] == "Yes"
+	p.Private = labels["rack.Private"] == "Yes"
+	p.PrivateBuild = labels["rack.PrivateBuild"] == "Yes"
 	p.SecurityGroup = labels["rack.SecurityGroup"]
 	p.SettingsBucket = labels["rack.SettingsBucket"]
 	p.SpotInstances = labels["rack.SpotInstances"] == "Yes"

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2526,6 +2526,7 @@
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
+              "rack.PrivateBuild": { "Ref": "PrivateBuild" },
               "rack.SecurityGroup": { "Fn::If": [ "BlankInstanceSecurityGroup", { "Ref": "InstancesSecurity" }, { "Ref": "InstanceSecurityGroup" } ] },
               "rack.SettingsBucket": { "Ref": "Settings" },
               "rack.SpotInstances": { "Fn::If": [ "SpotInstances", "Yes", "No" ] },

--- a/provider/aws/registries.go
+++ b/provider/aws/registries.go
@@ -51,16 +51,15 @@ func (p *Provider) RegistryAdd(server, username, password string) (*structs.Regi
 		if _, _, err := p.authECR(server, username, password); err != nil {
 			return nil, fmt.Errorf("unable to authenticate")
 		}
+	case p.PrivateBuild:
 	default:
-		if !(p.PrivateBuild) {		
-			_, err := dc.AuthCheck(&docker.AuthConfiguration{
-				ServerAddress: server,
-				Username:      username,
-				Password:      password,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("unable to authenticate")
-			}
+		_, err := dc.AuthCheck(&docker.AuthConfiguration{
+			ServerAddress: server,
+			Username:      username,
+			Password:      password,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to authenticate")
 		}
 	}
 

--- a/provider/aws/registries.go
+++ b/provider/aws/registries.go
@@ -52,6 +52,7 @@ func (p *Provider) RegistryAdd(server, username, password string) (*structs.Regi
 			return nil, fmt.Errorf("unable to authenticate")
 		}
 	case p.PrivateBuild:
+		// Don't authenticate the registry if PrivateBuild is enabled.  Keeps all registry access on the Build Cluster rather than the main Rack.
 	default:
 		_, err := dc.AuthCheck(&docker.AuthConfiguration{
 			ServerAddress: server,

--- a/provider/aws/registries.go
+++ b/provider/aws/registries.go
@@ -52,13 +52,15 @@ func (p *Provider) RegistryAdd(server, username, password string) (*structs.Regi
 			return nil, fmt.Errorf("unable to authenticate")
 		}
 	default:
-		_, err := dc.AuthCheck(&docker.AuthConfiguration{
-			ServerAddress: server,
-			Username:      username,
-			Password:      password,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("unable to authenticate")
+		if !(p.PrivateBuild) {		
+			_, err := dc.AuthCheck(&docker.AuthConfiguration{
+				ServerAddress: server,
+				Username:      username,
+				Password:      password,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("unable to authenticate")
+			}
 		}
 	}
 


### PR DESCRIPTION
ECR registries can't be locked down to IP ranges so aren't affected, only normal registries.
Also corrected the label for the 'Private' parameter.