### PR TITLE
Rack with HighAvailability false should AutoScale

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -582,10 +582,18 @@
       "Type": "String",
       "Default": ""
     },
+    "NoHaInstanceCount": {
+      "Default": "1",
+      "Description": "The number of instances in the runtime cluster for no HighAvailable racks",
+      "MinValue": "1",
+      "MaxValue": "3",
+      "Type": "Number"
+    },
     "HighAvailability": {
+      "AllowedValues": [ "true", "false" ],
+      "Default": "true",
       "Description": "Wether to create rack in High Availability mode.",
-      "Type": "String",
-      "Default": "true"
+      "Type": "String"
     },
     "HttpProxy": {
       "Description": "Connect using an outbound HTTP proxy (for network-restricted Racks)",
@@ -633,7 +641,7 @@
     },
     "InstanceCount": {
       "Default": "3",
-      "Description": "The number of instances in the runtime cluster",
+      "Description": "The number of instances in the runtime cluster for high available racks",
       "MinValue": "3",
       "Type": "Number"
     },
@@ -1751,7 +1759,7 @@
           ] ]
         },
         "Cooldown": 5,
-        "DesiredCapacity" : { "Fn::If": [ "SpotInstances", { "Ref": "AWS::NoValue" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
+        "DesiredCapacity" : { "Fn::If": [ "SpotInstances", { "Ref": "AWS::NoValue" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, { "Ref": "NoHaInstanceCount"} ] } ] },
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "MinSize" : { "Fn::If": [ "SpotInstancesAndHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
@@ -1828,7 +1836,7 @@
       "Condition": "SetScheduleRackScale",
       "Properties":{
         "AutoScalingGroupName": { "Ref": "Instances" },
-        "DesiredCapacity" : { "Fn::If": [ "SpotInstances", { "Ref": "AWS::NoValue" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
+        "DesiredCapacity" : { "Fn::If": [ "SpotInstances", { "Ref": "AWS::NoValue" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, { "Ref": "NoHaInstanceCount"} ] } ] },
         "MinSize" : { "Fn::If": [ "SpotInstancesAndHA", { "Ref": "OnDemandMinCount" }, { "Fn::If": [ "HighAvailability", { "Ref": "InstanceCount"}, "1" ] } ] },
         "MaxSize" : { "Fn::If": [ "HighAvailability", "1000", "3" ] },
         "Recurrence": { "Ref": "ScheduleRackScaleUp" }
@@ -1869,6 +1877,7 @@
             "ASG": { "Ref": "Instances" },
             "CLUSTER": { "Ref": "Cluster" },
             "EXTRA": { "Ref": "AutoscaleExtra" },
+            "HIGH_AVAILABILITY": { "Ref": "HighAvailability" },
             "STACK": { "Ref": "AWS::StackName" }
           }
         },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -516,7 +516,7 @@
     },
     "AutoscaleExtra": {
       "Type": "Number",
-      "Description": "The number of instances of extra capacity that autoscale should keep running",
+      "Description": "The number of instances of extra capacity that autoscale should keep running (not used in non HA racks)",
       "Default": "1"
     },
     "AvailabilityZones": {

--- a/provider/aws/lambda/autoscale/handler.go
+++ b/provider/aws/lambda/autoscale/handler.go
@@ -298,9 +298,13 @@ func desiredCapacity(largest, total *Metrics) (int64, error) {
 	debug("extraWidth = %+v\n", extraWidth)
 
 	// comes from AutoscaleExtra
-	extra, err := strconv.ParseInt(os.Getenv("EXTRA"), 10, 64)
-	if err != nil {
-		return 0, err
+	var extra int64
+	if IsHA == "true" {
+		var err error
+		extra, err = strconv.ParseInt(os.Getenv("EXTRA"), 10, 64)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	// total desired count is the current instance count minus the smallest calculated extra type plus the number of desired extra instances


### PR DESCRIPTION
Implement the autoscale for no-HA racks. It will scale to a max of 3 instances (the max allowed by the AutoScalingGroup).