### PR TITLE
Change minimum healthy percent for no-ha

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2845,7 +2845,7 @@
       "DependsOn": [ "Instances" ],
       "Properties": {
         "Cluster": { "Ref": "Cluster" },
-        "DeploymentConfiguration": { "MinimumHealthyPercent": "50", "MaximumPercent": "200" },
+        "DeploymentConfiguration": { "MinimumHealthyPercent": { "Fn::If": [ "HighAvailability", "50", "0" ] }, "MaximumPercent": "200" },
         "DesiredCount": { "Fn::If": [ "HighAvailability", { "Ref": "ApiCount" }, 1 ] },
         "LoadBalancers": [ { "Fn::If": [ "ApiRouterALB",
           { "ContainerName": "web", "ContainerPort": "5443", "TargetGroupArn": { "Ref": "RouterApiTargetGroup" } },


### PR DESCRIPTION
No-HA racks only has one instances, and it conflicts when updating
Setting min health to 0 will enable the ApiWebService to be replaced