### PR TITLE
Allow running processes in such a way that stop signals are preserved

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -22,6 +22,7 @@ func init() {
 			flagRack,
 			flagApp,
 			stdcli.BoolFlag("detach", "d", "run process in the background"),
+			stdcli.BoolFlag("bare", "b", "run the command directly on the instance without running in a shell"),
 			stdcli.IntFlag("timeout", "t", "timeout"),
 			entrypoint,
 		),
@@ -52,6 +53,8 @@ func Run(rack sdk.Interface, c *stdcli.Context) error {
 	if t := c.Int("timeout"); t > 0 {
 		timeout = t
 	}
+
+	opts.Bare = options.Bool(c.Bool("bare"))
 
 	if w, h, err := c.TerminalSize(); err == nil {
 		opts.Height = options.Int(h)

--- a/pkg/structs/process.go
+++ b/pkg/structs/process.go
@@ -37,6 +37,7 @@ type ProcessListOptions struct {
 }
 
 type ProcessRunOptions struct {
+	Bare        *bool             `header:"Bare" default:"false"`
 	Command     *string           `header:"Command"`
 	Environment map[string]string `header:"Environment"`
 	Height      *int              `header:"Height"`


### PR DESCRIPTION
One-off processes, including `convox run`, `convox exec`, and timers don't pass stop signals to processes properly.

For exec and non-detached runs, this makes sense, as Convox runs a `sleep {timeout}` command in the container and then attaches a secondary process to it (a la `docker exec`). But for timers and detached runs, SIGTERM is never received by the process. The problem stems from the use of `["sh", "-c", command]`, as `sh -c` does not propagate signals to apps. 

This [violates 12 factor](https://12factor.net/disposability) as processes aren't given the opportunity to run any cleanup tasks. While apps should also be robust against the occasional SIGTERM, Convox should do it's best to allow more graceful stoppage.

Our use-case revolves around spinning up ETL pipelines on regular intervals, but really any worker process use-case that that wants to use Convox's autoscaling features to create processes on-demand will benefit from this. 

This change allows you to disable the shell wrapper for detached runs. Simply removing `sh -c` would likely be a breaking change for users who have come to expect their commands to be run in a shell, so instead I put the behavior behind a flag. I called is flag "bare" but I don't love the name, perhaps `[--no]-shell`, `--shell=false` or similar would be better. Alternatively, we could use a rack parameter, or we could make this the default behavior going forward with a version check. Looking for guidance on this.

```bash
convox run --detach app python test.py # current behavior, passes ['sh', '-c', 'python test.py'] to container
convox run --detach --bare app python test.py # passes ['python', 'test.py'] directly to container
```

I only added support to the `aws` provider, as the `k8s` provider (and `local` by extension) [already behave this way](https://github.com/convox/rack/blob/master/provider/k8s/process.go#L367).

Note this MR does not fix [the same issue for timers](https://github.com/convox/rack/blob/master/provider/aws/formation/timer.json.tmpl#L107), as I wasn't sure of a good backwards-compatible solution.

By the way, detached runs don't actually support the timeout option. This could be resolved by using the [unix timeout command](https://www.man7.org/linux/man-pages/man1/timeout.1.html). I could add that to this MR also.