### PR TITLE
Build the binary as statically linked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage.txt
 profile.out
 /monitor
 /rack
+cmd/convox/pkg

--- a/cmd/convox/Makefile
+++ b/cmd/convox/Makefile
@@ -13,12 +13,11 @@ build:
 
 package:
 	mkdir -p pkg/
-	export CGO_ENABLED=0
-	env GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o $(pkg_linux)
-	env GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -o $(pkg_linux_arm64)
-	env GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o $(pkg_darwin)
-	env GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -o $(pkg_darwin_arm64)
-	env GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o $(pkg_windows)
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o $(pkg_linux)
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -o $(pkg_linux_arm64)
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o $(pkg_darwin)
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -o $(pkg_darwin_arm64)
+	env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o $(pkg_windows)
 
 release: package
 	aws s3 cp $(pkg_darwin) s3://convox/release/$(VERSION)/cli/darwin/convox --acl public-read


### PR DESCRIPTION
The binary was not being built as statically linked but as dynamically linked.
This was causing errors on Alpine.