### PR TITLE
Using LogDriver to send logs to CloudWatch, Syslog or disable it

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -498,5 +498,9 @@ func validateParams(params map[string]string) error {
 		return fmt.Errorf("to configure ScheduleAction you need both ScheduleRackScaleDown and ScheduleRackScaleUp parameters")
 	}
 
+	if params["LogDriver"] == "Syslog" && params["SyslogDestination"] == "" {
+		return fmt.Errorf("to enable Syslog as the LogDriver you must pass SyslogDestination parameter")
+	}
+
 	return nil
 }

--- a/provider/aws/apps.go
+++ b/provider/aws/apps.go
@@ -57,8 +57,9 @@ func (p *Provider) AppCreate(name string, opts structs.AppCreateOptions) (*struc
 	}
 
 	params := map[string]string{
-		"LogBucket": p.LogBucket,
-		"Rack":      p.Rack,
+		"EnableCloudWatch": p.EnableCloudWatch,
+		"LogBucket":        p.LogBucket,
+		"Rack":             p.Rack,
 	}
 
 	tags := map[string]string{

--- a/provider/aws/apps.go
+++ b/provider/aws/apps.go
@@ -57,9 +57,11 @@ func (p *Provider) AppCreate(name string, opts structs.AppCreateOptions) (*struc
 	}
 
 	params := map[string]string{
-		"EnableCloudWatch": p.EnableCloudWatch,
-		"LogBucket":        p.LogBucket,
-		"Rack":             p.Rack,
+		"LogBucket":         p.LogBucket,
+		"LogDriver":         p.LogDriver,
+		"Rack":              p.Rack,
+		"SyslogDestination": p.SyslogDestination,
+		"SyslogFormat":      p.SyslogFormat,
 	}
 
 	tags := map[string]string{

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -56,6 +56,7 @@ type Provider struct {
 	DynamoBuilds        string
 	DynamoReleases      string
 	EcsPollInterval     int
+	EnableCloudWatch    string
 	EncryptionKey       string
 	Fargate             bool
 	HighAvailability    bool
@@ -149,6 +150,7 @@ func (p *Provider) loadParams() error {
 	p.DynamoBuilds = labels["rack.DynamoBuilds"]
 	p.DynamoReleases = labels["rack.DynamoReleases"]
 	p.EcsPollInterval = intParam(labels["rack.EcsPollInterval"], 1)
+	p.EnableCloudWatch = labels["rack.EnableCloudWatch"]
 	p.EncryptionKey = labels["rack.EncryptionKey"]
 	p.Fargate = labels["rack.Fargate"] == "Yes"
 	p.HighAvailability = labels["rack.HighAvailability"] == "true"

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -56,7 +56,6 @@ type Provider struct {
 	DynamoBuilds        string
 	DynamoReleases      string
 	EcsPollInterval     int
-	EnableCloudWatch    string
 	EncryptionKey       string
 	Fargate             bool
 	HighAvailability    bool
@@ -64,6 +63,7 @@ type Provider struct {
 	InternalOnly        bool
 	ELBLogBucket        string
 	LogBucket           string
+	LogDriver           string
 	NotificationTopic   string
 	OnDemandMinCount    int
 	Password            string
@@ -77,6 +77,8 @@ type Provider struct {
 	Subnets             string
 	SubnetsPrivate      string
 	StackId             string
+	SyslogDestination   string
+	SyslogFormat        string
 	Version             string
 	Vpc                 string
 	VpcCidr             string
@@ -150,13 +152,13 @@ func (p *Provider) loadParams() error {
 	p.DynamoBuilds = labels["rack.DynamoBuilds"]
 	p.DynamoReleases = labels["rack.DynamoReleases"]
 	p.EcsPollInterval = intParam(labels["rack.EcsPollInterval"], 1)
-	p.EnableCloudWatch = labels["rack.EnableCloudWatch"]
 	p.EncryptionKey = labels["rack.EncryptionKey"]
 	p.Fargate = labels["rack.Fargate"] == "Yes"
 	p.HighAvailability = labels["rack.HighAvailability"] == "true"
 	p.Internal = labels["rack.Internal"] == "Yes"
 	p.InternalOnly = labels["rack.InternalOnly"] == "Yes"
 	p.LogBucket = labels["rack.LogBucket"]
+	p.LogDriver = labels["rack.LogDriver"]
 	p.NotificationTopic = labels["rack.NotificationTopic"]
 	p.OnDemandMinCount = intParam(labels["rack.OnDemandMinCount"], 2)
 	p.Private = labels["rack.Private"] == "Yes"
@@ -167,6 +169,8 @@ func (p *Provider) loadParams() error {
 	p.SshKey = labels["rack.SshKey"]
 	p.Subnets = labels["rack.Subnets"]
 	p.SubnetsPrivate = labels["rack.SubnetsPrivate"]
+	p.SyslogDestination = labels["rack.SyslogDestination"]
+	p.SyslogFormat = labels["rack.SyslogFormat"]
 	p.Version = labels["rack.Version"]
 	p.Vpc = labels["rack.Vpc"]
 	p.VpcCidr = labels["rack.VpcCidr"]

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -5,6 +5,7 @@
 
     "BlankIamPolicy": { "Fn::Equals": [ { "Ref": "IamPolicy" }, "" ] },
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
+    "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "EnableCloudWatch" }, "Yes" ] },
     "BlankLogRetention": { "Fn::Equals": [ { "Ref": "LogRetention" }, "" ] },
     "BlankResourcePassword": { "Fn::Equals": [ { "Ref": "ResourcePassword" }, "" ] },
     "CircuitBreaker": { "Fn::Equals": [ { "Ref": "CircuitBreaker" }, "Yes" ] },
@@ -36,6 +37,7 @@
       "Value": { "Fn::If": [ "FargateServicesSpot", "Yes", "No" ] }
     },
     "LogGroup": {
+      "Condition": "EnableCloudWatch",
       "Value": { "Ref": "LogGroup" }
     },
     "Release": {
@@ -60,6 +62,12 @@
     "CircuitBreaker": {
       "Type": "String",
       "Default": "No",
+      "AllowedValues": [ "Yes", "No" ]
+    },
+    "EnableCloudWatch": {
+      "Type": "String",
+      "Description": "Enable CloudWatch log group",
+      "Default": "Yes",
       "AllowedValues": [ "Yes", "No" ]
     },
     "FargateServices": {
@@ -170,6 +178,7 @@
     },
     "LogGroup": {
       "Type": "AWS::Logs::LogGroup",
+      "Condition": "EnableCloudWatch",
       "Properties": {
         "RetentionInDays": { "Fn::If": [ "BlankLogRetention", { "Ref": "AWS::NoValue" }, { "Ref": "LogRetention" } ] }
       }
@@ -341,10 +350,11 @@
           "CircuitBreaker": { "Ref": "CircuitBreaker" },
           "Count": { "Fn::Select": [ 0, { "Ref": "{{ upper .Name }}Formation" } ] },
           "Cpu": { "Fn::Select": [ 1, { "Ref": "{{ upper .Name }}Formation" } ] },
+          "EnableCloudWatch": { "Ref": "EnableCloudWatch" },
           "Fargate": { "Fn::If": [ "Service{{ upper .Name }}Fargate", "Yes", { "Fn::If": [ "Service{{ upper .Name }}FargateSpot", "Spot", "No" ] } ] },
           "LoadBalancerAlgorithm": { "Ref": "LoadBalancerAlgorithm" },
           "LoadBalancerSuccessCodes": { "Ref": "LoadBalancerSuccessCodes" },
-          "LogGroup": { "Ref": "LogGroup" },
+          "LogGroup": { "Fn::If": [ "EnableCloudWatch", { "Ref": "LogGroup" }, { "Ref": "AWS::NoValue" } ] },
           "InternalDomains": { "Ref": "InternalDomains" },
           "Isolate": { "Fn::If": [ "IsolateServices", "Yes", "No" ] },
           "Memory": { "Fn::Select": [ 2, { "Ref": "{{ upper .Name }}Formation" } ] },
@@ -494,10 +504,11 @@
         "NotificationARNs": [ "{{ $.Topic }}" ],
         "Parameters": {
           "Cpu": { "Fn::Select": [ 1, { "Ref": "{{ upper .Service }}Formation" } ] },
+          "EnableCloudWatch": { "Ref": "EnableCloudWatch" },
           "ExecutionRole": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
           "Fargate": { "Fn::If": [ "FargateTimersBase", "Yes", { "Fn::If": [ "FargateTimersSpot", "Spot", "No" ] } ] },
           "Launcher": { "Fn::GetAtt": [ "TimerLauncher", "Arn" ] },
-          "LogGroup": { "Ref": "LogGroup" },
+          "LogGroup": { "Fn::If": [ "EnableCloudWatch", { "Ref": "LogGroup" }, { "Ref": "AWS::NoValue" } ] },
           "Memory": { "Fn::Select": [ 2, { "Ref": "{{ upper .Service }}Formation" } ] },
           "Rack": { "Ref": "Rack" },
           "RackUrl": { "Ref": "RackUrl" },

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -5,12 +5,12 @@
 
     "BlankIamPolicy": { "Fn::Equals": [ { "Ref": "IamPolicy" }, "" ] },
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
-    "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "EnableCloudWatch" }, "Yes" ] },
     "BlankLogRetention": { "Fn::Equals": [ { "Ref": "LogRetention" }, "" ] },
     "BlankResourcePassword": { "Fn::Equals": [ { "Ref": "ResourcePassword" }, "" ] },
     "CircuitBreaker": { "Fn::Equals": [ { "Ref": "CircuitBreaker" }, "Yes" ] },
     "EC2Services": { "Fn::Not": [ { "Condition": "FargateServicesEither" } ] },
     "EC2Timers": { "Fn::Not": [ { "Condition": "FargateTimersEither" } ] },
+    "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "LogDriver" }, "CloudWatch" ] },
     "FargateServicesEither": { "Fn::Or": [ { "Condition": "FargateServicesBase" }, { "Condition": "FargateServicesSpot" } ] },
     "FargateServicesBase": { "Fn::Equals": [ { "Ref": "FargateServices" }, "Yes" ] },
     "FargateServicesSpot": { "Fn::Equals": [ { "Ref": "FargateServices" }, "Spot" ] },
@@ -64,12 +64,6 @@
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
     },
-    "EnableCloudWatch": {
-      "Type": "String",
-      "Description": "Enable CloudWatch log group",
-      "Default": "Yes",
-      "AllowedValues": [ "Yes", "No" ]
-    },
     "FargateServices": {
       "Type": "String",
       "Default": "No",
@@ -109,6 +103,12 @@
       "Type": "String",
       "Default": ""
     },
+    "LogDriver": {
+      "Default": "CloudWatch",
+      "Description": "Log driver used by the rack and services to send logs. Default to CloudWatch. You must provide the SyslogDestination when setting as Syslog. It disable logs if blank.",
+      "Type": "String",
+      "AllowedValues": [ "CloudWatch", "Syslog", ""]
+    },
     "LogRetention": {
       "Default": "7",
       "Description": "Number of days to keep logs (blank for unlimited)",
@@ -146,6 +146,16 @@
       "Default": "0",
       "Description": "The ramp up period during which a newly deployed service will receive an increasing share of traffic. Defaults to 0 seconds (disabled)",
       "Type": "String"
+    },
+    "SyslogDestination": {
+      "Type": "String",
+      "Description": "Syslog address destination, you need to pass the protocol to be used, e.g. tcp+tls://logsX.syslog.com:1234",
+      "Default": ""
+    },
+    "SyslogFormat": {
+      "Type": "String",
+      "Description": "Syslog format to sent to SyslogDestination.",
+      "Default": "rfc5424"
     },
     "TaskTags": {
       "Type": "String",
@@ -350,10 +360,10 @@
           "CircuitBreaker": { "Ref": "CircuitBreaker" },
           "Count": { "Fn::Select": [ 0, { "Ref": "{{ upper .Name }}Formation" } ] },
           "Cpu": { "Fn::Select": [ 1, { "Ref": "{{ upper .Name }}Formation" } ] },
-          "EnableCloudWatch": { "Ref": "EnableCloudWatch" },
           "Fargate": { "Fn::If": [ "Service{{ upper .Name }}Fargate", "Yes", { "Fn::If": [ "Service{{ upper .Name }}FargateSpot", "Spot", "No" ] } ] },
           "LoadBalancerAlgorithm": { "Ref": "LoadBalancerAlgorithm" },
           "LoadBalancerSuccessCodes": { "Ref": "LoadBalancerSuccessCodes" },
+          "LogDriver": { "Ref": "LogDriver" },
           "LogGroup": { "Fn::If": [ "EnableCloudWatch", { "Ref": "LogGroup" }, { "Ref": "AWS::NoValue" } ] },
           "InternalDomains": { "Ref": "InternalDomains" },
           "Isolate": { "Fn::If": [ "IsolateServices", "Yes", "No" ] },
@@ -369,6 +379,8 @@
           "Role": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
           "Settings": { "Ref": "Settings" },
           "SlowStartDuration": { "Ref": "SlowStartDuration" },
+          "SyslogDestination": { "Ref": "SyslogDestination" },
+          "SyslogFormat": { "Ref": "SyslogFormat" },
           "TaskTags": { "Ref": "TaskTags" }
         },
         "Tags": [
@@ -504,10 +516,10 @@
         "NotificationARNs": [ "{{ $.Topic }}" ],
         "Parameters": {
           "Cpu": { "Fn::Select": [ 1, { "Ref": "{{ upper .Service }}Formation" } ] },
-          "EnableCloudWatch": { "Ref": "EnableCloudWatch" },
           "ExecutionRole": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
           "Fargate": { "Fn::If": [ "FargateTimersBase", "Yes", { "Fn::If": [ "FargateTimersSpot", "Spot", "No" ] } ] },
           "Launcher": { "Fn::GetAtt": [ "TimerLauncher", "Arn" ] },
+          "LogDriver": { "Ref": "LogDriver" },
           "LogGroup": { "Fn::If": [ "EnableCloudWatch", { "Ref": "LogGroup" }, { "Ref": "AWS::NoValue" } ] },
           "Memory": { "Fn::Select": [ 2, { "Ref": "{{ upper .Service }}Formation" } ] },
           "Rack": { "Ref": "Rack" },
@@ -519,6 +531,8 @@
           "Role": { "Fn::GetAtt": [ "TimerRole", "Arn" ] },
           "ServiceRole": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
           "Settings": { "Ref": "Settings" }
+          "SyslogDestination": { "Ref": "SyslogDestination" }
+          "SyslogFormat": { "Ref": "SyslogFormat" }
         },
         "Tags": [
           { "Key": "App", "Value": "{{ $.App }}" },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -27,7 +27,8 @@
     "BlankSslPolicy": { "Fn::Equals": [ { "Ref": "SslPolicy" }, "" ] },
     "DedicatedBuilder": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstance" }, "" ] } ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
-    "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "EnableCloudWatch" }, "Yes" ] },
+    "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "LogDriver" }, "CloudWatch" ] },
+    "EnableSyslog": { "Fn::Equals": [ { "Ref": "LogDriver" }, "Syslog" ] },
     "EncryptEbs" : { "Fn::Equals": [ { "Ref": "EncryptEbs" }, "Yes" ] },
     "ExistingVpc": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "ExistingVpc" }, "" ] } ] },
     "ExistingVpcAndBlankInternetGateway": {
@@ -256,10 +257,6 @@
     "EcsPollInterval": {
       "Value": { "Ref": "EcsPollInterval" }
     },
-    "EnableCloudWatch": {
-      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:EnableCloudWatch" } },
-      "Value": { "Ref": "EnableCloudWatch" }
-    },
     "EncryptionKey": {
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:EncryptionKey" } },
       "Value": { "Ref": "EncryptionKey" }
@@ -301,6 +298,9 @@
     },
     "LogBucket": {
       "Value": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] }
+    },
+    "LogDriver": {
+      "Value": { "Ref": "LogDriver" }
     },
     "LogGroup": {
       "Condition": "EnableCloudWatch",
@@ -497,6 +497,12 @@
     "StackId": {
       "Value": { "Ref": "AWS::StackId" }
     },
+    "SyslogDestination": {
+      "Value": { "Ref": "SyslogDestination" }
+    },
+    "SyslogFormat": {
+      "Value": { "Ref": "SyslogFormat" }
+    },
     "Version": {
       "Value": { "Ref": "Version" }
     },
@@ -605,12 +611,6 @@
       "Type": "Number",
       "Default": "1",
       "Description": "How often to poll ECS for service events in seconds. Longer intervals may alleviate rate limiting / throttling from ECS."
-    },
-    "EnableCloudWatch": {
-      "Type": "String",
-      "Description": "Enable CloudWatch log group",
-      "Default": "Yes",
-      "AllowedValues": [ "Yes", "No" ]
     },
     "EncryptEbs": {
       "Type": "String",
@@ -739,6 +739,12 @@
       "Description": "Bucket to receive S3 logs",
       "Type": "String"
     },
+    "LogDriver": {
+      "Default": "CloudWatch",
+      "Description": "Log driver used by the rack and services to send logs. Default to CloudWatch. You must provide the SyslogDestination when setting as Syslog. It disable logs if blank.",
+      "Type": "String",
+      "AllowedValues": [ "CloudWatch", "Syslog", ""]
+    },
     "LogRetention": {
       "Default": "7",
       "Description": "Number of days to keep logs (blank for unlimited)",
@@ -855,6 +861,16 @@
       "Type": "Number",
       "Description": "Default swap volume size in GB",
       "Default": "5"
+    },
+    "SyslogDestination": {
+      "Type": "String",
+      "Description": "Syslog address destination, you need to pass the protocol to be used, e.g. tcp+tls://logsX.syslog.com:1234",
+      "Default": ""
+    },
+    "SyslogFormat": {
+      "Type": "String",
+      "Description": "Syslog format (low case) to sent to SyslogDestination.",
+      "Default": "rfc5424"
     },
     "Version": {
       "Description": "(REQUIRED) Convox release version",
@@ -2935,7 +2951,7 @@
               "rack.DynamoBuilds": { "Ref": "DynamoBuilds" },
               "rack.DynamoReleases": { "Ref": "DynamoReleases" },
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
-              "rack.EnableCloudWatch": { "Ref": "EnableCloudWatch" },
+              "rack.LogDriver": { "Ref": "LogDriver" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
               "rack.Fargate": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] },
               "rack.HighAvailability": { "Ref": "HighAvailability" },
@@ -2962,6 +2978,8 @@
                 ] ] },
                 { "Ref": "AWS::NoValue" }
               ] },
+              "rack.SyslogDestination": { "Ref": "SyslogDestination" },
+              "rack.SyslogFormat": { "Ref": "SyslogFormat" },
               "rack.Version": { "Ref": "Version" },
               "rack.Vpc": { "Fn::If": [ "BlankExistingVpc",
                 { "Ref": "Vpc" },
@@ -3026,7 +3044,7 @@
               "rack.DynamoBuilds": { "Ref": "DynamoBuilds" },
               "rack.DynamoReleases": { "Ref": "DynamoReleases" },
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
-              "rack.EnableCloudWatch": { "Ref": "EnableCloudWatch" },
+              "rack.LogDriver": { "Ref": "LogDriver" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
               "rack.Fargate": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] },
               "rack.HighAvailability": { "Ref": "HighAvailability" },
@@ -3053,6 +3071,8 @@
                 ] ] },
                 { "Ref": "AWS::NoValue" }
               ] },
+              "rack.SyslogDestination": { "Ref": "SyslogDestination" },
+              "rack.SyslogFormat": { "Ref": "SyslogFormat" },
               "rack.Version": { "Ref": "Version" },
               "rack.Vpc": { "Fn::If": [ "BlankExistingVpc",
                 { "Ref": "Vpc" },
@@ -3083,21 +3103,29 @@
             },
             "LogConfiguration": {
               "Fn::If": [
-                "EnableCloudWatch",
+                "EnableSyslog",
                 {
-                  "LogDriver": "awslogs",
+                  "LogDriver": "syslog",
                   "Options": {
-                    "awslogs-region": {
-                      "Ref": "AWS::Region"
-                    },
-                    "awslogs-group": {
-                      "Ref": "LogGroup"
-                    },
-                    "awslogs-stream-prefix": "service"
+                    "syslog-address": { "Ref": "SyslogDestination" },
+                    "syslog-format": { "Ref": "SyslogFormat" }
                   }
                 },
                 {
-                  "Ref": "AWS::NoValue"
+                  "Fn::If": [
+                    "EnableCloudWatch",
+                    {
+                      "LogDriver": "awslogs",
+                      "Options": {
+                        "awslogs-region": { "Ref": "AWS::Region" },
+                        "awslogs-group": { "Ref": "LogGroup" },
+                        "awslogs-stream-prefix": "service"
+                      }
+                    },
+                    {
+                      "Ref": "AWS::NoValue"
+                    }
+                  ]
                 }
               ]
             },
@@ -3147,7 +3175,7 @@
               "rack.DynamoBuilds": { "Ref": "DynamoBuilds" },
               "rack.DynamoReleases": { "Ref": "DynamoReleases" },
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
-              "rack.EnableCloudWatch": { "Ref": "EnableCloudWatch" },
+              "rack.LogDriver": { "Ref": "LogDriver" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
               "rack.Fargate": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] },
               "rack.HighAvailability": { "Ref": "HighAvailability" },
@@ -3175,6 +3203,8 @@
                 ] ] },
                 { "Ref": "AWS::NoValue" }
               ] },
+              "rack.SyslogDestination": { "Ref": "SyslogDestination" },
+              "rack.SyslogFormat": { "Ref": "SyslogFormat" },
               "rack.Version": { "Ref": "Version" },
               "rack.Vpc": { "Fn::If": [ "BlankExistingVpc",
                 { "Ref": "Vpc" },
@@ -3205,21 +3235,29 @@
             },
             "LogConfiguration": {
               "Fn::If": [
-                "EnableCloudWatch",
+                "EnableSyslog",
                 {
-                  "LogDriver": "awslogs",
+                  "LogDriver": "syslog",
                   "Options": {
-                    "awslogs-region": {
-                      "Ref": "AWS::Region"
-                    },
-                    "awslogs-group": {
-                      "Ref": "LogGroup"
-                    },
-                    "awslogs-stream-prefix": "service"
+                    "syslog-address": { "Ref": "SyslogDestination" },
+                    "syslog-format": { "Ref": "SyslogFormat" }
                   }
                 },
                 {
-                  "Ref": "AWS::NoValue"
+                  "Fn::If": [
+                    "EnableCloudWatch",
+                    {
+                      "LogDriver": "awslogs",
+                      "Options": {
+                        "awslogs-region": { "Ref": "AWS::Region" },
+                        "awslogs-group": { "Ref": "LogGroup" },
+                        "awslogs-stream-prefix": "service"
+                      }
+                    },
+                    {
+                      "Ref": "AWS::NoValue"
+                    }
+                  ]
                 }
               ]
             },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -27,6 +27,7 @@
     "BlankSslPolicy": { "Fn::Equals": [ { "Ref": "SslPolicy" }, "" ] },
     "DedicatedBuilder": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstance" }, "" ] } ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
+    "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "EnableCloudWatch" }, "Yes" ] },
     "EncryptEbs" : { "Fn::Equals": [ { "Ref": "EncryptEbs" }, "Yes" ] },
     "ExistingVpc": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "ExistingVpc" }, "" ] } ] },
     "ExistingVpcAndBlankInternetGateway": {
@@ -255,6 +256,10 @@
     "EcsPollInterval": {
       "Value": { "Ref": "EcsPollInterval" }
     },
+    "EnableCloudWatch": {
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:EnableCloudWatch" } },
+      "Value": { "Ref": "EnableCloudWatch" }
+    },
     "EncryptionKey": {
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:EncryptionKey" } },
       "Value": { "Ref": "EncryptionKey" }
@@ -298,6 +303,7 @@
       "Value": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] }
     },
     "LogGroup": {
+      "Condition": "EnableCloudWatch",
       "Value": { "Ref": "LogGroup" }
     },
     "NatGateways": {
@@ -600,6 +606,12 @@
       "Default": "1",
       "Description": "How often to poll ECS for service events in seconds. Longer intervals may alleviate rate limiting / throttling from ECS."
     },
+    "EnableCloudWatch": {
+      "Type": "String",
+      "Description": "Enable CloudWatch log group",
+      "Default": "Yes",
+      "AllowedValues": [ "Yes", "No" ]
+    },
     "EncryptEbs": {
       "Type": "String",
       "Description": "Enable encryption at rest for EBS volumes",
@@ -886,6 +898,7 @@
     },
     "LogGroup": {
       "Type": "AWS::Logs::LogGroup",
+      "Condition": "EnableCloudWatch",
       "Properties": {
         "RetentionInDays": { "Fn::If": [ "BlankLogRetention", { "Ref": "AWS::NoValue" }, { "Ref": "LogRetention" } ] }
       }
@@ -2922,6 +2935,7 @@
               "rack.DynamoBuilds": { "Ref": "DynamoBuilds" },
               "rack.DynamoReleases": { "Ref": "DynamoReleases" },
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
+              "rack.EnableCloudWatch": { "Ref": "EnableCloudWatch" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
               "rack.Fargate": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] },
               "rack.HighAvailability": { "Ref": "HighAvailability" },
@@ -3012,6 +3026,7 @@
               "rack.DynamoBuilds": { "Ref": "DynamoBuilds" },
               "rack.DynamoReleases": { "Ref": "DynamoReleases" },
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
+              "rack.EnableCloudWatch": { "Ref": "EnableCloudWatch" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
               "rack.Fargate": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] },
               "rack.HighAvailability": { "Ref": "HighAvailability" },
@@ -3067,12 +3082,24 @@
               "InitProcessEnabled": "true"
             },
             "LogConfiguration": {
-              "LogDriver": "awslogs",
-              "Options": {
-                "awslogs-region": { "Ref": "AWS::Region" },
-                "awslogs-group": { "Ref": "LogGroup" },
-                "awslogs-stream-prefix": "service"
-              }
+              "Fn::If": [
+                "EnableCloudWatch",
+                {
+                  "LogDriver": "awslogs",
+                  "Options": {
+                    "awslogs-region": {
+                      "Ref": "AWS::Region"
+                    },
+                    "awslogs-group": {
+                      "Ref": "LogGroup"
+                    },
+                    "awslogs-stream-prefix": "service"
+                  }
+                },
+                {
+                  "Ref": "AWS::NoValue"
+                }
+              ]
             },
             "Memory": { "Ref": "ApiMonitorMemory" },
             "MountPoints": [ { "SourceVolume": "docker", "ContainerPath": "/var/run/docker.sock" } ],
@@ -3120,6 +3147,7 @@
               "rack.DynamoBuilds": { "Ref": "DynamoBuilds" },
               "rack.DynamoReleases": { "Ref": "DynamoReleases" },
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
+              "rack.EnableCloudWatch": { "Ref": "EnableCloudWatch" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
               "rack.Fargate": { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "Fargate" ] },
               "rack.HighAvailability": { "Ref": "HighAvailability" },
@@ -3176,12 +3204,24 @@
               "InitProcessEnabled": "true"
             },
             "LogConfiguration": {
-              "LogDriver": "awslogs",
-              "Options": {
-                "awslogs-region": { "Ref": "AWS::Region" },
-                "awslogs-group": { "Ref": "LogGroup" },
-                "awslogs-stream-prefix": "service"
-              }
+              "Fn::If": [
+                "EnableCloudWatch",
+                {
+                  "LogDriver": "awslogs",
+                  "Options": {
+                    "awslogs-region": {
+                      "Ref": "AWS::Region"
+                    },
+                    "awslogs-group": {
+                      "Ref": "LogGroup"
+                    },
+                    "awslogs-stream-prefix": "service"
+                  }
+                },
+                {
+                  "Ref": "AWS::NoValue"
+                }
+              ]
             },
             "MemoryReservation": { "Ref": "ApiWebMemory" },
             "MountPoints": [ { "SourceVolume": "docker", "ContainerPath": "/var/run/docker.sock" } ],

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -4,7 +4,8 @@
     "Conditions": {
       "CircuitBreaker": { "Fn::Equals": [ { "Ref": "CircuitBreaker" }, "Yes" ] },
       "EC2Launch": { "Fn::Not": [ { "Condition": "FargateEither" } ] },
-      "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "EnableCloudWatch" }, "Yes" ] },
+      "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "LogDriver" }, "CloudWatch" ] },
+      "EnableSyslog": { "Fn::Equals": [ { "Ref": "LogDriver" }, "Syslog" ] },
       "FargateEither": { "Fn::Or": [ { "Condition": "FargateBase" }, { "Condition": "FargateSpot" } ] },
       "FargateBase": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
       "FargateSpot": { "Fn::Equals": [ { "Ref": "Fargate" }, "Spot" ] },
@@ -61,12 +62,6 @@
       "Cpu": {
         "Type": "Number"
       },
-      "EnableCloudWatch": {
-        "Type": "String",
-        "Description": "Enable CloudWatch log group",
-        "Default": "Yes",
-        "AllowedValues": [ "Yes", "No" ]
-      },
       "Fargate": {
         "Type": "String",
         "Default": "No",
@@ -92,6 +87,12 @@
         "Type": "String",
         "Default": "200-399,401",
         "Description": "Specifies the HTTP codes that healthy targets must use when responding to an HTTP health check.  You can specify values between 200 and 499, and the default value is \"200-399,401\". You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\")."
+      },
+      "LogDriver": {
+        "Default": "CloudWatch",
+        "Description": "Log driver used by the rack and services to send logs. Default to CloudWatch. You must provide the SyslogDestination when setting as Syslog. It disable logs if blank.",
+        "Type": "String",
+        "AllowedValues": [ "CloudWatch", "Syslog", ""]
       },
       "LogGroup": {
         "Default": "",
@@ -130,12 +131,6 @@
       "Role": {
         "Type": "String"
       },
-      "TaskTags": {
-        "Type": "String",
-        "Default": "No",
-        "Description": "Enable tag propagation to ECS tasks",
-        "AllowedValues": [ "Yes", "No" ]
-      },
       "Settings": {
         "Type": "String"
       },
@@ -144,6 +139,22 @@
         "Default": "0",
         "Description": "The ramp up period during which a newly deployed service will receive an increasing share of traffic. Defaults to 0 seconds (disabled)",
         "AllowedPattern": "^(0|[3-8][0-9]|9[0-9]|[1-8][0-9]{2}|900)$"
+      },
+      "SyslogDestination": {
+        "Type": "String",
+        "Description": "Syslog address destination, you need to pass the protocol to be used, e.g. tcp+tls://logsX.syslog.com:1234",
+        "Default": ""
+      },
+      "SyslogFormat": {
+        "Type": "String",
+        "Description": "Syslog format to sent to SyslogDestination.",
+        "Default": "rfc5424"
+      },
+      "TaskTags": {
+        "Type": "String",
+        "Default": "No",
+        "Description": "Enable tag propagation to ECS tasks",
+        "AllowedValues": [ "Yes", "No" ]
       }
     },
     "Resources": {
@@ -539,21 +550,29 @@
               "Privileged": "{{ .Privileged }}",
               "LogConfiguration": {
                 "Fn::If": [
-                  "EnableCloudWatch",
+                  "EnableSyslog",
                   {
-                    "LogDriver": "awslogs",
+                    "LogDriver": "syslog",
                     "Options": {
-                      "awslogs-region": {
-                        "Ref": "AWS::Region"
-                      },
-                      "awslogs-group": {
-                        "Ref": "LogGroup"
-                      },
-                      "awslogs-stream-prefix": "service"
+                      "syslog-address": { "Ref": "SyslogDestination" },
+                      "syslog-format": { "Ref": "SyslogFormat" }
                     }
                   },
                   {
-                    "Ref": "AWS::NoValue"
+                    "Fn::If": [
+                      "EnableCloudWatch",
+                      {
+                        "LogDriver": "awslogs",
+                        "Options": {
+                          "awslogs-region": { "Ref": "AWS::Region" },
+                          "awslogs-group": { "Ref": "LogGroup" },
+                          "awslogs-stream-prefix": "service"
+                        }
+                      },
+                      {
+                        "Ref": "AWS::NoValue"
+                      }
+                    ]
                   }
                 ]
               },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -4,6 +4,7 @@
     "Conditions": {
       "CircuitBreaker": { "Fn::Equals": [ { "Ref": "CircuitBreaker" }, "Yes" ] },
       "EC2Launch": { "Fn::Not": [ { "Condition": "FargateEither" } ] },
+      "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "EnableCloudWatch" }, "Yes" ] },
       "FargateEither": { "Fn::Or": [ { "Condition": "FargateBase" }, { "Condition": "FargateSpot" } ] },
       "FargateBase": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
       "FargateSpot": { "Fn::Equals": [ { "Ref": "Fargate" }, "Spot" ] },
@@ -53,12 +54,18 @@
         "Type": "String",
         "Default": "No",
         "AllowedValues": [ "Yes", "No" ]
-      },      
+      },
       "Count": {
         "Type": "Number"
       },
       "Cpu": {
         "Type": "Number"
+      },
+      "EnableCloudWatch": {
+        "Type": "String",
+        "Description": "Enable CloudWatch log group",
+        "Default": "Yes",
+        "AllowedValues": [ "Yes", "No" ]
       },
       "Fargate": {
         "Type": "String",
@@ -87,6 +94,7 @@
         "Description": "Specifies the HTTP codes that healthy targets must use when responding to an HTTP health check.  You can specify values between 200 and 499, and the default value is \"200-399,401\". You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\")."
       },
       "LogGroup": {
+        "Default": "",
         "Type": "String"
       },
       "Memory": {
@@ -130,7 +138,7 @@
       },
       "Settings": {
         "Type": "String"
-      },      
+      },
       "SlowStartDuration": {
         "Type": "String",
         "Default": "0",
@@ -530,12 +538,24 @@
               },
               "Privileged": "{{ .Privileged }}",
               "LogConfiguration": {
-                "LogDriver": "awslogs",
-                "Options": {
-                  "awslogs-region": { "Ref": "AWS::Region" },
-                  "awslogs-group": { "Ref": "LogGroup" },
-                  "awslogs-stream-prefix": "service"
-                }
+                "Fn::If": [
+                  "EnableCloudWatch",
+                  {
+                    "LogDriver": "awslogs",
+                    "Options": {
+                      "awslogs-region": {
+                        "Ref": "AWS::Region"
+                      },
+                      "awslogs-group": {
+                        "Ref": "LogGroup"
+                      },
+                      "awslogs-stream-prefix": "service"
+                    }
+                  },
+                  {
+                    "Ref": "AWS::NoValue"
+                  }
+                ]
               },
               "Memory": { "Ref": "Memory" },
               "MountPoints": [

--- a/provider/aws/formation/timer.json.tmpl
+++ b/provider/aws/formation/timer.json.tmpl
@@ -2,6 +2,7 @@
   {
     "AWSTemplateFormatVersion" : "2010-09-09",
     "Conditions": {
+      "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "EnableCloudWatch" }, "Yes" ] },
       "FargateEither": { "Fn::Or": [ { "Condition": "FargateBase" }, { "Condition": "FargateSpot" } ] },
       "FargateBase": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
       "FargateSpot": { "Fn::Equals": [ { "Ref": "Fargate" }, "Spot" ] },
@@ -19,6 +20,12 @@
       "Cpu": {
         "Type": "Number"
       },
+      "EnableCloudWatch": {
+        "Type": "String",
+        "Description": "Enable CloudWatch log group",
+        "Default": "Yes",
+        "AllowedValues": [ "Yes", "No" ]
+      },
       "ExecutionRole": {
         "Type": "String"
       },
@@ -31,6 +38,7 @@
         "Type": "String"
       },
       "LogGroup": {
+        "Default": "",
         "Type": "String"
       },
       "Memory": {
@@ -136,12 +144,24 @@
                 ],
                 "Image": { "Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${Registry}:{{.Name}}.{{$.Release.Build}}" },
                 "LogConfiguration": {
-                  "LogDriver": "awslogs",
-                  "Options": {
-                    "awslogs-region": { "Ref": "AWS::Region" },
-                    "awslogs-group": { "Ref": "LogGroup" },
-                    "awslogs-stream-prefix": "timer"
-                  }
+                  "Fn::If": [
+                    "EnableCloudWatch",
+                    {
+                      "LogDriver": "awslogs",
+                      "Options": {
+                        "awslogs-region": {
+                          "Ref": "AWS::Region"
+                        },
+                        "awslogs-group": {
+                          "Ref": "LogGroup"
+                        },
+                        "awslogs-stream-prefix": "timer"
+                      }
+                    },
+                    {
+                      "Ref": "AWS::NoValue"
+                    }
+                  ]
                 },
                 "Memory": { "Ref": "Memory" },
                 "MountPoints": [

--- a/provider/aws/formation/timer.json.tmpl
+++ b/provider/aws/formation/timer.json.tmpl
@@ -2,7 +2,8 @@
   {
     "AWSTemplateFormatVersion" : "2010-09-09",
     "Conditions": {
-      "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "EnableCloudWatch" }, "Yes" ] },
+      "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "LogDriver" }, "CloudWatch" ] },
+      "EnableSyslog": { "Fn::Equals": [ { "Ref": "LogDriver" }, "Syslog" ] },
       "FargateEither": { "Fn::Or": [ { "Condition": "FargateBase" }, { "Condition": "FargateSpot" } ] },
       "FargateBase": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
       "FargateSpot": { "Fn::Equals": [ { "Ref": "Fargate" }, "Spot" ] },
@@ -20,12 +21,6 @@
       "Cpu": {
         "Type": "Number"
       },
-      "EnableCloudWatch": {
-        "Type": "String",
-        "Description": "Enable CloudWatch log group",
-        "Default": "Yes",
-        "AllowedValues": [ "Yes", "No" ]
-      },
       "ExecutionRole": {
         "Type": "String"
       },
@@ -36,6 +31,12 @@
       },
       "Launcher": {
         "Type": "String"
+      },
+      "LogDriver": {
+        "Default": "CloudWatch",
+        "Description": "Log driver used by the rack and services to send logs. Default to CloudWatch. You must provide the SyslogDestination when setting as Syslog. It disable logs if blank.",
+        "Type": "String",
+        "AllowedValues": [ "CloudWatch", "Syslog", ""]
       },
       "LogGroup": {
         "Default": "",
@@ -69,6 +70,16 @@
       },
       "Settings": {
         "Type": "String"
+      },
+      "SyslogDestination": {
+        "Type": "String",
+        "Description": "Syslog address destination, you need to pass the protocol to be used, e.g. tcp+tls://logsX.syslog.com:1234",
+        "Default": ""
+      },
+      "SyslogFormat": {
+        "Type": "String",
+        "Description": "Syslog format to sent to SyslogDestination.",
+        "Default": "rfc5424"
       }
     },
     "Resources": {
@@ -145,21 +156,29 @@
                 "Image": { "Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${Registry}:{{.Name}}.{{$.Release.Build}}" },
                 "LogConfiguration": {
                   "Fn::If": [
-                    "EnableCloudWatch",
+                    "EnableSyslog",
                     {
-                      "LogDriver": "awslogs",
+                      "LogDriver": "syslog",
                       "Options": {
-                        "awslogs-region": {
-                          "Ref": "AWS::Region"
-                        },
-                        "awslogs-group": {
-                          "Ref": "LogGroup"
-                        },
-                        "awslogs-stream-prefix": "timer"
+                        "syslog-address": { "Ref": "SyslogDestination" },
+                        "syslog-format": { "Ref": "SyslogFormat" }
                       }
                     },
                     {
-                      "Ref": "AWS::NoValue"
+                      "Fn::If": [
+                        "EnableCloudWatch",
+                        {
+                          "LogDriver": "awslogs",
+                          "Options": {
+                            "awslogs-region": { "Ref": "AWS::Region" },
+                            "awslogs-group": { "Ref": "LogGroup" },
+                            "awslogs-stream-prefix": "service"
+                          }
+                        },
+                        {
+                          "Ref": "AWS::NoValue"
+                        }
+                      ]
                     }
                   ]
                 },

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -1439,18 +1439,20 @@ func (p *Provider) taskDefinitionForRun(app, service string, opts structs.Proces
 	}
 
 	group, err := p.stackResource(p.rackStack(app), "LogGroup")
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "resource not found") {
 		return "", err
 	}
 
-	for i := range td.ContainerDefinitions {
-		td.ContainerDefinitions[i].LogConfiguration = &ecs.LogConfiguration{
-			LogDriver: aws.String("awslogs"),
-			Options: map[string]*string{
-				"awslogs-group":         aws.String(*group.PhysicalResourceId),
-				"awslogs-region":        aws.String(p.Region),
-				"awslogs-stream-prefix": aws.String("service"),
-			},
+	if err == nil {
+		for i := range td.ContainerDefinitions {
+			td.ContainerDefinitions[i].LogConfiguration = &ecs.LogConfiguration{
+				LogDriver: aws.String("awslogs"),
+				Options: map[string]*string{
+					"awslogs-group":         aws.String(*group.PhysicalResourceId),
+					"awslogs-region":        aws.String(p.Region),
+					"awslogs-stream-prefix": aws.String("service"),
+				},
+			}
 		}
 	}
 

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -353,9 +353,11 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 	}
 
 	updates := map[string]string{
-		"EnableCloudWatch": p.EnableCloudWatch,
-		"LogBucket":        p.LogBucket,
-		"Private":          private,
+		"LogBucket":         p.LogBucket,
+		"LogDriver":         p.LogDriver,
+		"Private":           private,
+		"SyslogDestination": p.SyslogDestination,
+		"SyslogFormat":      p.SyslogFormat,
 	}
 
 	if m.Params != nil {
@@ -473,7 +475,6 @@ func (p *Provider) releasePromoteGeneration1(a *structs.App, r *structs.Release)
 	params["Cluster"] = p.Cluster
 	params["Key"] = p.EncryptionKey
 	params["ELBLogBucket"] = p.ELBLogBucket
-	params["EnableCloudWatch"] = p.EnableCloudWatch
 	params["LogBucket"] = p.LogBucket
 	params["Rack"] = p.Rack
 	params["Release"] = r.Id

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -353,8 +353,9 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 	}
 
 	updates := map[string]string{
-		"LogBucket": p.LogBucket,
-		"Private":   private,
+		"EnableCloudWatch": p.EnableCloudWatch,
+		"LogBucket":        p.LogBucket,
+		"Private":          private,
 	}
 
 	if m.Params != nil {
@@ -472,6 +473,7 @@ func (p *Provider) releasePromoteGeneration1(a *structs.App, r *structs.Release)
 	params["Cluster"] = p.Cluster
 	params["Key"] = p.EncryptionKey
 	params["ELBLogBucket"] = p.ELBLogBucket
+	params["EnableCloudWatch"] = p.EnableCloudWatch
 	params["LogBucket"] = p.LogBucket
 	params["Rack"] = p.Rack
 	params["Release"] = r.Id


### PR DESCRIPTION
By default, CloudWatch is enabled, it can be changed to `Syslog` or turned off setting `LogDriver` empty.

`SyslogDestination` must be provided if `LogDriver` is `Syslog`.

```
 $ convox rack params set LogDriver=Syslog
ERROR: to enable Syslog as the LogDriver you must pass SyslogDestination parameter
```

Syslog format can be changed on`SyslogFormat`, the default is `rfc5424` (same as the current Syslog resource).