### PR TITLE
Fix inconsistent vendoring error when building the cli

### DIFF
--- a/cmd/convox/Makefile
+++ b/cmd/convox/Makefile
@@ -19,7 +19,7 @@ clean:
 package: package-deps package-gopath $(pkg_darwin) $(pkg_linux) $(pkg_windows) package-export
 
 package-deps:
-	go get -u github.com/crazy-max/xgo
+	go install github.com/crazy-max/xgo@v0.7.5
 	mkdir -p pkg
 
 # copy finished packages out if running inside a container

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/andybalholm/cascadia v0.0.0-20161224141413-349dd0209470 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/convox/inotify v0.0.0-20170313035821-b56f5149b5c6 // indirect
-	github.com/crazy-max/xgo v0.7.4 // indirect
 	github.com/docker/spdystream v0.0.0-20170912183627-bc6354cbbc29 // indirect
 	github.com/elazarl/goproxy v0.0.0-20210801061803-8e322dfb79c4 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
@@ -68,7 +67,6 @@ require (
 	github.com/headzoo/ut v0.0.0-20181013193318-a13b5a7a02ca // indirect
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
-	github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/moby/moby v1.13.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,6 @@ github.com/convox/version v0.0.0-20160822184233-ffefa0d565d2/go.mod h1:s8HHEf4LL
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/crazy-max/xgo v0.7.4 h1:3MJ6dADFt1+Pt+9t0H738H9l6mrxbAV2Anp66CWBF8c=
-github.com/crazy-max/xgo v0.7.4/go.mod h1:m/aqfKaN/cYzfw+Pzk7Mk0tkmShg3/rCS4Zdhdugi4o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -306,8 +304,6 @@ github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
-github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 h1:AYzjK/SHz6m6mg5iuFwkrAhCc14jvCpW9d6frC9iDPE=
-github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7/go.mod h1:iYGcTYIPUvEWhFo6aKUuLchs+AV4ssYdyuBbQJZGcBk=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.7.7/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.7.8/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -121,8 +121,6 @@ github.com/convox/u2f/u2ftoken
 # github.com/convox/version v0.0.0-20160822184233-ffefa0d565d2
 ## explicit
 github.com/convox/version
-# github.com/crazy-max/xgo v0.7.4
-## explicit
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/docker/docker v1.13.1
@@ -265,8 +263,6 @@ github.com/joho/godotenv
 # github.com/json-iterator/go v1.1.5
 ## explicit
 github.com/json-iterator/go
-# github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7
-## explicit
 # github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 ## explicit
 github.com/kballard/go-shellquote


### PR DESCRIPTION
Tidy up go modules and install `xgo` without modifying `go.mod` to avoid `inconsistent vendoring` errors when building the cli.

Edit: build was  successfully created https://github.com/convox/rack/releases/tag/20211124183359-fix-build