### PR TITLE
rack: provide support for FARGATE_SPOT

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -159,7 +159,7 @@
       "Type": "AWS::ECR::Repository",
       "Properties": {
         "ImageScanningConfiguration": {
-          "scanOnPush": "true"
+          "ScanOnPush": "true"
         }
       },
       "DeletionPolicy": "Retain"

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -7,11 +7,15 @@
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
     "BlankLogRetention": { "Fn::Equals": [ { "Ref": "LogRetention" }, "" ] },
     "BlankResourcePassword": { "Fn::Equals": [ { "Ref": "ResourcePassword" }, "" ] },
-    "FargateServices": { "Fn::Equals": [ { "Ref": "FargateServices" }, "Yes" ] },
-    "FargateTimers": { "Fn::Equals": [ { "Ref": "FargateTimers" }, "Yes" ] },
+    "FargateServicesEither": { "Fn::Or": [ { "Condition": "FargateServicesBase" }, { "Condition": "FargateServicesSpot" } ] },
+    "FargateServicesBase": { "Fn::Equals": [ { "Ref": "FargateServices" }, "Yes" ] },
+    "FargateServicesSpot": { "Fn::Equals": [ { "Ref": "FargateServices" }, "Spot" ] },
+    "FargateTimersEither": { "Fn::Or": [ { "Condition": "FargateTimersBase" }, { "Condition": "FargateTimersSpot" } ] },
+    "FargateTimersBase": { "Fn::Equals": [ { "Ref": "FargateTimers" }, "Yes" ] },
+    "FargateTimersSpot": { "Fn::Equals": [ { "Ref": "FargateTimers" }, "Spot" ] },
     "InternalDomains": { "Fn::Equals": [ { "Ref": "InternalDomains" }, "Yes" ] },
     "Isolate": { "Fn::And": [ { "Condition": "Private" }, { "Fn::Equals": [ { "Ref": "Isolate" }, "Yes" ] } ] },
-    "IsolateServices": { "Fn::Or": [ { "Condition": "FargateServices" }, { "Condition": "Isolate" } ] },
+    "IsolateServices": { "Fn::Or": [ { "Condition": "FargateServicesEither" }, { "Condition": "Isolate" } ] },
     "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] },
     "RackUrl": { "Fn::Equals": [ { "Ref": "RackUrl" }, "Yes" ] }
   },
@@ -23,7 +27,10 @@
       "Value": "{{ join .Manifest.Agents "," }}"
     },
     "FargateServices": {
-      "Value": { "Fn::If": [ "FargateServices", "Yes", "No" ] }
+      "Value": { "Fn::If": [ "FargateServicesBase", "Yes", "No" ] }
+    },
+    "FargateSpotServices": {
+      "Value": { "Fn::If": [ "FargateServicesSpot", "Yes", "No" ] }
     },
     "LogGroup": {
       "Value": { "Ref": "LogGroup" }
@@ -45,12 +52,12 @@
     "FargateServices": {
       "Type": "String",
       "Default": "No",
-      "AllowedValues": [ "Yes", "No" ]
+      "AllowedValues": [ "Yes", "Spot", "No" ]
     },
     "FargateTimers": {
       "Type": "String",
       "Default": "No",
-      "AllowedValues": [ "Yes", "No" ]
+      "AllowedValues": [ "Yes", "Spot", "No" ]
     },
     "IamPolicy": {
       "Type": "String",
@@ -235,7 +242,16 @@
         ] },
         "FARGATE"
       ] },
-      { "Condition": "FargateServices" }
+      { "Condition": "FargateServicesBase" }
+    ] },
+    "Service{{ upper .Name }}FargateSpot": { "Fn::Or": [
+      { "Fn::Equals": [
+        { "Fn::Select": [ 3,
+          { "Fn::Split": [ ",", { "Fn::Sub": [ "${Formation},", { "Formation": { "Fn::Join": [ ",", { "Ref": "{{ upper .Name }}Formation" } ] } } ] } ] }
+        ] },
+        "FARGATE_SPOT"
+      ] },
+      { "Condition": "FargateServicesSpot" }
     ] },
   {{ end }}
 {{ end }}
@@ -299,7 +315,7 @@
           {{ end }}
           "Count": { "Fn::Select": [ 0, { "Ref": "{{ upper .Name }}Formation" } ] },
           "Cpu": { "Fn::Select": [ 1, { "Ref": "{{ upper .Name }}Formation" } ] },
-          "Fargate": { "Fn::If": [ "Service{{ upper .Name }}Fargate", "Yes", "No" ] },
+          "Fargate": { "Fn::If": [ "Service{{ upper .Name }}Fargate", "Yes", { "Fn::If": [ "Service{{ upper .Name }}FargateSpot", "Spot", "No" ] } ] },
           "LoadBalancerAlgorithm": { "Ref": "LoadBalancerAlgorithm" },
           "LogGroup": { "Ref": "LogGroup" },
           "InternalDomains": { "Ref": "InternalDomains" },
@@ -342,16 +358,23 @@
           "ZipFile": { "Fn::Join": [ "\n", [
             "exports.handler = function(event, context, cb) {",
             "  var params = {",
+            { "Fn::If": [ "FargateTimersBase",
+              "  capacityProviderStrategy: [{capacityProvider: 'FARGATE'}],",
+              { "Fn::If": [ "FargateTimersSpot",
+                "  capacityProviderStrategy: [{capacityProvider: 'FARGATE_SPOT'}],",
+                ""
+              ] }
+            ] },            
             "    cluster: event.cluster,",
             "    taskDefinition: event.taskDefinition,",
             "    count: 1,",
-            { "Fn::If": [ "FargateTimers",
-              "    launchType: 'FARGATE',",
-              "    launchType: 'EC2',"
+            { "Fn::If": [ "Fn::Not": [ { "FargateTimersEither" } ],
+              "    launchType: 'EC2',",
+              ""
             ] },
             "    networkConfiguration: {",
             "      awsvpcConfiguration: {",
-            { "Fn::If": [ "FargateTimers",
+            { "Fn::If": [ "FargateTimersEither",
               "        assignPublicIp: 'ENABLED',",
               { "Ref": "AWS::NoValue" }
             ] },
@@ -432,7 +455,7 @@
         "Parameters": {
           "Cpu": { "Fn::Select": [ 1, { "Ref": "{{ upper .Service }}Formation" } ] },
           "ExecutionRole": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
-          "Fargate": { "Fn::If": [ "FargateTimers", "Yes", "No" ] },
+          "Fargate": { "Fn::If": [ "FargateTimersBase", "Yes", { "Fn::If": [ "FargateTimersSpot", "Spot", "No" ] } ] },
           "Launcher": { "Fn::GetAtt": [ "TimerLauncher", "Arn" ] },
           "LogGroup": { "Ref": "LogGroup" },
           "Memory": { "Fn::Select": [ 2, { "Ref": "{{ upper .Service }}Formation" } ] },

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -7,6 +7,8 @@
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
     "BlankLogRetention": { "Fn::Equals": [ { "Ref": "LogRetention" }, "" ] },
     "BlankResourcePassword": { "Fn::Equals": [ { "Ref": "ResourcePassword" }, "" ] },
+    "EC2Services": { "Fn::Not": [ { "Condition": "FargateServiceEither" } ] },
+    "EC2Timers": { "Fn::Not": [ { "Condition": "FargateTimersEither" } ] },
     "FargateServicesEither": { "Fn::Or": [ { "Condition": "FargateServicesBase" }, { "Condition": "FargateServicesSpot" } ] },
     "FargateServicesBase": { "Fn::Equals": [ { "Ref": "FargateServices" }, "Yes" ] },
     "FargateServicesSpot": { "Fn::Equals": [ { "Ref": "FargateServices" }, "Spot" ] },
@@ -368,7 +370,7 @@
             "    cluster: event.cluster,",
             "    taskDefinition: event.taskDefinition,",
             "    count: 1,",
-            { "Fn::If": [ "Fn::Not": [ { "FargateTimersEither" } ],
+            { "Fn::If": [ "EC2Timers",
               "    launchType: 'EC2',",
               ""
             ] },

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -7,7 +7,7 @@
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
     "BlankLogRetention": { "Fn::Equals": [ { "Ref": "LogRetention" }, "" ] },
     "BlankResourcePassword": { "Fn::Equals": [ { "Ref": "ResourcePassword" }, "" ] },
-    "EC2Services": { "Fn::Not": [ { "Condition": "FargateServiceEither" } ] },
+    "EC2Services": { "Fn::Not": [ { "Condition": "FargateServicesEither" } ] },
     "EC2Timers": { "Fn::Not": [ { "Condition": "FargateTimersEither" } ] },
     "FargateServicesEither": { "Fn::Or": [ { "Condition": "FargateServicesBase" }, { "Condition": "FargateServicesSpot" } ] },
     "FargateServicesBase": { "Fn::Equals": [ { "Ref": "FargateServices" }, "Yes" ] },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2431,7 +2431,13 @@
       }
     },
     "Cluster": {
-      "Type": "AWS::ECS::Cluster"
+      "Type": "AWS::ECS::Cluster",
+      "Properties": {
+        "CapacityProviders": [
+          "FARGATE",
+          "FARGATE_SPOT"
+        ]
+      }
     },
     "ServiceRole": {
       "Type": "AWS::IAM::Role",

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -2,11 +2,13 @@
   {
     "AWSTemplateFormatVersion" : "2010-09-09",
     "Conditions": {
-      "Fargate": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
+      "FargateEither": { "Fn::Or": [ { "Condition": "FargateBase" }, { "Condition": "FargateSpot" } ] },
+      "FargateBase": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
+      "FargateSpot": { "Fn::Equals": [ { "Ref": "Fargate" }, "Spot" ] },
       "InternalDomains": { "Fn::Equals": [ { "Ref": "InternalDomains" }, "Yes" ] },
       "InternalDomainsAndRouteHttp": { "Fn::And": [ { "Condition": "InternalDomains" }, { "Condition": "RouteHttp" } ] },
       "Isolate": { "Fn::And": [ { "Condition": "Private" }, { "Fn::Equals": [ { "Ref": "Isolate" }, "Yes" ] } ] },
-      "IsolateServices": { "Fn::Or": [ { "Condition": "Fargate" }, { "Condition": "Isolate" } ] },
+      "IsolateServices": { "Fn::Or": [ { "Condition": "FargateEither" }, { "Condition": "Isolate" } ] },
       "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] },
       "RackUrl": { "Fn::Equals": [ { "Ref": "RackUrl" }, "Yes" ] },
       "RouteHttp": { "Fn::Equals": [ { "Ref": "RedirectHttps" }, "No" ] },
@@ -28,7 +30,10 @@
         },
       {{ end }}
       "Fargate": {
-        "Value": { "Fn::If": [ "Fargate", "Yes", "No" ] }
+        "Value": { "Fn::If": [ "FargateBase", "Yes", "No" ] }
+      },
+      "FargateSpot": {
+        "Value": { "Fn::If": [ "FargateSpot", "Yes", "No" ] }
       },
       "SecurityGroup": {
         "Condition": "IsolateServices",
@@ -51,7 +56,7 @@
       "Fargate": {
         "Type": "String",
         "Default": "No",
-        "AllowedValues": [ "Yes", "No" ]
+        "AllowedValues": [ "Yes", "Spot", "No" ]
       },
       "InternalDomains": {
         "Type": "String",
@@ -421,7 +426,7 @@
               "DesiredCount": { "Ref": "Count" },
             {{ end }}
             "SchedulingStrategy": "REPLICA",
-            "PlacementStrategies": { "Fn::If": [ "Fargate",
+            "PlacementStrategies": { "Fn::If": [ "FargateEither",
               { "Ref": "AWS::NoValue" },
               [
                 { "Type": "spread", "Field": "attribute:ecs.availability-zone" },
@@ -429,7 +434,7 @@
               ]
             ] },
           {{ end }}
-          "LaunchType": { "Fn::If": [ "Fargate", "FARGATE", { "Ref": "AWS::NoValue" } ] },
+          "LaunchType": { "Fn::If": [ "FargateBase", "FARGATE", { "Ref": "AWS::NoValue" } ] },
           "NetworkConfiguration": { "Fn::If": [ "IsolateServices",
             {
               "AwsvpcConfiguration": {
@@ -531,12 +536,12 @@
               "Ulimits": [ { "Name": "nofile", "SoftLimit": "1024000", "HardLimit": "1024000" } ]
             }
           ],
-          "Cpu": { "Fn::If": [ "Fargate", { "Ref": "Cpu" }, { "Ref": "AWS::NoValue" } ] },
+          "Cpu": { "Fn::If": [ "FargateEither", { "Ref": "Cpu" }, { "Ref": "AWS::NoValue" } ] },
           "ExecutionRoleArn": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
           "Family": { "Fn::Sub": "${AWS::StackName}-service-{{.Name}}" },
-          "Memory": { "Fn::If": [ "Fargate", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },
+          "Memory": { "Fn::If": [ "FargateEither", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },
           "NetworkMode": { "Fn::If": [ "IsolateServices", "awsvpc", { "Ref": "AWS::NoValue" } ] },
-          "RequiresCompatibilities": [ { "Fn::If": [ "Fargate", "FARGATE", { "Ref": "AWS::NoValue" } ] } ],
+          "RequiresCompatibilities": [ { "Fn::If": [ "FargateEither", "FARGATE", { "Ref": "AWS::NoValue" } ] } ],
           "TaskRoleArn": { "Ref": "Role" },
           "Volumes": [
             {{ range $i, $v := .Volumes }}

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -409,11 +409,13 @@
         "Properties": {
           "CapacityProviderStrategy": { "Fn::If": [ "FargateBase",
             [{
-              "CapacityProvider": "FARGATE"
+              "CapacityProvider": "FARGATE",
+              "Weight": 1
             }],
             { "Fn::If": [ "FargateSpot",
               [{
-                "CapacityProvider": "FARGATE_SPOT"
+                "CapacityProvider": "FARGATE_SPOT",
+                "Weight": 1
               }],
               { "Ref": "AWS::NoValue" }
             ] }

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -407,14 +407,14 @@
           "DependsOn": "BalancerListenerRule443{{ if .Domain }}Domain0{{ end }}",
         {{ end }}
         "Properties": {
-          "CapacityProviderStrategy" : { "Fn::If": [ "FargateBase",
-            {
+          "CapacityProviderStrategy": { "Fn::If": [ "FargateBase",
+            [{
               "CapacityProvider": "FARGATE"
-            },
+            }],
             { "Fn::If": [ "FargateSpot",
-              {
+              [{
                 "CapacityProvider": "FARGATE_SPOT"
-              },
+              }],
               { "Ref": "AWS::NoValue" }
             ] }
           ] },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -2,6 +2,7 @@
   {
     "AWSTemplateFormatVersion" : "2010-09-09",
     "Conditions": {
+      "EC2Launch": { "Fn::Not": [ { "Condition": "FargateEither" } ] },
       "FargateEither": { "Fn::Or": [ { "Condition": "FargateBase" }, { "Condition": "FargateSpot" } ] },
       "FargateBase": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
       "FargateSpot": { "Fn::Equals": [ { "Ref": "Fargate" }, "Spot" ] },
@@ -406,6 +407,17 @@
           "DependsOn": "BalancerListenerRule443{{ if .Domain }}Domain0{{ end }}",
         {{ end }}
         "Properties": {
+          "CapacityProviderStrategy" : { "Fn::If": [ "FargateBase",
+            {
+              "CapacityProvider": "FARGATE"
+            },
+            { "Fn::If": [ "FargateSpot",
+              {
+                "CapacityProvider": "FARGATE_SPOT"
+              },
+              { "Ref": "AWS::NoValue" }
+            ] }
+          ] },
           "Cluster": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } },
           "DeploymentConfiguration": {
             "MinimumHealthyPercent": "{{$.DeploymentMin}}",
@@ -434,7 +446,7 @@
               ]
             ] },
           {{ end }}
-          "LaunchType": { "Fn::If": [ "FargateBase", "FARGATE", { "Ref": "AWS::NoValue" } ] },
+          "LaunchType": { "Fn::If": [ "EC2Launch", "EC2", { "Ref": "AWS::NoValue" } ] },
           "NetworkConfiguration": { "Fn::If": [ "IsolateServices",
             {
               "AwsvpcConfiguration": {

--- a/provider/aws/formation/timer.json.tmpl
+++ b/provider/aws/formation/timer.json.tmpl
@@ -91,7 +91,7 @@
               { "Fn::Join": [ "", [ "{ \"cluster\": \"", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } }, "\", \"taskDefinition\": \"", { "Ref": "TaskDefinition" }, "\" }" ] ] },
               { "Ref": "AWS::NoValue" }
             ] },
-            "RoleArn": { "Fn::If": [ "FargatEither",
+            "RoleArn": { "Fn::If": [ "FargateEither",
               { "Ref": "AWS::NoValue" },
               { "Ref": "Role" }
             ] }

--- a/provider/aws/formation/timer.json.tmpl
+++ b/provider/aws/formation/timer.json.tmpl
@@ -2,12 +2,17 @@
   {
     "AWSTemplateFormatVersion" : "2010-09-09",
     "Conditions": {
-      "Fargate": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
+      "FargateEither": { "Fn::Or": [ { "Condition": "FargateBase" }, { "Condition": "FargateSpot" } ] },
+      "FargateBase": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
+      "FargateSpot": { "Fn::Equals": [ { "Ref": "Fargate" }, "Spot" ] },
       "RackUrl": { "Fn::Equals": [ { "Ref": "RackUrl" }, "Yes" ] }
     },
     "Outputs": {
       "Fargate": {
-        "Value": { "Fn::If": [ "Fargate", "Yes", "No" ] }
+        "Value": { "Fn::If": [ "FargateBase", "Yes", "No" ] }
+      },
+      "FargateSpot": {
+        "Value": { "Fn::If": [ "FargateSpot", "Yes", "No" ] }
       }
     },
     "Parameters" : {
@@ -20,7 +25,7 @@
       "Fargate": {
         "Type": "String",
         "Default": "No",
-        "AllowedValues": [ "Yes", "No" ]
+        "AllowedValues": [ "Yes", "Spot", "No" ]
       },
       "Launcher": {
         "Type": "String"
@@ -73,20 +78,20 @@
         "Properties": {
           "ScheduleExpression": "cron({{.Cron}})",
           "Targets": [ {
-            "Arn": { "Fn::If": [ "Fargate",
+            "Arn": { "Fn::If": [ "FargateEither",
               { "Ref": "Launcher" },
               { "Fn::Sub": [ "arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${Cluster}", { "Cluster": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } } } ] }
             ] },
-            "EcsParameters": { "Fn::If": [ "Fargate",
+            "EcsParameters": { "Fn::If": [ "FargateEither",
               { "Ref": "AWS::NoValue" },
               { "TaskCount": "1", "TaskDefinitionArn": { "Ref": "TaskDefinition" } }
             ] },
             "Id": "{{.Name}}",
-            "Input": { "Fn::If": [ "Fargate",
+            "Input": { "Fn::If": [ "FargateEither",
               { "Fn::Join": [ "", [ "{ \"cluster\": \"", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } }, "\", \"taskDefinition\": \"", { "Ref": "TaskDefinition" }, "\" }" ] ] },
               { "Ref": "AWS::NoValue" }
             ] },
-            "RoleArn": { "Fn::If": [ "Fargate",
+            "RoleArn": { "Fn::If": [ "FargatEither",
               { "Ref": "AWS::NoValue" },
               { "Ref": "Role" }
             ] }
@@ -150,12 +155,12 @@
               }
             {{ end }}
           ],
-          "Cpu": { "Fn::If": [ "Fargate", { "Ref": "Cpu" }, { "Ref": "AWS::NoValue" } ] },
+          "Cpu": { "Fn::If": [ "FargateEither", { "Ref": "Cpu" }, { "Ref": "AWS::NoValue" } ] },
           "ExecutionRoleArn": { "Ref": "ExecutionRole" },
           "Family": { "Fn::Sub": "${AWS::StackName}-timer-{{.Name}}" },
-          "Memory": { "Fn::If": [ "Fargate", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },
-          "NetworkMode": { "Fn::If": [ "Fargate", "awsvpc", { "Ref": "AWS::NoValue" } ] },
-          "RequiresCompatibilities": [ { "Fn::If": [ "Fargate", "FARGATE", { "Ref": "AWS::NoValue" } ] } ],
+          "Memory": { "Fn::If": [ "FargateEither", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },
+          "NetworkMode": { "Fn::If": [ "FargateEither", "awsvpc", { "Ref": "AWS::NoValue" } ] },
+          "RequiresCompatibilities": [ { "Fn::If": [ "FargateEither", "FARGATE", { "Ref": "AWS::NoValue" } ] } ],
           "TaskRoleArn": { "Ref": "ServiceRole" },
           "Volumes": [
             {{ range $i, $v := ($.Manifest.Service .Service).Volumes }}


### PR DESCRIPTION
You can now set `FargateServices` and `FargateTimers` to `Spot` as well as `Yes` or `No`. That would enable Spot support.  The old style Formation method also works if you specify `FARGATE_SPOT`.