### PR TITLE
Fix environment variable bug when using convox apps cancel

### DIFF
--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -118,7 +118,7 @@ func Apps(rack sdk.Interface, c *stdcli.Context) error {
 func AppsCancel(rack sdk.Interface, c *stdcli.Context) error {
 	aname := coalesce(c.Arg(0), app(c))
 
-	c.Startf("Cancelling deployment of <app>%s</app>\n", aname)
+	c.Writef("Cancelling deployment of <app>%s</app>...\n", aname)
 
 	rl, err := helpers.ReleaseLatest(rack, aname)
 

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -120,17 +120,17 @@ func AppsCancel(rack sdk.Interface, c *stdcli.Context) error {
 
 	c.Writef("Cancelling deployment of <app>%s</app>...\n", aname)
 
-	rl, err := helpers.ReleaseLatest(rack, aname)
-
-	if err != nil {
-		return fmt.Errorf("failed to fetch last active release - %s", err.Error())
-	}
-
 	if err := rack.AppCancel(aname); err != nil {
 		return err
 	}
 
 	c.Writef("Rewriting last active release... \n")
+
+	rl, err := helpers.ReleaseLatest(rack, aname)
+
+	if err != nil {
+		return fmt.Errorf("failed to fetch last active release - %s", err.Error())
+	}
 
 	_, err = rack.ReleaseCreate(aname, structs.ReleaseCreateOptions{Build: &rl.Build, Description: &rl.Description, Env: &rl.Env})
 	if err != nil {

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -118,37 +118,29 @@ func Apps(rack sdk.Interface, c *stdcli.Context) error {
 func AppsCancel(rack sdk.Interface, c *stdcli.Context) error {
 	aname := coalesce(c.Arg(0), app(c))
 
-	c.Startf("Cancelling <app>%s</app>", aname)
+	c.Startf("Cancelling deployment of <app>%s</app>\n", aname)
+
+	rl, err := helpers.ReleaseLatest(rack, aname)
+
+	if err != nil {
+		return fmt.Errorf("failed to fetch last active release - %s", err.Error())
+	}
 
 	if err := rack.AppCancel(aname); err != nil {
 		return err
 	}
 
-	app, err := rack.AppGet(aname)
+	c.Writef("Rewriting last active release... \n")
+
+	_, err = rack.ReleaseCreate(aname, structs.ReleaseCreateOptions{Build: &rl.Build, Description: &rl.Description, Env: &rl.Env})
 	if err != nil {
 		return err
-	}
-
-	c.Writef("Rewriting last active release... ")
-
-	rs, err := rack.ReleaseList(app.Name, structs.ReleaseListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, r := range rs {
-		if app.Release == r.Id {
-			_, err := rack.ReleaseCreate(app.Name, structs.ReleaseCreateOptions{Build: &r.Build, Description: &r.Description, Env: &r.Env})
-			if err != nil {
-				return err
-			}
-			break
-		}
 	}
 
 	if c.Bool("wait") {
 		c.Writef("\n")
 
-		if err := helpers.WaitForAppRollbackWithLogsContext(context.Background(), rack, c, app.Name); err != nil {
+		if err := helpers.WaitForAppRollbackWithLogsContext(context.Background(), rack, c, aname); err != nil {
 			return err
 		}
 	}

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -115,12 +115,7 @@ func TestAppsCancelWait(t *testing.T) {
 
 func TestAppsCancelError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		fxapp := fxApp()
-		fxrelease := fxRelease()
-
 		i.On("AppCancel", "app1").Return(fmt.Errorf("err1"))
-		i.On("ReleaseList", fxapp.Name, structs.ReleaseListOptions{Limit: options.Int(1)}).Return(fxReleaseList(), nil)
-		i.On("ReleaseGet", "app1", fxrelease.Id).Return(fxRelease(), nil)
 
 		res, err := testExecute(e, "apps cancel app1", nil)
 		require.NoError(t, err)

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -62,8 +62,8 @@ func TestAppsCancel(t *testing.T) {
 		fxapp := fxApp()
 		fxrelease := fxRelease()
 		i.On("AppCancel", "app1").Return(nil)
-		i.On("AppGet", "app1").Return(fxapp, nil)
-		i.On("ReleaseList", fxapp.Name, structs.ReleaseListOptions{}).Return(fxReleaseList(), nil)
+		i.On("ReleaseList", fxapp.Name, structs.ReleaseListOptions{Limit: options.Int(1)}).Return(fxReleaseList(), nil)
+		i.On("ReleaseGet", "app1", fxrelease.Id).Return(fxRelease(), nil)
 		i.On("ReleaseCreate", fxapp.Name, structs.ReleaseCreateOptions{
 			Build: &fxrelease.Build, Description: &fxrelease.Description, Env: &fxrelease.Env},
 		).Return(nil, nil)
@@ -72,17 +72,13 @@ func TestAppsCancel(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
-		res.RequireStdout(t, []string{
-			"Cancelling app1... Rewriting last active release... OK",
-		})
+		res.RequireStdout(t, []string{"Cancelling deployment of app1...", "Rewriting last active release... ", "OK"})
 
 		res, err = testExecute(e, "apps cancel -a app1", nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
-		res.RequireStdout(t, []string{
-			"Cancelling app1... Rewriting last active release... OK",
-		})
+		res.RequireStdout(t, []string{"Cancelling deployment of app1...", "Rewriting last active release... ", "OK"})
 	})
 }
 
@@ -92,8 +88,9 @@ func TestAppsCancelWait(t *testing.T) {
 		fxrelease := fxRelease()
 		opts := structs.LogsOptions{Prefix: options.Bool(true), Since: options.Duration(5 * time.Second)}
 		i.On("AppCancel", "app1").Return(nil)
-		i.On("AppGet", "app1").Return(fxapp, nil).Times(2)
-		i.On("ReleaseList", fxapp.Name, structs.ReleaseListOptions{}).Return(fxReleaseList(), nil)
+		i.On("AppGet", "app1").Return(fxapp, nil).Times(1)
+		i.On("ReleaseList", fxapp.Name, structs.ReleaseListOptions{Limit: options.Int(1)}).Return(fxReleaseList(), nil)
+		i.On("ReleaseGet", "app1", fxrelease.Id).Return(fxRelease(), nil)
 		i.On("ReleaseCreate", fxapp.Name, structs.ReleaseCreateOptions{
 			Build: &fxrelease.Build, Description: &fxrelease.Description, Env: &fxrelease.Env},
 		).Return(nil, nil)
@@ -106,7 +103,9 @@ func TestAppsCancelWait(t *testing.T) {
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{
-			"Cancelling app1... Rewriting last active release... ",
+			"Cancelling deployment of app1...",
+			"Rewriting last active release... ",
+			"",
 			"TIME system/aws/component log1",
 			"TIME system/aws/component log2",
 			"OK",

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -115,15 +115,18 @@ func TestAppsCancelWait(t *testing.T) {
 
 func TestAppsCancelError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		fxapp := fxApp()
+		fxrelease := fxRelease()
+
 		i.On("AppCancel", "app1").Return(fmt.Errorf("err1"))
+		i.On("ReleaseList", fxapp.Name, structs.ReleaseListOptions{Limit: options.Int(1)}).Return(fxReleaseList(), nil)
+		i.On("ReleaseGet", "app1", fxrelease.Id).Return(fxRelease(), nil)
 
 		res, err := testExecute(e, "apps cancel app1", nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, res.Code)
 		res.RequireStderr(t, []string{"ERROR: err1"})
-		res.RequireStdout(t, []string{
-			"Cancelling app1... ",
-		})
+		res.RequireStdout(t, []string{"Cancelling deployment of app1..."})
 	})
 }
 


### PR DESCRIPTION
When using `convox apps cancel` we were not injecting the environment variables properly