### PR TITLE
Fix HttpProxy param

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -1414,7 +1414,7 @@
             "  - export NO_PROXY=169.254.169.254\n",
             "  - echo NO_PROXY=169.254.169.254 >> /etc/environment\n",
             { "Fn::If": [ "HttpProxy",
-              { "Fn::Join": ["", ["  - echo \"proxy=", { "Ref": "HttpProxy" }, "/\" >> /etc/yum.conf\n"
+              { "Fn::Join": ["", ["  - echo \"proxy=http://", { "Ref": "HttpProxy" }, "/\" >> /etc/yum.conf\n"
               ] ] },
               { "Ref": "AWS::NoValue" }
             ] },
@@ -1605,7 +1605,7 @@
             "  - export NO_PROXY=169.254.169.254\n",
             "  - echo NO_PROXY=169.254.169.254 >> /etc/environment\n",
             { "Fn::If": [ "HttpProxy",
-              { "Fn::Join": ["", ["  - echo \"proxy=", { "Ref": "HttpProxy" }, "/\" >> /etc/yum.conf\n"
+              { "Fn::Join": ["", ["  - echo \"proxy=http://", { "Ref": "HttpProxy" }, "/\" >> /etc/yum.conf\n"
               ] ] },
               { "Ref": "AWS::NoValue" }
             ] },
@@ -2065,7 +2065,7 @@
             "  - export NO_PROXY=169.254.169.254\n",
             "  - echo NO_PROXY=169.254.169.254 >> /etc/environment\n",
             { "Fn::If": [ "HttpProxy",
-              { "Fn::Join": ["", ["  - echo \"proxy=", { "Ref": "HttpProxy" }, "/\" >> /etc/yum.conf\n"
+              { "Fn::Join": ["", ["  - echo \"proxy=http://", { "Ref": "HttpProxy" }, "/\" >> /etc/yum.conf\n"
               ] ] },
               { "Ref": "AWS::NoValue" }
             ] },
@@ -2801,6 +2801,7 @@
             },
             "Environment": [
               { "Name": "AWS_REGION", "Value": { "Ref": "AWS::Region" } },
+              { "Name": "NO_PROXY", "Value": "169.254.169.254,169.254.170.2,/var/run/docker.sock" },
               { "Name": "HTTP_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "HTTPS_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "PASSWORD", "Value": { "Ref": "Password" } },
@@ -2890,6 +2891,7 @@
             "Environment": [
               { "Name": "AWS_REGION", "Value": { "Ref": "AWS::Region" } },
               { "Name": "CLIENT_ID", "Value": { "Ref": "ClientId" } },
+              { "Name": "NO_PROXY", "Value": "169.254.169.254,169.254.170.2,/var/run/docker.sock" },
               { "Name": "HTTP_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "HTTPS_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "PASSWORD", "Value": { "Ref": "Password" } },
@@ -2997,6 +2999,7 @@
             "Environment": [
               { "Name": "AWS_REGION", "Value": { "Ref": "AWS::Region" } },
               { "Name": "CLIENT_ID", "Value": { "Ref": "ClientId" } },
+              { "Name": "NO_PROXY", "Value": "169.254.169.254,169.254.170.2,/var/run/docker.sock" },
               { "Name": "HTTP_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "HTTPS_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "PASSWORD", "Value": { "Ref": "Password" } },


### PR DESCRIPTION
The HttpProxy was failing due to not being able to `yum update`. The rack was giving the 502 status because it didn't have the `NO_PROXY` set.

The user still has to set the environment variables on convox.yml:

```
environment:
  - PORT=3000
services:
  web:
    build: .
    port: 3000
    environment:
      - http_proxy=10.0.1.124:8888
      - https_proxy=10.0.1.124:8888
      - NO_PROXY=169.254.170.2

```