### PR TITLE
Allow major version upgrade and switch to default parameter groups

### DIFF
--- a/provider/aws/formation/resource/mysql.json.tmpl
+++ b/provider/aws/formation/resource/mysql.json.tmpl
@@ -70,10 +70,16 @@
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "AllocatedStorage": { "Ref": "Storage" },
+        "AllowMajorVersionUpgrade": "true",
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
         "DBName": "app",
-        "DBParameterGroupName": { "Ref": "ParameterGroup" },
+        "DBParameterGroupName": { "Fn::Sub": [ "default.mysql${Base}", {
+          "Base": { "Fn::Join": [ ".", [
+            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
+            { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+          ] ] }
+        } ] },
         "DBSubnetGroupName": { "Ref": "SubnetGroup" },
         "Engine": "mysql",
         "EngineVersion": { "Ref": "Version" },
@@ -86,18 +92,6 @@
         "StorageEncrypted": { "Ref": "Encrypted" },
         "StorageType": { "Fn::If": [ "BlankIops", "gp2", "io1" ] },
         "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ]
-      }
-    },
-    "ParameterGroup": {
-      "Type": "AWS::RDS::DBParameterGroup",
-      "Properties": {
-        "Description": { "Fn::Sub": "${AWS::StackName} parameters" },
-        "Family": { "Fn::Sub": [ "mysql${Base}", {
-          "Base": { "Fn::Join": [ ".", [
-            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
-            { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
-          ] ] }
-        } ] }
       }
     }
   }

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -71,10 +71,19 @@
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "AllocatedStorage": { "Ref": "Storage" },
+        "AllowMajorVersionUpgrade": "true",
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
         "DBName": "app",
-        "DBParameterGroupName": { "Ref": "ParameterGroup" },
+        "DBParameterGroupName": { "Fn::Sub": [ "default.postgres${Base}", {
+          "Base": { "Fn::If": [ "Version9",
+            { "Fn::Join": [ ".", [
+              { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
+              { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+            ] ] },
+            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+          ] }
+        } ] },
         "DBSubnetGroupName": { "Ref": "SubnetGroup" },
         "Engine": "postgres",
         "EngineVersion": { "Ref": "Version" },
@@ -87,21 +96,6 @@
         "StorageEncrypted": { "Ref": "Encrypted" },
         "StorageType": { "Fn::If": [ "BlankIops", "gp2", "io1" ] },
         "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ]
-      }
-    },
-    "ParameterGroup": {
-      "Type": "AWS::RDS::DBParameterGroup",
-      "Properties": {
-        "Description": { "Fn::Sub": "${AWS::StackName} parameters" },
-        "Family": { "Fn::Sub": [ "postgres${Base}", {
-          "Base": { "Fn::If": [ "Version9",
-            { "Fn::Join": [ ".", [
-              { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
-              { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
-            ] ] },
-            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
-          ] }
-        } ] }
       }
     }
   }


### PR DESCRIPTION
Move away from unnecessary custom parameter groups to allow for Major version upgrade compatibility through CloudFormation.