### PR TITLE
When canceling an app update, rewrite the last active release on top

### DIFF
--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -129,7 +129,7 @@ func AppsCancel(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	c.Writef("Rewriting last active release")
+	c.Writef("Rewriting last active release... ")
 
 	rs, err := rack.ReleaseList(app.Name, structs.ReleaseListOptions{})
 	if err != nil {
@@ -141,6 +141,7 @@ func AppsCancel(rack sdk.Interface, c *stdcli.Context) error {
 			if err != nil {
 				return err
 			}
+			break
 		}
 	}
 

--- a/pkg/cli/fixtures_test.go
+++ b/pkg/cli/fixtures_test.go
@@ -224,6 +224,10 @@ func fxRelease3() *structs.Release {
 	}
 }
 
+func fxReleaseList() structs.Releases {
+	return structs.Releases{*fxRelease(), *fxRelease2(), *fxRelease3()}
+}
+
 func fxResource() *structs.Resource {
 	return &structs.Resource{
 		Name:       "resource1",


### PR DESCRIPTION
When canceling an app update, rewrite the last active release on top of canceled one