### PR TITLE
Use MicroSecond instead of Millisecond

### DIFF
--- a/pkg/helpers/aws.go
+++ b/pkg/helpers/aws.go
@@ -359,7 +359,7 @@ func CloudWatchLogsStream(ctx context.Context, cw cloudwatchlogsiface.CloudWatch
 	var start int64
 
 	if opts.Since != nil {
-		start = time.Now().UTC().Add((*opts.Since)*-1).UnixNano() / int64(time.Millisecond)
+		start = time.Now().UTC().Add((*opts.Since)*-1).Unix() * int64(time.Microsecond)
 		req.StartTime = aws.Int64(start)
 	}
 


### PR DESCRIPTION
Sometimes the request has a slight difference from the expected startTime. Possibly because when dividing, it would round up to the closest number.

The difference in the request caused it to fail intermittently. The error was happening a lot.

![image](https://user-images.githubusercontent.com/8239709/188744365-6a652879-2afd-4c31-aa35-c4a79e307807.png)

https://app.circleci.com/pipelines/github/convox/rack/4125/workflows/faa681cf-9cbe-4887-9ffa-15c68f14218a/jobs/9824

_I didn't want to include this commit into #3570 because the e2e was running and committing this would restart it._