### PR TITLE
Add BuildKit support for rack arm64 image

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -20,7 +20,9 @@ ARG KUBECTL_ARCH=arm64
 
 RUN apt-get -qq update && apt-get -qq -y install curl
 
-RUN curl -s https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-18.03.1-ce.tgz | \
+ENV DOCKER_BUILDKIT=1
+
+RUN curl -s https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-18.09.9.tgz | \
     tar -C /usr/bin --strip-components 1 -xz
 
 RUN curl -Ls https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/${KUBECTL_ARCH}/kubectl -o /usr/bin/kubectl && \

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -113,7 +113,7 @@ convox deploy -a ci2 --wait
 convox registries
 convox registries add quay.io convox+ci 6D5CJVRM5P3L24OG4AWOYGCDRJLPL0PFQAENZYJ1KGE040YDUGPYKOZYNWFTE5CV
 convox registries | grep quay.io | grep convox+ci
-convox build -a ci2 | grep "Authenticating https://quay.io: Login Succeeded"
+convox build -a ci2 | grep -A 5 "Authenticating https://quay.io" | grep "Login Succeeded"
 convox registries remove quay.io
 convox registries | grep -v quay.io
 


### PR DESCRIPTION
Forgot to add BuildKit support to the ARM image.
Also fixing a failing test step(`docker build` logs are displayed a bit different when using BuildKit)