### PR TITLE
Spot Instances and HA false should have one Instances

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -58,6 +58,7 @@ type Provider struct {
 	EcsPollInterval     int
 	EncryptionKey       string
 	Fargate             bool
+	HighAvailability    bool
 	Internal            bool
 	InternalOnly        bool
 	LogBucket           string
@@ -149,6 +150,7 @@ func (p *Provider) loadParams() error {
 	p.EcsPollInterval = intParam(labels["rack.EcsPollInterval"], 1)
 	p.EncryptionKey = labels["rack.EncryptionKey"]
 	p.Fargate = labels["rack.Fargate"] == "Yes"
+	p.HighAvailability = labels["rack.HighAvailability"] == "Yes"
 	p.Internal = labels["rack.Internal"] == "Yes"
 	p.InternalOnly = labels["rack.InternalOnly"] == "Yes"
 	p.LogBucket = labels["rack.LogBucket"]

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -120,7 +120,7 @@
       ]}
     ] },
     "SpotInstances": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SpotInstanceBid"}, "" ] } ] },
-    "SpotInstancesNoHA": { "Fn::And": [ { "Condition": "SpotInstances" }, { "Condition": "HighAvailability" } ] },
+    "SpotInstancesAndHA": { "Fn::And": [ { "Condition": "SpotInstances" }, { "Condition": "HighAvailability" } ] },
     "SwapEnabled": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SwapSize" }, "0" ] } ] },
     "ThirdAvailabilityZone": { "Fn::And": [
       { "Fn::Equals": [ { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "ThirdAvailabilityZone" ] }, "Yes" ] },
@@ -1687,7 +1687,7 @@
         "DesiredCapacity" : { "Fn::If": [ "SpotInstances", { "Ref": "AWS::NoValue" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
-        "MinSize" : { "Fn::If": [ "SpotInstancesNoHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
+        "MinSize" : { "Fn::If": [ "SpotInstancesAndHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
         "MaxSize" : { "Fn::If": [ "HighAvailability", "1000", "3" ] },
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "TerminationPolicies": [ "NewestInstance" ],
@@ -1737,7 +1737,7 @@
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
           "MaxBatchSize": { "Ref": "InstanceUpdateBatchSize" },
-          "MinInstancesInService": { "Fn::If": [ "SpotInstancesNoHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
+          "MinInstancesInService": { "Fn::If": [ "SpotInstancesAndHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
           "PauseTime" : "PT5M",
           "SuspendProcesses": [
             "ScheduledActions"
@@ -1762,7 +1762,7 @@
       "Properties":{
         "AutoScalingGroupName": { "Ref": "Instances" },
         "DesiredCapacity" : { "Fn::If": [ "SpotInstances", { "Ref": "AWS::NoValue" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
-        "MinSize" : { "Fn::If": [ "SpotInstancesNoHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
+        "MinSize" : { "Fn::If": [ "SpotInstancesAndHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
         "MaxSize" : { "Fn::If": [ "HighAvailability", "1000", "3" ] },
         "Recurrence": { "Ref": "ScheduleRackScaleUp" }
       }

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -120,6 +120,7 @@
       ]}
     ] },
     "SpotInstances": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SpotInstanceBid"}, "" ] } ] },
+    "SpotInstancesNoHA": { "Fn::And": [ { "Condition": "SpotInstances" }, { "Condition": "HighAvailability" } ] },
     "SwapEnabled": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SwapSize" }, "0" ] } ] },
     "ThirdAvailabilityZone": { "Fn::And": [
       { "Fn::Equals": [ { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "ThirdAvailabilityZone" ] }, "Yes" ] },
@@ -1686,7 +1687,7 @@
         "DesiredCapacity" : { "Fn::If": [ "SpotInstances", { "Ref": "AWS::NoValue" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
-        "MinSize" : { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
+        "MinSize" : { "Fn::If": [ "SpotInstancesNoHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
         "MaxSize" : { "Fn::If": [ "HighAvailability", "1000", "3" ] },
         "MetricsCollection": [ { "Granularity": "1Minute" } ],
         "TerminationPolicies": [ "NewestInstance" ],
@@ -1736,7 +1737,7 @@
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
           "MaxBatchSize": { "Ref": "InstanceUpdateBatchSize" },
-          "MinInstancesInService": { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
+          "MinInstancesInService": { "Fn::If": [ "SpotInstancesNoHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
           "PauseTime" : "PT5M",
           "SuspendProcesses": [
             "ScheduledActions"
@@ -1761,7 +1762,7 @@
       "Properties":{
         "AutoScalingGroupName": { "Ref": "Instances" },
         "DesiredCapacity" : { "Fn::If": [ "SpotInstances", { "Ref": "AWS::NoValue" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
-        "MinSize" : { "Fn::If": [ "SpotInstances", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
+        "MinSize" : { "Fn::If": [ "SpotInstancesNoHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
         "MaxSize" : { "Fn::If": [ "HighAvailability", "1000", "3" ] },
         "Recurrence": { "Ref": "ScheduleRackScaleUp" }
       }
@@ -2797,6 +2798,7 @@
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
               "rack.Fargate": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] },
+              "rack.HighAvailability": { "Ref": "HighAvailability" },
               "rack.Internal": { "Ref": "Internal" },
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
@@ -2886,6 +2888,7 @@
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
               "rack.Fargate": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] },
+              "rack.HighAvailability": { "Ref": "HighAvailability" },
               "rack.Internal": { "Ref": "Internal" },
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
@@ -2993,6 +2996,7 @@
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
               "rack.Fargate": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] },
+              "rack.HighAvailability": { "Ref": "HighAvailability" },
               "rack.Internal": { "Ref": "Internal" },
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },

--- a/provider/aws/workers_spotreplace.go
+++ b/provider/aws/workers_spotreplace.go
@@ -81,7 +81,7 @@ func (p *Provider) spotReplace() error {
 
 	spotDesired := ic - odmin
 
-	if spc != spotDesired {
+	if spc != spotDesired && p.HighAvailability {
 		log.Logf("stack=SpotInstances setDesiredCount=%d", spotDesired)
 
 		if err := p.setAsgResourceDesiredCount("SpotInstances", spotDesired); err != nil {
@@ -91,7 +91,7 @@ func (p *Provider) spotReplace() error {
 
 	onDemandDesired := ic - spcr
 
-	if odc != onDemandDesired {
+	if odc != onDemandDesired && p.HighAvailability {
 		log.Logf("stack=Instances setDesiredCount=%d", onDemandDesired)
 
 		if err := p.setAsgResourceDesiredCount("Instances", onDemandDesired); err != nil {


### PR DESCRIPTION
A rack with HA is disabled and the user sets the SpotInstanceBid, instead of using 1 instance for the rack, it changes to use 3 instances. Since the HighAvailabilty is disabled, should use 1 as the desired capacity.