### PR TITLE
Filter invalid headers in ALB

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2148,7 +2148,7 @@
           { "Key": "access_logs.s3.bucket", "Value": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] } },
           { "Key": "access_logs.s3.prefix", "Value": { "Fn::Sub": "convox/logs/${AWS::StackName}/alb" } },
           { "Key": "idle_timeout.timeout_seconds", "Value": "3600" },
-          { "Key": "routing.http.drop_invalid_header_fields.enabled", "true" }
+          { "Key": "routing.http.drop_invalid_header_fields.enabled", "Value": "true" }
         ],
         "Subnets": [
           { "Ref": "Subnet0" },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -479,7 +479,7 @@
     "DropInvalidHeaderFieldsAtLoadBalancer": {
       "Type": "String",
       "Description": "Should the ALB remove invalid HTTP headers before passing the request to the application",
-      "Default": "No",
+      "Default": "Yes",
       "AllowedValues": [ "Yes", "No" ]
     },
     "EcsPollInterval": {
@@ -2155,7 +2155,7 @@
           { "Key": "access_logs.s3.bucket", "Value": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] } },
           { "Key": "access_logs.s3.prefix", "Value": { "Fn::Sub": "convox/logs/${AWS::StackName}/alb" } },
           { "Key": "idle_timeout.timeout_seconds", "Value": "3600" },
-          { "Key": "routing.http.drop_invalid_header_fields.enabled", "Value": { "Fn::If": [ "DropInvalidHeaderFieldsAtLoadBalancer", "true", { "Ref": "AWS::NoValue" } ] } }
+          { "Key": "routing.http.drop_invalid_header_fields.enabled", "Value": { "Fn::If": [ "DropInvalidHeaderFieldsAtLoadBalancer", "true", "false" ] } }
         ],
         "Subnets": [
           { "Ref": "Subnet0" },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -26,7 +26,6 @@
     "BlankSslPolicy": { "Fn::Equals": [ { "Ref": "SslPolicy" }, "" ] },
     "DedicatedBuilder": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstance" }, "" ] } ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
-    "DropInvalidHeaderFieldsAtLoadBalancer" : { "Fn::Equals": [ { "Ref": "DropInvalidHeaderFieldsAtLoadBalancer" }, "Yes" ] },
     "EncryptEbs" : { "Fn::Equals": [ { "Ref": "EncryptEbs" }, "Yes" ] },
     "ExistingVpc": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "ExistingVpc" }, "" ] } ] },
     "ExistingVpcAndBlankInternetGateway": {
@@ -474,12 +473,6 @@
       "Type": "String",
       "Description": "Development mode",
       "Default": "No",
-      "AllowedValues": [ "Yes", "No" ]
-    },
-    "DropInvalidHeaderFieldsAtLoadBalancer": {
-      "Type": "String",
-      "Description": "Should the ALB remove invalid HTTP headers before passing the request to the application",
-      "Default": "Yes",
       "AllowedValues": [ "Yes", "No" ]
     },
     "EcsPollInterval": {
@@ -2155,7 +2148,7 @@
           { "Key": "access_logs.s3.bucket", "Value": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] } },
           { "Key": "access_logs.s3.prefix", "Value": { "Fn::Sub": "convox/logs/${AWS::StackName}/alb" } },
           { "Key": "idle_timeout.timeout_seconds", "Value": "3600" },
-          { "Key": "routing.http.drop_invalid_header_fields.enabled", "Value": { "Fn::If": [ "DropInvalidHeaderFieldsAtLoadBalancer", "true", "false" ] } }
+          { "Key": "routing.http.drop_invalid_header_fields.enabled", "true" }
         ],
         "Subnets": [
           { "Ref": "Subnet0" },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -26,6 +26,7 @@
     "BlankSslPolicy": { "Fn::Equals": [ { "Ref": "SslPolicy" }, "" ] },
     "DedicatedBuilder": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstance" }, "" ] } ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
+    "DropInvalidHeaderFieldsAtLoadBalancer" : { "Fn::Equals": [ { "Ref": "DropInvalidHeaderFieldsAtLoadBalancer" }, "Yes" ] },
     "EncryptEbs" : { "Fn::Equals": [ { "Ref": "EncryptEbs" }, "Yes" ] },
     "ExistingVpc": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "ExistingVpc" }, "" ] } ] },
     "ExistingVpcAndBlankInternetGateway": {
@@ -472,6 +473,12 @@
     "Development": {
       "Type": "String",
       "Description": "Development mode",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ]
+    },
+    "DropInvalidHeaderFieldsAtLoadBalancer": {
+      "Type": "String",
+      "Description": "Should the ALB remove invalid HTTP headers before passing the request to the application",
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
     },
@@ -2147,7 +2154,8 @@
           { "Key": "access_logs.s3.enabled", "Value": "true" },
           { "Key": "access_logs.s3.bucket", "Value": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] } },
           { "Key": "access_logs.s3.prefix", "Value": { "Fn::Sub": "convox/logs/${AWS::StackName}/alb" } },
-          { "Key": "idle_timeout.timeout_seconds", "Value": "3600" }
+          { "Key": "idle_timeout.timeout_seconds", "Value": "3600" },
+          { "Key": "routing.http.drop_invalid_header_fields.enabled", "Value": { "Fn::If": [ "DropInvalidHeaderFieldsAtLoadBalancer", "true", { "Ref": "AWS::NoValue" } ] } }
         ],
         "Subnets": [
           { "Ref": "Subnet0" },


### PR DESCRIPTION
This updates the rack CF template to support a rack parameter that toggles the [ALB `routing.http.drop_invalid_header_fields.enabled` attribute](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes).