### PR TITLE
add manual control over deployments

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -243,6 +243,22 @@ func (m *Manifest) ApplyDefaults() error {
 			m.Services[i].Build.Manifest = "Dockerfile"
 		}
 
+		if !m.AttributeSet(fmt.Sprintf("services.%s.deployment.maximum", s.Name)) {
+			if s.Agent.Enabled || s.Singleton {
+				m.Services[i].Deployment.Maximum = 100
+			} else {
+				m.Services[i].Deployment.Maximum = 200
+			}
+		}
+
+		if !m.AttributeSet(fmt.Sprintf("services.%s.deployment.minimum", s.Name)) {
+			if s.Agent.Enabled || s.Singleton {
+				m.Services[i].Deployment.Minimum = 0
+			} else {
+				m.Services[i].Deployment.Minimum = 50
+			}
+		}
+
 		if s.Drain == 0 {
 			m.Services[i].Drain = 30
 		}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -35,6 +35,10 @@ func TestManifestLoad(t *testing.T) {
 					Path:     "api",
 				},
 				Command: "",
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 25,
+					Maximum: 65,
+				},
 				Domains: []string{"foo.example.org"},
 				Drain:   30,
 				Environment: []string{
@@ -62,6 +66,10 @@ func TestManifestLoad(t *testing.T) {
 			manifest.Service{
 				Name:    "proxy",
 				Command: "bash",
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
 				Domains: []string{"bar.example.org", "*.example.org"},
 				Drain:   30,
 				Health: manifest.ServiceHealth{
@@ -89,6 +97,10 @@ func TestManifestLoad(t *testing.T) {
 					Path:     ".",
 				},
 				Command: "foo",
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 0,
+					Maximum: 100,
+				},
 				Domains: []string{"baz.example.org", "qux.example.org"},
 				Drain:   60,
 				Health: manifest.ServiceHealth{
@@ -113,7 +125,11 @@ func TestManifestLoad(t *testing.T) {
 					Path:     ".",
 				},
 				Command: "",
-				Drain:   30,
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
+				Drain: 30,
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Interval: 5,
@@ -134,7 +150,11 @@ func TestManifestLoad(t *testing.T) {
 					Path:     ".",
 				},
 				Command: "",
-				Drain:   30,
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
+				Drain: 30,
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Interval: 5,
@@ -165,6 +185,10 @@ func TestManifestLoad(t *testing.T) {
 			manifest.Service{
 				Name:    "inherit",
 				Command: "inherit",
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
 				Domains: []string{"bar.example.org", "*.example.org"},
 				Drain:   30,
 				Health: manifest.ServiceHealth{
@@ -198,6 +222,10 @@ func TestManifestLoad(t *testing.T) {
 				Build: manifest.ServiceBuild{
 					Manifest: "Dockerfile",
 					Path:     ".",
+				},
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 0,
+					Maximum: 100,
 				},
 				Drain: 30,
 				Health: manifest.ServiceHealth{
@@ -233,6 +261,9 @@ func TestManifestLoad(t *testing.T) {
 		"services.api.build",
 		"services.api.build.manifest",
 		"services.api.build.path",
+		"services.api.deployment",
+		"services.api.deployment.maximum",
+		"services.api.deployment.minimum",
 		"services.api.domain",
 		"services.api.environment",
 		"services.api.health",
@@ -331,6 +362,10 @@ func TestManifestLoadSimple(t *testing.T) {
 				Build: manifest.ServiceBuild{
 					Manifest: "Dockerfile",
 					Path:     ".",
+				},
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
 				},
 				Drain: 30,
 				Environment: manifest.Environment{

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -10,25 +10,26 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent       ServiceAgent   `yaml:"agent,omitempty"`
-	Build       ServiceBuild   `yaml:"build,omitempty"`
-	Command     string         `yaml:"command,omitempty"`
-	Domains     ServiceDomains `yaml:"domain,omitempty"`
-	Drain       int            `yaml:"drain,omitempty"`
-	Environment Environment    `yaml:"environment,omitempty"`
-	Health      ServiceHealth  `yaml:"health,omitempty"`
-	Image       string         `yaml:"image,omitempty"`
-	Init        bool           `yaml:"init,omitempty"`
-	Internal    bool           `yaml:"internal,omitempty"`
-	Links       []string       `yaml:"links,omitempty"`
-	Port        ServicePort    `yaml:"port,omitempty"`
-	Privileged  bool           `yaml:"privileged,omitempty"`
-	Resources   []string       `yaml:"resources,omitempty"`
-	Scale       ServiceScale   `yaml:"scale,omitempty"`
-	Singleton   bool           `yaml:"singleton,omitempty"`
-	Sticky      bool           `yaml:"sticky,omitempty"`
-	Test        string         `yaml:"test,omitempty"`
-	Volumes     []string       `yaml:"volumes,omitempty"`
+	Agent       ServiceAgent      `yaml:"agent,omitempty"`
+	Build       ServiceBuild      `yaml:"build,omitempty"`
+	Command     string            `yaml:"command,omitempty"`
+	Deployment  ServiceDeployment `yaml:"deployment,omitempty"`
+	Domains     ServiceDomains    `yaml:"domain,omitempty"`
+	Drain       int               `yaml:"drain,omitempty"`
+	Environment Environment       `yaml:"environment,omitempty"`
+	Health      ServiceHealth     `yaml:"health,omitempty"`
+	Image       string            `yaml:"image,omitempty"`
+	Init        bool              `yaml:"init,omitempty"`
+	Internal    bool              `yaml:"internal,omitempty"`
+	Links       []string          `yaml:"links,omitempty"`
+	Port        ServicePort       `yaml:"port,omitempty"`
+	Privileged  bool              `yaml:"privileged,omitempty"`
+	Resources   []string          `yaml:"resources,omitempty"`
+	Scale       ServiceScale      `yaml:"scale,omitempty"`
+	Singleton   bool              `yaml:"singleton,omitempty"`
+	Sticky      bool              `yaml:"sticky,omitempty"`
+	Test        string            `yaml:"test,omitempty"`
+	Volumes     []string          `yaml:"volumes,omitempty"`
 }
 
 type Services []Service
@@ -47,6 +48,11 @@ type ServiceBuild struct {
 	Args     []string `yaml:"args,omitempty"`
 	Manifest string   `yaml:"manifest,omitempty"`
 	Path     string   `yaml:"path,omitempty"`
+}
+
+type ServiceDeployment struct {
+	Maximum int `yaml:"maximum,omitempty"`
+	Minimum int `yaml:"minimum,omitempty"`
 }
 
 type ServiceDomains []string

--- a/pkg/manifest/testdata/full.yml
+++ b/pkg/manifest/testdata/full.yml
@@ -15,6 +15,9 @@ services:
       manifest: Dockerfile2
       path: api
     domain: foo.example.org
+    deployment:
+      minimum: 25
+      maximum: 65
     environment:
       - DEFAULT=test
       - DEVELOPMENT=false

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -265,13 +265,8 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 	}
 
 	for _, s := range m.Services {
-		min := 50
-		max := 200
-
-		if s.Agent.Enabled || s.Singleton {
-			min = 0
-			max = 100
-		}
+		min := s.Deployment.Minimum
+		max := s.Deployment.Maximum
 
 		if opts.Min != nil {
 			min = *opts.Min


### PR DESCRIPTION
Adds new attributes to `convox.yml` to allow for manual control of deployment minimum/maximum percent:

    services:
      web:
        deployment:
          minimum: 50
          maximum: 100