### PR TITLE
Fixing syslog json syntax on Timers

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -530,8 +530,8 @@
           {{ end }}
           "Role": { "Fn::GetAtt": [ "TimerRole", "Arn" ] },
           "ServiceRole": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
-          "Settings": { "Ref": "Settings" }
-          "SyslogDestination": { "Ref": "SyslogDestination" }
+          "Settings": { "Ref": "Settings" },
+          "SyslogDestination": { "Ref": "SyslogDestination" },
           "SyslogFormat": { "Ref": "SyslogFormat" }
         },
         "Tags": [


### PR DESCRIPTION
Fix `ERROR: json syntax error: line 664 pos 10: invalid character '"' after object key:value pair` error when deploying an app with Timer configured.