### PR TITLE
Do not fetch metrics if services don't have any process

### DIFF
--- a/provider/aws/metrics.go
+++ b/provider/aws/metrics.go
@@ -23,6 +23,10 @@ var (
 )
 
 func (p *Provider) cloudwatchMetrics(mdqs []metricDataQuerier, opts structs.MetricsOptions) (structs.Metrics, error) {
+	if len(mdqs) == 0 {
+		return nil, fmt.Errorf("can't fetch metrics with empty query")
+	}
+
 	period := ci(opts.Period, 3600)
 
 	req := &cloudwatch.GetMetricDataInput{

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -192,6 +192,9 @@ func (p *Provider) ProcessList(app string, opts structs.ProcessListOptions) (str
 	}
 
 	mdqs := p.servicesMetricQueries(serviceNames)
+	if len(mdqs) == 0 {
+		return ps, nil
+	}
 
 	ms, err := p.cloudwatchMetrics(mdqs, structs.MetricsOptions{
 		Start: aws.Time(time.Now().Add(-5 * time.Minute)),


### PR DESCRIPTION
`ProcessList` will return an "empty" slice.

Changed the `cloudwatchMetrics` function to return a message for empty metrics queries.