### PR TITLE
Add s3 SSL only policy and assign lambdas to the rack VPC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,4 +173,4 @@ commands:
     steps:
       - run:
           command: ci/uninstall.sh
-          no_output_timeout: 30m
+          no_output_timeout: 90m

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -422,6 +422,15 @@
             "  });",
             "};"
           ] ] }
+        },
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            { "Fn::ImportValue": { "Fn::Sub": "${Rack}:InstancesSecurityGroup" }}
+          ],
+          "SubnetIds": [
+            { "Fn::ImportValue": { "Fn::Sub": "${Rack}:SubnetPrivate0" }},
+            { "Fn::ImportValue": { "Fn::Sub": "${Rack}:SubnetPrivate1" }}
+          ]
         }
       }
     },
@@ -435,7 +444,10 @@
             { "Effect": "Allow", "Action": [ "sts:AssumeRole" ], "Principal": { "Service": [ "lambda.amazonaws.com" ] } }
           ]
         },
-        "ManagedPolicyArns": [ { "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole" } ],
+        "ManagedPolicyArns": [
+          { "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole" },
+          { "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole" }
+        ],
         "Path": "/convox/",
         "Policies": [
           {
@@ -521,6 +533,39 @@
         { "Key": "system", "Value": "convox" },
         { "Key": "app", "Value": { "Ref": "AWS::StackName" } }
       ]
+    }
+  },
+  "SettingsPolicy": {
+    "Type": "AWS::S3::BucketPolicy",
+    "Properties": {
+      "Bucket": { "Ref": "Settings" },
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "AllowSSLRequestsOnly",
+            "Action": "s3:*",
+            "Effect": "Deny",
+            "Resource": [
+              { "Fn::GetAtt": ["Settings", "Arn"]},
+              {
+                "Fn::Sub": [
+                  "${bucket}/*",
+                  {
+                    "bucket": { "Fn::GetAtt": ["Settings", "Arn"] }
+                  }
+                ]
+              }
+            ],
+            "Condition": {
+              "Bool": {
+                "aws:SecureTransport": "false"
+              }
+            },
+            "Principal": "*"
+          }
+        ]
+      }
     }
   },
 {{ end }}

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -868,6 +868,15 @@
       }
     },
     "CustomTopic": {
+      "DependsOn": [
+        "RouteDefault",
+        "RouteDefaultPrivate0",
+        "RouteDefaultPrivate1",
+        "Subnet0Routes",
+        "Subnet1Routes",
+        "SubnetPrivate1Routes",
+        "SubnetPrivate0Routes"
+     ],
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -445,12 +445,10 @@
       }
     },
     "SubnetPrivate0": {
-      "Condition": "Private",
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:SubnetPrivate0" } },
       "Value": { "Ref": "SubnetPrivate0" }
     },
     "SubnetPrivate1": {
-      "Condition": "Private",
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:SubnetPrivate1" } },
       "Value": { "Ref": "SubnetPrivate1" }
     },
@@ -845,6 +843,9 @@
             }
           ]
         },
+        "ManagedPolicyArns": [
+          { "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole" }
+        ],
         "Path": "/convox/",
         "Policies": [
           {
@@ -878,7 +879,16 @@
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "CustomTopicRole", "Arn" ] },
         "Runtime": "nodejs14.x",
-        "Timeout": "300"
+        "Timeout": "300",
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            { "Fn::If": [ "BlankInstanceSecurityGroup", { "Ref": "InstancesSecurity" }, { "Ref": "InstanceSecurityGroup" }]}
+          ],
+          "SubnetIds": [
+            {"Ref": "SubnetPrivate0"},
+            {"Ref": "SubnetPrivate1"}
+          ]
+        }
       }
     },
     "Vpc": {
@@ -921,7 +931,6 @@
       }
     },
     "Nat0": {
-      "Condition": "Private",
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
         "AllocationId": { "Fn::GetAtt": [ "NatAddress0", "AllocationId" ] },
@@ -929,7 +938,6 @@
       }
     },
     "Nat1": {
-      "Condition": "Private",
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
         "AllocationId": { "Fn::GetAtt": [ "NatAddress1", "AllocationId" ] },
@@ -945,14 +953,12 @@
       }
     },
     "NatAddress0": {
-      "Condition": "Private",
       "Type": "AWS::EC2::EIP",
       "Properties": {
         "Domain": "vpc"
       }
     },
     "NatAddress1": {
-      "Condition": "Private",
       "Type": "AWS::EC2::EIP",
       "Properties": {
         "Domain": "vpc"
@@ -1051,7 +1057,6 @@
       }
     },
     "SubnetPrivate0": {
-      "Condition": "Private",
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "Tags": [ { "Key": "Name", "Value": { "Fn::Join": [ " ", [ { "Ref": "AWS::StackName" }, "private", "0" ] ] } } ],
@@ -1067,7 +1072,6 @@
       }
     },
     "SubnetPrivate1": {
-      "Condition": "Private",
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "Tags": [ { "Key": "Name", "Value": { "Fn::Join": [ " ", [ { "Ref": "AWS::StackName" }, "private", "1" ] ] } } ],
@@ -1125,7 +1129,6 @@
       }
     },
     "RouteTablePrivate0": {
-      "Condition": "Private",
       "DependsOn": [ "Nat0" ],
       "Type": "AWS::EC2::RouteTable",
       "Properties": {
@@ -1139,7 +1142,6 @@
       }
     },
     "RouteTablePrivate1": {
-      "Condition": "Private",
       "DependsOn": [ "Nat1" ],
       "Type": "AWS::EC2::RouteTable",
       "Properties": {
@@ -1167,7 +1169,6 @@
       }
     },
     "RouteDefaultPrivate0": {
-      "Condition": "Private",
       "Type": "AWS::EC2::Route",
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
@@ -1176,7 +1177,6 @@
       }
     },
     "RouteDefaultPrivate1": {
-      "Condition": "Private",
       "Type": "AWS::EC2::Route",
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
@@ -1218,7 +1218,6 @@
       }
     },
     "SubnetPrivate0Routes": {
-      "Condition": "Private",
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {
         "SubnetId": { "Ref": "SubnetPrivate0" },
@@ -1226,7 +1225,6 @@
       }
     },
     "SubnetPrivate1Routes": {
-      "Condition": "Private",
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {
         "SubnetId": { "Ref": "SubnetPrivate1" },
@@ -1801,7 +1799,16 @@
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
         "Runtime": "go1.x",
-        "Timeout": "60"
+        "Timeout": "60",
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            { "Fn::If": [ "BlankInstanceSecurityGroup", { "Ref": "InstancesSecurity" }, { "Ref": "InstanceSecurityGroup" }]}
+          ],
+          "SubnetIds": [
+            { "Ref": "SubnetPrivate0"},
+            { "Ref": "SubnetPrivate1"}
+          ]
+        }
       }
     },
     "InstancesAutoscalerPermission": {
@@ -1919,7 +1926,16 @@
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "InstancesLifecycleHandlerRole", "Arn" ] },
         "Runtime": "go1.x",
-        "Timeout": "300"
+        "Timeout": "300",
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            { "Fn::If": [ "BlankInstanceSecurityGroup", { "Ref": "InstancesSecurity" }, { "Ref": "InstanceSecurityGroup" }]}
+          ],
+          "SubnetIds": [
+            { "Ref": "SubnetPrivate0"},
+            { "Ref": "SubnetPrivate1"}
+          ]
+        }
       }
     },
     "InstancesLifecycleHandlerPermission": {
@@ -1944,6 +1960,9 @@
             }
           ]
         },
+        "ManagedPolicyArns": [
+          { "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole" }
+        ],
         "Path": "/convox/",
         "Policies": [
           {
@@ -3106,6 +3125,28 @@
               "Principal": { "AWS": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "ELBAccountId" ] } },
               "Action": "s3:PutObject",
               "Resource": { "Fn::Sub": "arn:${AWS::Partition}:s3:::${Logs}/*" }
+            },
+            {
+              "Sid": "AllowSSLRequestsOnly",
+              "Action": "s3:*",
+              "Effect": "Deny",
+              "Resource": [
+                { "Fn::GetAtt": ["Logs", "Arn"]},
+                {
+                  "Fn::Sub": [
+                    "${bucket}/*",
+                    {
+                      "bucket": { "Fn::GetAtt": ["Logs", "Arn"] }
+                    }
+                  ]
+                }
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Principal": "*"
             }
           ]
         }
@@ -3128,6 +3169,39 @@
           { "Key": "System", "Value": "convox" },
           { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } }
         ]
+      }
+    },
+    "SettingsPolicy": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": { "Ref": "Settings" },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowSSLRequestsOnly",
+              "Action": "s3:*",
+              "Effect": "Deny",
+              "Resource": [
+                { "Fn::GetAtt": ["Settings", "Arn"]},
+                {
+                  "Fn::Sub": [
+                    "${bucket}/*",
+                    {
+                      "bucket": { "Fn::GetAtt": ["Settings", "Arn"] }
+                    }
+                  ]
+                }
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Principal": "*"
+            }
+          ]
+        }
       }
     }
   }


### PR DESCRIPTION
Adds two new security rules to rack resources:

- s3 managed buckets will only allow SSL traffic
- lambdas will be assigned to the rack VPC