### PR TITLE
Keep any existing custom app tags that should supersede the Rack tags

### DIFF
--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -367,11 +367,18 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		"Version": p.Version,
 	}
 
-	customTags, err := p.getCustomRackTags(p.Rack)
+	customRackTags, err := p.getCustomTags(p.Rack)
 	if err != nil {
 		return err
 	} 
-	for k, v := range customTags {
+	customAppTags, err := p.getCustomTags(p.rackStack(r.App))
+	if err != nil {
+		return err
+	} 
+	for k, v := range customRackTags {
+		tags[k] = v
+	}
+	for k, v := range customAppTags {
 		tags[k] = v
 	}
 
@@ -386,7 +393,7 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 	return nil
 }
 
-func (p *Provider) getCustomRackTags(rackName string) (map[string]string, error) {
+func (p *Provider) getCustomTags(rackName string) (map[string]string, error) {
 	stack, err := p.describeStack(rackName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Rack tags should not overwrite existing custom app tags with the same name, so we pull them and update the tags map to be used after the Rack tags have been pulled in.