### PR TITLE
Explicitly declare dependencies for the KMS Custom resource

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -810,6 +810,7 @@
   },
   "Resources": {
     "EncryptionKey": {
+      "DependsOn": ["S3Endpoint", "KMSEndpoint", "CFEndpoint", "SubnetPrivate0Routes", "SubnetPrivate1Routes"],
       "Type": "Custom::KMSKey",
       "Properties": {
         "ServiceToken": { "Fn::GetAtt": [ "CustomTopic", "Arn" ] },
@@ -911,7 +912,7 @@
       }
     },
     "CustomTopic": {
-      "DependsOn": ["S3Endpoint","KMSEndpoint","CFEndpoint", "SubnetPrivate0Routes", "SubnetPrivate1Routes"],
+      "DependsOn": ["S3Endpoint", "KMSEndpoint", "CFEndpoint", "SubnetPrivate0Routes", "SubnetPrivate1Routes"],
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {


### PR DESCRIPTION
I noticed that sometimes the rack installation can fail due to a timeout error when creating the `EncryptionKey`. Although it should respect the implicit dependency between `CustomTopic` and the interface endpoints, explicitly adding them to `EncriptionKey` seem to have fixed it.