### PR TITLE
Add support to schedule the rack to shutdown and up

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -142,6 +142,10 @@ func RackInstall(rack sdk.Interface, c *stdcli.Context) error {
 		opts.Parameters[parts[0]] = parts[1]
 	}
 
+	if err := validateParams(opts.Parameters); err != nil {
+		return err
+	}
+
 	p, err := pv.FromName(c.Arg(0))
 	if err != nil {
 		return err
@@ -252,6 +256,10 @@ func RackParamsSet(rack sdk.Interface, c *stdcli.Context) error {
 		}
 
 		opts.Parameters[parts[0]] = parts[1]
+	}
+
+	if err := validateParams(opts.Parameters); err != nil {
+		return err
 	}
 
 	c.Startf("Updating parameters")
@@ -428,4 +436,14 @@ func RackWait(rack sdk.Interface, c *stdcli.Context) error {
 	}
 
 	return c.OK()
+}
+
+// validateParams validate parameters for install and update rack
+func validateParams(params map[string]string) error {
+	srdown, srup := params["ScheduleRackScaleDown"], params["ScheduleRackScaleUp"]
+	if (srdown == "" || srup == "") && (srdown != "" || srup != "") {
+		return fmt.Errorf("to configure ScheduleAction you need both ScheduleRackScaleDown and ScheduleRackScaleUp parameters")
+	}
+
+	return nil
 }

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -113,6 +113,12 @@
     "RegionHasEFSAndThirdAvailabilityZoneAndHighAvailability": {
       "Fn::And": [ { "Condition": "RegionHasEFS" }, { "Condition": "ThirdAvailabilityZone" }, { "Condition": "HighAvailability" } ]
     },
+    "SetScheduleRackScale": { "Fn::Not" : [{
+      "Fn::And": [
+        { "Fn::Equals": [ { "Ref": "ScheduleRackScaleDown" }, "" ] },
+        { "Fn::Equals": [ { "Ref": "ScheduleRackScaleUp" }, "" ] }
+      ]}
+    ] },
     "SpotInstances": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SpotInstanceBid"}, "" ] } ] },
     "SwapEnabled": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SwapSize" }, "0" ] } ] },
     "ThirdAvailabilityZone": { "Fn::And": [
@@ -725,6 +731,16 @@
       "Default": "",
       "Description": "The security groups (comma delimited) to assign to the rack router.",
       "Type": "CommaDelimitedList"
+    },
+    "ScheduleRackScaleDown": {
+      "Type": "String",
+      "Description": "The recurring schedule for when the rack will be shutdown. This format consists of five fields separated by white spaces: [Minute] [Hour] [Day_of_Month] [Month_of_Year] [Day_of_Week]",
+      "Default": ""
+    },
+    "ScheduleRackScaleUp": {
+      "Type": "String",
+      "Description": "The recurring schedule for when the rack will start. This format consists of five fields separated by white spaces: [Minute] [Hour] [Day_of_Month] [Month_of_Year] [Day_of_Week]",
+      "Default": ""
     },
     "SpotInstanceBid": {
       "Default": "",
@@ -1720,6 +1736,49 @@
           ],
           "WaitOnResourceSignals": "true"
         }
+      }
+    },
+    "InstancesScheduleRackScaleDown":{
+      "Type":"AWS::AutoScaling::ScheduledAction",
+      "Condition": "SetScheduleRackScale",
+      "Properties":{
+        "AutoScalingGroupName": { "Ref": "Instances" },
+        "MaxSize": "0",
+        "MinSize": "0",
+        "Recurrence": { "Ref": "ScheduleRackScaleDown" }
+      }
+    },
+    "InstancesScheduleRackScaleUp":{
+      "Type":"AWS::AutoScaling::ScheduledAction",
+      "Condition": "SetScheduleRackScale",
+      "Properties":{
+        "AutoScalingGroupName": { "Ref": "Instances" },
+        "DesiredCapacity" : { "Fn::If": [ "SpotInstances", { "Ref": "AWS::NoValue" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
+        "MinSize" : { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
+        "MaxSize" : { "Fn::If": [ "HighAvailability", "1000", "3" ] },
+        "Recurrence": { "Ref": "ScheduleRackScaleUp" }
+      }
+    },
+    "BuildScheduleRackScaleDown":{
+      "Type":"AWS::AutoScaling::ScheduledAction",
+      "Condition": "SetScheduleRackScale",
+      "Properties":{
+        "AutoScalingGroupName": { "Ref": "BuildInstances" },
+        "DesiredCapacity": "0",
+        "MaxSize": "0",
+        "MinSize": "0",
+        "Recurrence": { "Ref": "ScheduleRackScaleDown" }
+      }
+    },
+    "BuildScheduleRackScaleUp":{
+      "Type":"AWS::AutoScaling::ScheduledAction",
+      "Condition": "SetScheduleRackScale",
+      "Properties":{
+        "AutoScalingGroupName": { "Ref": "BuildInstances" },
+        "DesiredCapacity": "1",
+        "MaxSize":"2",
+        "MinSize":"1",
+        "Recurrence": { "Ref": "ScheduleRackScaleUp" }
       }
     },
     "InstancesAutoscaler": {


### PR DESCRIPTION
User can pass a cron to shutdown the rack and another cron to set up the rack.

```
convox rack params set ScheduleRackScaleDown="0 18 * * 5" ScheduleRackScaleUp="0 9 * * 1"
```