### PR TITLE
Adds an app param to configure health check success codes

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -92,6 +92,11 @@
       "Description": "Type of routing algorithm to apply to the load balancer for this application",
       "AllowedValues": [ "round_robin", "least_outstanding_requests" ]
     },
+    "LoadBalancerSuccessCodes": {
+      "Type": "String",
+      "Default": "200-399,401",
+      "Description": "Specifies the HTTP codes that healthy targets must use when responding to an HTTP health check.  You can specify values between 200 and 499, and the default value is \"200-399,401\". You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\")."
+    },
     "LogBucket": {
       "Type": "String",
       "Default": ""
@@ -332,6 +337,7 @@
           "Cpu": { "Fn::Select": [ 1, { "Ref": "{{ upper .Name }}Formation" } ] },
           "Fargate": { "Fn::If": [ "Service{{ upper .Name }}Fargate", "Yes", { "Fn::If": [ "Service{{ upper .Name }}FargateSpot", "Spot", "No" ] } ] },
           "LoadBalancerAlgorithm": { "Ref": "LoadBalancerAlgorithm" },
+          "LoadBalancerSuccessCodes": { "Ref": "LoadBalancerSuccessCodes" },
           "LogGroup": { "Ref": "LogGroup" },
           "InternalDomains": { "Ref": "InternalDomains" },
           "Isolate": { "Fn::If": [ "IsolateServices", "Yes", "No" ] },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -81,6 +81,11 @@
         "Description": "Type of routing algorithm to apply to the load balancer for this application",
         "AllowedValues": [ "round_robin", "least_outstanding_requests" ]
       },
+      "LoadBalancerSuccessCodes": {
+        "Type": "String",
+        "Default": "200-399,401",
+        "Description": "Specifies the HTTP codes that healthy targets must use when responding to an HTTP health check.  You can specify values between 200 and 499, and the default value is \"200-399,401\". You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\")."
+      },
       "LogGroup": {
         "Type": "String"
       },
@@ -188,7 +193,7 @@
             "HealthyThresholdCount": "2",
             "UnhealthyThresholdCount": "2",
             "HealthCheckPath": "{{.Health.Path}}",
-            "Matcher": { "HttpCode": "200-399,401" },
+            "Matcher": { "HttpCode": { "Ref": "LoadBalancerSuccessCodes" } },
             "Port": "{{.Port.Port}}",
             "Protocol": "{{ upcase .Port.Scheme }}",
             "TargetGroupAttributes": [


### PR DESCRIPTION
Solves an issue for a customer trying to run a Squid proxy, which only returns a 400 code when the service is healthy.