### PR TITLE
Get all processes and stop task from build instance

### DIFF
--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -331,7 +331,7 @@ func (p *Provider) taskProcesses(tasks []string) (structs.Processes, error) {
 			for _, task := range buildTasks {
 				ecsTasks = append(ecsTasks, task)
 			}
-		} 
+		}
 
 		for _, task := range ecsTasks {
 			if p.IsTest() {
@@ -458,23 +458,32 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 func (p *Provider) ProcessStop(app, pid string) error {
 	log := Logger.At("ProcessStop").Namespace("app=%q pid=%q", app, pid).Start()
 
-	arn, err := p.taskArnFromPid(pid)
+	arn, err := p.taskArnFromAppPid(app, pid)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
 
-	_, err = p.ecs().StopTask(&ecs.StopTaskInput{
-		Cluster: aws.String(p.Cluster),
-		Task:    aws.String(arn),
-	})
+	err = p.stopTaskFromCluster(p.Cluster, arn)
 	if err != nil {
-		log.Error(err)
-		return err
+		err = p.stopTaskFromCluster(p.BuildCluster, arn)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
 	}
 
 	log.Success()
 	return nil
+}
+
+func (p *Provider) stopTaskFromCluster(cluster, arn string) error {
+	_, err := p.ecs().StopTask(&ecs.StopTaskInput{
+		Cluster: aws.String(cluster),
+		Task:    aws.String(arn),
+	})
+
+	return err
 }
 
 func arnToPid(arn string) string {
@@ -607,7 +616,7 @@ func (p *Provider) describeTaskInner(arn string) (*ecs.Task, error) {
 	// If the task is in the build cluster, use that
 	if (p.BuildCluster != p.Cluster) && (strings.Contains(arn, p.BuildCluster)) {
 		cluster = p.BuildCluster
-	} 
+	}
 
 	res, err := p.describeTasks(&ecs.DescribeTasksInput{
 		Cluster: aws.String(cluster),
@@ -1137,82 +1146,6 @@ func (p *Provider) generateTaskDefinition2(app, service string, opts structs.Pro
 	return req, nil
 }
 
-// func (p *Provider) processRunAttached(app string, rw io.ReadWriter, opts structs.ProcessRunOptions) (*structs.Process, error) {
-//   if opts.Service == nil {
-//     return nil, fmt.Errorf("must specify a service")
-//   }
-
-//   td, err := p.taskDefinitionForRun(app, rw, opts)
-//   if err != nil {
-//     return nil, err
-//   }
-
-//   timeout := "3600"
-
-//   if opts.Timeout != nil {
-//     timeout = strconv.Itoa(*opts.Timeout)
-//   }
-
-//   req := &ecs.RunTaskInput{
-//     Cluster:        aws.String(p.Cluster),
-//     Count:          aws.Int64(1),
-//     StartedBy:      aws.String(fmt.Sprintf("convox.%s", app)),
-//     TaskDefinition: aws.String(td),
-//   }
-
-//   if opts.Command != nil {
-//     req.Overrides = &ecs.TaskOverride{
-//       ContainerOverrides: []*ecs.ContainerOverride{
-//         {
-//           Name: aws.String(*opts.Service),
-//           Command: []*string{
-//             aws.String("sleep"),
-//             aws.String(timeout),
-//           },
-//           Environment: []*ecs.KeyValuePair{
-//             &ecs.KeyValuePair{Name: aws.String("COMMAND"), Value: aws.String(*opts.Command)},
-//           },
-//         },
-//       },
-//     }
-//   }
-
-//   task, err := p.runTask(req)
-//   if err != nil {
-//     return nil, err
-//   }
-
-//   status, err := p.waitForTask(*task.TaskArn)
-//   if err != nil {
-//     return nil, err
-//   }
-//   if status != "RUNNING" {
-//     return nil, fmt.Errorf("error starting container")
-//   }
-
-//   pid := arnToPid(*task.TaskArn)
-
-//   if opts.Command != nil {
-//     code, err := p.ProcessExec(app, pid, *opts.Command, rw, structs.ProcessExecOptions{
-//       Entrypoint: options.Bool(true),
-//       Height:     opts.Height,
-//       Width:      opts.Width,
-//     })
-//     if err != nil && !strings.Contains(err.Error(), "use of closed network") {
-//       return nil, err
-//     }
-
-//     p.stopTask(*task.TaskArn, fmt.Sprintf("exit:%d", code))
-//   }
-
-//   ps, err := p.ProcessGet(app, pid)
-//   if err != nil {
-//     return nil, err
-//   }
-
-//   return ps, nil
-// }
-
 func (p *Provider) ProcessWait(app, pid string) (int, error) {
 	arn, err := p.taskArnFromPid(pid)
 	if err != nil {
@@ -1330,6 +1263,21 @@ func (p *Provider) stopTask(arn string, reason string) error {
 	}
 
 	return nil
+}
+
+func (p *Provider) taskArnFromAppPid(app, pid string) (string, error) {
+	tasks, err := p.appTaskARNs(app)
+	if err != nil {
+		return "", err
+	}
+
+	for _, t := range tasks {
+		if strings.HasSuffix(t, pid) {
+			return t, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find process")
 }
 
 func (p *Provider) taskArnFromPid(pid string) (string, error) {

--- a/provider/aws/processes_test.go
+++ b/provider/aws/processes_test.go
@@ -264,8 +264,12 @@ func TestProcessRunDetached(t *testing.T) {
 
 func TestProcessStop(t *testing.T) {
 	provider := StubAwsProvider(
-		cycleProcessListTasksRunning,
-		cycleProcessListTasksStopped,
+		cycleProcessListStackResources,
+		cycleProcessDescribeStacks,
+		cycleProcessListTasksByStack,
+		cycleProcessListTasksByService1,
+		cycleProcessListTasksByService2,
+		cycleProcessListTasksByStarted,
 		cycleProcessStopTask,
 	)
 	defer provider.Close()
@@ -762,7 +766,7 @@ var cycleProcessDescribeTasksAllWithBuildCluster = awsutil.Cycle{
 				"arn:aws:ecs:us-east-1:778743527532:task/cluster-test/50b8de99-f94f-4ecd-a98f-5850760f0846",
 				"arn:aws:ecs:us-east-1:778743527532:task/cluster-test/50b8de99-f94f-4ecd-a98f-5850760f0847",
 				"arn:aws:ecs:us-east-1:778743527532:task/cluster-test/50b8de99-f94f-4ecd-a98f-5850760f0845"
-				
+
 			]
 		}`,
 	},
@@ -1414,26 +1418,6 @@ var cycleProcessStopTask = awsutil.Cycle{
 		Body: `{
 			"task": {
 				"taskArn": "arn:aws:ecs:us-east-1:778743527532:task/cluster-test/014b7e61-cc23-47e8-9dc6-0f51f03ff369"
-			}
-		}`,
-	},
-}
-
-var cycleProcessStopTaskReason = awsutil.Cycle{
-	Request: awsutil.Request{
-		RequestURI: "/",
-		Operation:  "AmazonEC2ContainerServiceV20141113.StopTask",
-		Body: `{
-			"cluster": "cluster-test",
-			"reason": "exit:0",
-			"task": "arn:aws:ecs:us-east-1:778743527532:task/50b8de99-f94f-4ecd-a98f-5850760f0845"
-		}`,
-	},
-	Response: awsutil.Response{
-		StatusCode: 200,
-		Body: `{
-			"task": {
-				"taskArn": "arn:aws:ecs:us-east-1:778743527532:task/014b7e61-cc23-47e8-9dc6-0f51f03ff369"
 			}
 		}`,
 	},


### PR DESCRIPTION
You cannot currently kill a stuck build process. `ProccessStop` only tries to kill processes in the `Instances` cluster, it should also try to kill the process in the `BuildInstances`.