### PR TITLE
support array format for service command

### DIFF
--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -96,7 +96,7 @@ func TestManifestLoad(t *testing.T) {
 					Manifest: "Dockerfile",
 					Path:     ".",
 				},
-				Command: manifest.ServiceCommand{"sh", "-c", "foo"},
+				Command: manifest.ServiceCommand{"foo"},
 				Deployment: manifest.ServiceDeployment{
 					Minimum: 0,
 					Maximum: 100,

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -34,7 +34,7 @@ func TestManifestLoad(t *testing.T) {
 					Manifest: "Dockerfile2",
 					Path:     "api",
 				},
-				Command: "",
+				Command: manifest.ServiceCommand{"bin/api", "start"},
 				Deployment: manifest.ServiceDeployment{
 					Minimum: 25,
 					Maximum: 65,
@@ -65,7 +65,7 @@ func TestManifestLoad(t *testing.T) {
 			},
 			manifest.Service{
 				Name:    "proxy",
-				Command: "bash",
+				Command: manifest.ServiceCommand{"sh", "-c", "bash"},
 				Deployment: manifest.ServiceDeployment{
 					Minimum: 50,
 					Maximum: 200,
@@ -96,7 +96,7 @@ func TestManifestLoad(t *testing.T) {
 					Manifest: "Dockerfile",
 					Path:     ".",
 				},
-				Command: "foo",
+				Command: manifest.ServiceCommand{"sh", "-c", "foo"},
 				Deployment: manifest.ServiceDeployment{
 					Minimum: 0,
 					Maximum: 100,
@@ -124,7 +124,6 @@ func TestManifestLoad(t *testing.T) {
 					Manifest: "Dockerfile",
 					Path:     ".",
 				},
-				Command: "",
 				Deployment: manifest.ServiceDeployment{
 					Minimum: 50,
 					Maximum: 200,
@@ -149,7 +148,6 @@ func TestManifestLoad(t *testing.T) {
 					Manifest: "Dockerfile",
 					Path:     ".",
 				},
-				Command: "",
 				Deployment: manifest.ServiceDeployment{
 					Minimum: 50,
 					Maximum: 200,
@@ -184,7 +182,7 @@ func TestManifestLoad(t *testing.T) {
 			},
 			manifest.Service{
 				Name:    "inherit",
-				Command: "inherit",
+				Command: manifest.ServiceCommand{"sh", "-c", "inherit"},
 				Deployment: manifest.ServiceDeployment{
 					Minimum: 50,
 					Maximum: 200,
@@ -261,6 +259,7 @@ func TestManifestLoad(t *testing.T) {
 		"services.api.build",
 		"services.api.build.manifest",
 		"services.api.build.path",
+		"services.api.command",
 		"services.api.deployment",
 		"services.api.deployment.maximum",
 		"services.api.deployment.minimum",

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -12,7 +12,7 @@ type Service struct {
 
 	Agent       ServiceAgent      `yaml:"agent,omitempty"`
 	Build       ServiceBuild      `yaml:"build,omitempty"`
-	Command     string            `yaml:"command,omitempty"`
+	Command     ServiceCommand    `yaml:"command,omitempty"`
 	Deployment  ServiceDeployment `yaml:"deployment,omitempty"`
 	Domains     ServiceDomains    `yaml:"domain,omitempty"`
 	Drain       int               `yaml:"drain,omitempty"`
@@ -49,6 +49,8 @@ type ServiceBuild struct {
 	Manifest string   `yaml:"manifest,omitempty"`
 	Path     string   `yaml:"path,omitempty"`
 }
+
+type ServiceCommand []string
 
 type ServiceDeployment struct {
 	Maximum int `yaml:"maximum,omitempty"`

--- a/pkg/manifest/testdata/full.yml
+++ b/pkg/manifest/testdata/full.yml
@@ -14,6 +14,7 @@ services:
     build:
       manifest: Dockerfile2
       path: api
+    command: [bin/api, start]
     domain: foo.example.org
     deployment:
       minimum: 25

--- a/pkg/manifest/testdata/full.yml
+++ b/pkg/manifest/testdata/full.yml
@@ -45,7 +45,8 @@ services:
       cpu: 512
       memory: 1024
   foo:
-    command: foo
+    command:
+      - foo
     domain: baz.example.org, qux.example.org
     drain: 60
     health:

--- a/pkg/manifest/yaml.go
+++ b/pkg/manifest/yaml.go
@@ -166,6 +166,32 @@ func (v ServiceBuild) MarshalYAML() (interface{}, error) {
 	return v, nil
 }
 
+func (v *ServiceCommand) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var w interface{}
+
+	if err := unmarshal(&w); err != nil {
+		return err
+	}
+
+	switch t := w.(type) {
+	case []interface{}:
+		for _, s := range t {
+			switch st := s.(type) {
+			case string:
+				*v = append(*v, st)
+			default:
+				return fmt.Errorf("unknown type for service command: %T", st)
+			}
+		}
+	case string:
+		*v = ServiceCommand{"sh", "-c", t}
+	default:
+		return fmt.Errorf("unknown type for service command: %T", t)
+	}
+
+	return nil
+}
+
 func (v *ServiceDomains) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var w interface{}
 
@@ -182,7 +208,7 @@ func (v *ServiceDomains) UnmarshalYAML(unmarshal func(interface{}) error) error 
 					*v = append(*v, tst)
 				}
 			default:
-				return fmt.Errorf("unknown type for service domain: %T", s)
+				return fmt.Errorf("unknown type for service domain: %T", st)
 			}
 		}
 	case string:

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -1117,8 +1117,12 @@ func (p *Provider) generateTaskDefinition2(app, service string, opts structs.Pro
 		Privileged:        aws.Bool(s.Privileged),
 	}
 
-	if s.Command != "" {
-		cd.Command = []*string{aws.String("sh"), aws.String("-c"), aws.String(s.Command)}
+	if len(s.Command) > 0 {
+		cd.Command = []*string{}
+
+		for _, c := range s.Command {
+			cd.Command = append(cd.Command, aws.String(c))
+		}
 	}
 
 	req := &ecs.RegisterTaskDefinitionInput{

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -288,12 +288,8 @@ func (p *Provider) podSpecFromService(app, service, release string) (*ac.PodSpec
 		}
 
 		if s, _ := m.Service(service); s != nil {
-			if s.Command != "" {
-				parts, err := shellquote.Split(s.Command)
-				if err != nil {
-					return nil, err
-				}
-				c.Args = parts
+			if len(s.Command) > 0 {
+				c.Args = []string(s.Command)
 			}
 
 			for k, v := range s.EnvironmentDefaults() {


### PR DESCRIPTION
Adds support for an array format for a Service's `command:`

Currently, `command` is only supported as a string and is ultimately executed with `sh -c "$command"` to support bash-isms.

This change adds support for an array format:

```yaml
services:
  web:
    command: [bin/web, start]
```

or

```yaml
services:
  web:
    command:
      - bin/web
      - start
```

Using the array format will pass the command straight through to the container without wrapping it with `sh -c`