### PR TITLE
Set apps resource enrcrypt as false and use stack policy to prevent replacement

### DIFF
--- a/provider/aws/apps.go
+++ b/provider/aws/apps.go
@@ -261,7 +261,7 @@ func (p *Provider) AppUpdate(app string, opts structs.AppUpdateOptions) error {
 		}
 	}
 
-	return p.updateStack(p.rackStack(app), nil, opts.Parameters, map[string]string{}, "")
+	return p.updateStack(p.rackStack(app), nil, opts.Parameters, map[string]string{}, "", "")
 }
 
 func (p *Provider) appFromStack(stack *cloudformation.Stack) (*structs.App, error) {

--- a/provider/aws/certificates.go
+++ b/provider/aws/certificates.go
@@ -51,7 +51,7 @@ func (p *Provider) certificateApplyGeneration1(a *structs.App, service string, p
 		}
 	}
 
-	return p.updateStack(p.rackStack(a.Name), nil, params, map[string]string{}, "")
+	return p.updateStack(p.rackStack(a.Name), nil, params, map[string]string{}, "", "")
 }
 
 func (p *Provider) CertificateCreate(pub, key string, opts structs.CertificateCreateOptions) (*structs.Certificate, error) {

--- a/provider/aws/formation/resource/mariadb.json.tmpl
+++ b/provider/aws/formation/resource/mariadb.json.tmpl
@@ -9,7 +9,7 @@
       "Type" : "String",
       "Default": "true",
       "AllowedValues" : [ "true", "false" ]
-    },       
+    },
     "Class": {
       "Type": "String",
       "Default": "db.t2.micro"
@@ -21,7 +21,7 @@
     },
     "Encrypted": {
       "Type": "String",
-      "Default": "",
+      "Default": "false",
       "AllowedValues": [ "true", "false", "" ]
     },
     "Iops": {

--- a/provider/aws/formation/resource/mysql.json.tmpl
+++ b/provider/aws/formation/resource/mysql.json.tmpl
@@ -9,7 +9,7 @@
       "Type" : "String",
       "Default": "true",
       "AllowedValues" : [ "true", "false" ]
-    },    
+    },
     "Class": {
       "Type": "String",
       "Default": "db.t2.micro"
@@ -21,7 +21,7 @@
     },
     "Encrypted": {
       "Type": "String",
-      "Default": "",
+      "Default": "false",
       "AllowedValues": [ "true", "false", "" ]
     },
     "Iops": {

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -22,7 +22,7 @@
     },
     "Encrypted": {
       "Type": "String",
-      "Default": "",
+      "Default": "false",
       "AllowedValues": [ "true", "false", "" ]
     },
     "Iops": {

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -1240,7 +1240,7 @@ func (p *Provider) taskDefinitionRelease(arn string) (string, error) {
 // updateStack updates a stack
 //   template is url to a template or empty string to reuse previous
 //   changes is a list of parameter changes to make (does not need to include every param)
-func (p *Provider) updateStack(name string, template []byte, changes map[string]string, tags map[string]string, id string) error {
+func (p *Provider) updateStack(name string, template []byte, changes map[string]string, tags map[string]string, id string, stackPolicy string) error {
 	cache.Clear("describeStacks", nil)
 	cache.Clear("describeStacks", name)
 
@@ -1252,6 +1252,9 @@ func (p *Provider) updateStack(name string, template []byte, changes map[string]
 
 	if id != "" {
 		req.ClientRequestToken = aws.String(id)
+	}
+	if stackPolicy != "" {
+		req.StackPolicyBody = aws.String(stackPolicy)
 	}
 
 	params := map[string]bool{}

--- a/provider/aws/instances.go
+++ b/provider/aws/instances.go
@@ -29,7 +29,7 @@ func (p *Provider) InstanceKeyroll() error {
 		return err
 	}
 
-	if err := p.updateStack(p.Rack, nil, map[string]string{"Key": key}, map[string]string{}, ""); err != nil {
+	if err := p.updateStack(p.Rack, nil, map[string]string{"Key": key}, map[string]string{}, "", ""); err != nil {
 		return err
 	}
 

--- a/provider/aws/resource.go
+++ b/provider/aws/resource.go
@@ -724,7 +724,11 @@ func (p *Provider) updateResource(s *structs.Resource, params map[string]string)
 		"Type":     "resource",
 	}
 
-	if err := p.updateStack(p.rackStack(s.Name), []byte(formation), params, tags, ""); err != nil {
+	policy := ""
+	if params["encrypted"] != "" {
+		policy = DENY_UPDATE_RESOURCE_POLICY
+	}
+	if err := p.updateStack(p.rackStack(s.Name), []byte(formation), params, tags, "", policy); err != nil {
 		return err
 	}
 

--- a/provider/aws/service.go
+++ b/provider/aws/service.go
@@ -256,7 +256,7 @@ func (p *Provider) ServiceUpdate(app, name string, opts structs.ServiceUpdateOpt
 		parts[2] = strconv.Itoa(*opts.Memory)
 	}
 
-	if err := p.updateStack(p.rackStack(a.Name), nil, map[string]string{param: strings.Join(parts, ",")}, map[string]string{}, ""); err != nil {
+	if err := p.updateStack(p.rackStack(a.Name), nil, map[string]string{param: strings.Join(parts, ",")}, map[string]string{}, "", ""); err != nil {
 		return err
 	}
 

--- a/provider/aws/system.go
+++ b/provider/aws/system.go
@@ -593,7 +593,7 @@ func (p *Provider) SystemUpdate(opts structs.SystemUpdateOptions) error {
 		"Type":   "rack",
 	}
 
-	if err := p.updateStack(p.Rack, template, params, tags, ""); err != nil {
+	if err := p.updateStack(p.Rack, template, params, tags, "", ""); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
To avoid replacing app resources created using `encrypted` as an empty string, we will define a stack policy to deny `Update:Replace` for RDS instances.

Use `Encrypted` as `false` for new app resources.