### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/convox-env/main.go
+++ b/cmd/convox-env/main.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -66,7 +66,7 @@ func fetchConvoxEnv() ([]string, error) {
 	}
 	defer res.Body.Close()
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -2,7 +2,7 @@ package api_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"testing"
 
@@ -46,7 +46,7 @@ func TestCheck(t *testing.T) {
 		res, err := c.GetStream("/check", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		defer res.Body.Close()
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, "ok", string(data))
 	})

--- a/pkg/api/app_test.go
+++ b/pkg/api/app_test.go
@@ -3,7 +3,7 @@ package api_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -176,12 +176,12 @@ func TestAppListError(t *testing.T) {
 func TestAppLogs(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		d1 := []byte("test")
-		r1 := ioutil.NopCloser(bytes.NewReader(d1))
+		r1 := io.NopCloser(bytes.NewReader(d1))
 		opts := structs.LogsOptions{Since: options.Duration(2 * time.Minute)}
 		p.On("AppLogs", "app1", opts).Return(r1, nil)
 		r2, err := c.Websocket("/apps/app1/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		d2, err := ioutil.ReadAll(r2)
+		d2, err := io.ReadAll(r2)
 		require.NoError(t, err)
 		require.Equal(t, d1, d2)
 	})
@@ -194,7 +194,7 @@ func TestAppLogsError(t *testing.T) {
 		r1, err := c.Websocket("/apps/app1/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, r1)
-		d1, err := ioutil.ReadAll(r1)
+		d1, err := io.ReadAll(r1)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ERROR: err1\n"), d1)
 	})

--- a/pkg/api/build_test.go
+++ b/pkg/api/build_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -94,7 +93,7 @@ func TestBuildExport(t *testing.T) {
 		res, err := c.GetStream("/apps/app1/builds/build1.tgz", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		defer res.Body.Close()
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, "data", string(data))
 	})
@@ -138,7 +137,7 @@ func TestBuildImport(t *testing.T) {
 			Body: strings.NewReader("data"),
 		}
 		p.On("BuildImport", "app1", mock.Anything).Return(&b1, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			data, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "data", string(data))
 		})
@@ -161,12 +160,12 @@ func TestBuildImportError(t *testing.T) {
 func TestBuildLogs(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		d1 := []byte("test")
-		r1 := ioutil.NopCloser(bytes.NewReader(d1))
+		r1 := io.NopCloser(bytes.NewReader(d1))
 		opts := structs.LogsOptions{Since: options.Duration(2 * time.Minute)}
 		p.On("BuildLogs", "app1", "build1", opts).Return(r1, nil)
 		r2, err := c.Websocket("/apps/app1/builds/build1/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		d2, err := ioutil.ReadAll(r2)
+		d2, err := io.ReadAll(r2)
 		require.NoError(t, err)
 		require.Equal(t, d1, d2)
 	})
@@ -179,7 +178,7 @@ func TestBuildLogsError(t *testing.T) {
 		r1, err := c.Websocket("/apps/app1/builds/build1/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, r1)
-		d1, err := ioutil.ReadAll(r1)
+		d1, err := io.ReadAll(r1)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ERROR: err1\n"), d1)
 	})

--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -1448,4 +1448,3 @@ func (s *Server) SystemUpdate(c *stdapi.Context) error {
 func (s *Server) Workers(c *stdapi.Context) error {
 	return stdapi.Errorf(404, "not available via api")
 }
-

--- a/pkg/api/files_test.go
+++ b/pkg/api/files_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -51,7 +50,7 @@ func TestFilesDownload(t *testing.T) {
 		res, err := c.GetStream("/apps/app1/processes/pid1/files", opts)
 		require.NoError(t, err)
 		defer res.Body.Close()
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, "data", string(data))
 	})
@@ -77,7 +76,7 @@ func TestFilesUpload(t *testing.T) {
 			Body: strings.NewReader("data"),
 		}
 		p.On("FilesUpload", "app1", "pid1", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			data, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "data", string(data))
 		})

--- a/pkg/api/instance_test.go
+++ b/pkg/api/instance_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -82,13 +81,13 @@ func TestInstanceShell(t *testing.T) {
 		p.On("InstanceShell", "instance1", mock.Anything, opts).Return(1, nil).Run(func(args mock.Arguments) {
 			rw := args.Get(1).(io.ReadWriter)
 			rw.Write([]byte("out"))
-			data, err := ioutil.ReadAll(rw)
+			data, err := io.ReadAll(rw)
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 		})
 		r, err := c.Websocket("/instances/instance1/shell", ro)
 		require.NoError(t, err)
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, "outF1E49A85-0AD7-4AEF-A618-C249C6E6568D:1\n", string(data))
 	})
@@ -99,7 +98,7 @@ func TestInstanceShellError(t *testing.T) {
 		p.On("InstanceShell", "instance1", mock.Anything, structs.InstanceShellOptions{}).Return(0, fmt.Errorf("err1"))
 		r, err := c.Websocket("/instances/instance1/shell", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		d, err := ioutil.ReadAll(r)
+		d, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ERROR: err1\n"), d)
 	})

--- a/pkg/api/object_test.go
+++ b/pkg/api/object_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -57,13 +56,13 @@ func TestObjectExistsError(t *testing.T) {
 func TestObjectFetch(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		d1 := []byte("test")
-		r1 := ioutil.NopCloser(bytes.NewReader(d1))
+		r1 := io.NopCloser(bytes.NewReader(d1))
 		p.On("ObjectFetch", "app1", "path/object1.ext").Return(r1, nil)
 		res, err := c.GetStream("/apps/app1/objects/path/object1.ext", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, res)
 		defer res.Body.Close()
-		d2, err := ioutil.ReadAll(res.Body)
+		d2, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, d1, d2)
 	})
@@ -118,7 +117,7 @@ func TestObjectStore(t *testing.T) {
 			Body: strings.NewReader("data"),
 		}
 		p.On("ObjectStore", "app1", "path/object1.ext", mock.Anything, opts).Return(&o1, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			data, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "data", string(data))
 		})

--- a/pkg/api/process_test.go
+++ b/pkg/api/process_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -54,13 +53,13 @@ func TestProcessExec(t *testing.T) {
 		p.On("ProcessExec", "app1", "pid1", "command", mock.Anything, opts).Return(1, nil).Run(func(args mock.Arguments) {
 			rw := args.Get(3).(io.ReadWriter)
 			rw.Write([]byte("out"))
-			data, err := ioutil.ReadAll(rw)
+			data, err := io.ReadAll(rw)
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 		})
 		r, err := c.Websocket("/apps/app1/processes/pid1/exec", ro)
 		require.NoError(t, err)
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, "outF1E49A85-0AD7-4AEF-A618-C249C6E6568D:1\n", string(data))
 	})
@@ -82,10 +81,10 @@ func TestProcessLogs(t *testing.T) {
 				"Since":  "2m",
 			},
 		}
-		p.On("ProcessLogs", "app1", "pid1", opts).Return(ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil)
+		p.On("ProcessLogs", "app1", "pid1", opts).Return(io.NopCloser(bytes.NewBuffer([]byte{})), nil)
 		r, err := c.Websocket("/apps/app1/processes/pid1/logs", ro)
 		require.NoError(t, err)
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, "", string(data))
 	})
@@ -114,7 +113,7 @@ func TestProcessExecError(t *testing.T) {
 		p.On("ProcessExec", "app1", "pid1", "command", mock.Anything, opts).Return(0, fmt.Errorf("err1"))
 		r, err := c.Websocket("/apps/app1/processes/pid1/exec", ro)
 		require.NoError(t, err)
-		d, err := ioutil.ReadAll(r)
+		d, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ERROR: err1\n"), d)
 	})
@@ -125,7 +124,7 @@ func TestProcessExecValidate(t *testing.T) {
 		p.On("AppGet", "app1").Return(nil, fmt.Errorf("no such app: app1"))
 		r, err := c.Websocket("/apps/app1/processes/pid1/exec", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, "ERROR: no such app: app1\n", string(data))
 	})

--- a/pkg/api/proxy_test.go
+++ b/pkg/api/proxy_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -21,13 +20,13 @@ func TestProxy(t *testing.T) {
 		p.On("Proxy", "host", 5000, mock.Anything, structs.ProxyOptions{}).Return(nil).Run(func(args mock.Arguments) {
 			rw := args.Get(2).(io.ReadWriter)
 			rw.Write([]byte("out"))
-			data, err := ioutil.ReadAll(rw)
+			data, err := io.ReadAll(rw)
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 		})
 		r, err := c.Websocket("/proxy/host/5000", ro)
 		require.NoError(t, err)
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, "out", string(data))
 	})
@@ -38,7 +37,7 @@ func TestProxyError(t *testing.T) {
 		p.On("Proxy", "host", 5000, mock.Anything, structs.ProxyOptions{}).Return(fmt.Errorf("err1"))
 		r, err := c.Websocket("/proxy/host/5000", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		d, err := ioutil.ReadAll(r)
+		d, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ERROR: err1\n"), d)
 	})

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -76,4 +76,3 @@ func (s *Server) setupRoutes(r stdapi.Router) {
 	r.Route("PUT", "/system", s.SystemUpdate)
 	r.Route("", "", s.Workers)
 }
-

--- a/pkg/api/system_test.go
+++ b/pkg/api/system_test.go
@@ -3,7 +3,7 @@ package api_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -68,12 +68,12 @@ func TestSystemGetError(t *testing.T) {
 func TestSystemLogs(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		d1 := []byte("test")
-		r1 := ioutil.NopCloser(bytes.NewReader(d1))
+		r1 := io.NopCloser(bytes.NewReader(d1))
 		opts := structs.LogsOptions{Since: options.Duration(2 * time.Minute)}
 		p.On("SystemLogs", opts).Return(r1, nil)
 		r2, err := c.Websocket("/system/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		d2, err := ioutil.ReadAll(r2)
+		d2, err := io.ReadAll(r2)
 		require.NoError(t, err)
 		require.Equal(t, d1, d2)
 	})
@@ -86,7 +86,7 @@ func TestSystemLogsError(t *testing.T) {
 		r1, err := c.Websocket("/system/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, r1)
-		d1, err := ioutil.ReadAll(r1)
+		d1, err := io.ReadAll(r1)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ERROR: err1\n"), d1)
 	})

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -6,12 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
-	"sort"
-	// "os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -100,7 +98,7 @@ func (bb *Build) execute() error {
 		return err
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -138,7 +136,7 @@ func (bb *Build) execute() error {
 		return err
 	}
 
-	data, err := ioutil.ReadFile(bb.Manifest)
+	data, err := os.ReadFile(bb.Manifest)
 	if err != nil {
 		return err
 	}
@@ -197,7 +195,7 @@ func (bb *Build) buildGeneration1(dir string) error {
 		return fmt.Errorf("no such file: %s", bb.Manifest)
 	}
 
-	data, err := ioutil.ReadFile(dcy)
+	data, err := os.ReadFile(dcy)
 	if err != nil {
 		return err
 	}
@@ -250,7 +248,7 @@ func (bb *Build) buildGeneration2(dir string) error {
 		return fmt.Errorf("no such file: %s", bb.Manifest)
 	}
 
-	data, err := ioutil.ReadFile(config)
+	data, err := os.ReadFile(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -30,10 +30,10 @@ func TestBuildGeneration2(t *testing.T) {
 
 	testBuild(t, opts, func(b *build.Build, p *structs.MockProvider, e *exec.MockInterface, out *bytes.Buffer) {
 		p.On("BuildGet", "app1", "build1").Return(fxBuildStarted(), nil).Once()
-		bdata, err := ioutil.ReadFile("testdata/httpd.tgz")
+		bdata, err := os.ReadFile("testdata/httpd.tgz")
 		require.NoError(t, err)
-		p.On("ObjectFetch", "app1", "/object.tgz").Return(ioutil.NopCloser(bytes.NewReader(bdata)), nil)
-		mdata, err := ioutil.ReadFile("testdata/httpd/convox.yml")
+		p.On("ObjectFetch", "app1", "/object.tgz").Return(io.NopCloser(bytes.NewReader(bdata)), nil)
+		mdata, err := os.ReadFile("testdata/httpd/convox.yml")
 		require.NoError(t, err)
 		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
 		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
@@ -45,7 +45,7 @@ func TestBuildGeneration2(t *testing.T) {
 		e.On("Execute", "docker", "tag", "httpd", "rack1/app1:web.build1").Return([]byte("tagging\n"), nil)
 		e.On("Execute", "docker", "tag", "049f26f1b03bfca2e3af367d481a7bf1a94564ba", "rack1/app1:web2.build1").Return([]byte("tagging\n"), nil)
 		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			data, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "Building: .\nbuild1\nbuild2\nRunning: docker pull httpd\nRunning: docker tag 049f26f1b03bfca2e3af367d481a7bf1a94564ba rack1/app1:web2.build1\nRunning: docker tag httpd rack1/app1:web.build1\n", string(data))
 		})
@@ -95,10 +95,10 @@ func TestBuildGeneration2Development(t *testing.T) {
 
 	testBuild(t, opts, func(b *build.Build, p *structs.MockProvider, e *exec.MockInterface, out *bytes.Buffer) {
 		p.On("BuildGet", "app1", "build1").Return(fxBuildStarted(), nil).Once()
-		bdata, err := ioutil.ReadFile("testdata/httpd-dev.tgz")
+		bdata, err := os.ReadFile("testdata/httpd-dev.tgz")
 		require.NoError(t, err)
-		p.On("ObjectFetch", "app1", "/object.tgz").Return(ioutil.NopCloser(bytes.NewReader(bdata)), nil)
-		mdata, err := ioutil.ReadFile("testdata/httpd-dev/convox.yml")
+		p.On("ObjectFetch", "app1", "/object.tgz").Return(io.NopCloser(bytes.NewReader(bdata)), nil)
+		mdata, err := os.ReadFile("testdata/httpd-dev/convox.yml")
 		require.NoError(t, err)
 		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
 		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
@@ -108,7 +108,7 @@ func TestBuildGeneration2Development(t *testing.T) {
 		e.On("Execute", "docker", "inspect", "049f26f1b03bfca2e3af367d481a7bf1a94564ba", "--format", "{{json .Config.Entrypoint}}").Return([]byte("[]"), nil)
 		e.On("Execute", "docker", "tag", "049f26f1b03bfca2e3af367d481a7bf1a94564ba", "rack1/app1:web.build1").Return([]byte("tagging\n"), nil)
 		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			data, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "Building: .\nbuild1\nbuild2\nRunning: docker tag 049f26f1b03bfca2e3af367d481a7bf1a94564ba rack1/app1:web.build1\n", string(data))
 		})
@@ -155,10 +155,10 @@ func TestBuildGeneration2Entrypoint(t *testing.T) {
 
 	testBuild(t, opts, func(b *build.Build, p *structs.MockProvider, e *exec.MockInterface, out *bytes.Buffer) {
 		p.On("BuildGet", "app1", "build1").Return(fxBuildStarted(), nil).Once()
-		bdata, err := ioutil.ReadFile("testdata/httpd.tgz")
+		bdata, err := os.ReadFile("testdata/httpd.tgz")
 		require.NoError(t, err)
-		p.On("ObjectFetch", "app1", "/object.tgz").Return(ioutil.NopCloser(bytes.NewReader(bdata)), nil)
-		mdata, err := ioutil.ReadFile("testdata/httpd/convox.yml")
+		p.On("ObjectFetch", "app1", "/object.tgz").Return(io.NopCloser(bytes.NewReader(bdata)), nil)
+		mdata, err := os.ReadFile("testdata/httpd/convox.yml")
 		require.NoError(t, err)
 		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
 		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
@@ -170,7 +170,7 @@ func TestBuildGeneration2Entrypoint(t *testing.T) {
 		e.On("Execute", "docker", "tag", "httpd", "rack1/app1:web.build1").Return([]byte("tagging\n"), nil)
 		e.On("Execute", "docker", "tag", "049f26f1b03bfca2e3af367d481a7bf1a94564ba", "rack1/app1:web2.build1").Return([]byte("tagging\n"), nil)
 		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			data, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "Building: .\nbuild1\nbuild2\nRunning: docker pull httpd\nRunning: docker tag 049f26f1b03bfca2e3af367d481a7bf1a94564ba rack1/app1:web2.build1\nRunning: docker tag httpd rack1/app1:web.build1\n", string(data))
 		})
@@ -222,7 +222,7 @@ func TestBuildGeneration2Failure(t *testing.T) {
 		p.On("BuildGet", "app1", "build1").Return(fxBuildStarted(), nil)
 		p.On("ObjectFetch", "app1", "/object.tgz").Return(nil, fmt.Errorf("err1"))
 		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			data, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "ERROR: err1\n", string(data))
 		})
@@ -267,15 +267,15 @@ func TestBuildGeneration2Options(t *testing.T) {
 	testBuild(t, opts, func(b *build.Build, p *structs.MockProvider, e *exec.MockInterface, out *bytes.Buffer) {
 		p.On("BuildGet", "app1", "build1").Return(fxBuildStarted(), nil).Once()
 		e.On("Stream", mock.Anything, mock.Anything, "docker", "login", "-u", "user1", "--password-stdin", "host1").Return(nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			data, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "pass1", string(data))
 			fmt.Fprintf(args.Get(0).(io.Writer), "login-success\n")
 		})
-		bdata, err := ioutil.ReadFile("testdata/httpd.tgz")
+		bdata, err := os.ReadFile("testdata/httpd.tgz")
 		require.NoError(t, err)
-		p.On("ObjectFetch", "app1", "/object.tgz").Return(ioutil.NopCloser(bytes.NewReader(bdata)), nil)
-		mdata, err := ioutil.ReadFile("testdata/httpd/convox2.yml")
+		p.On("ObjectFetch", "app1", "/object.tgz").Return(io.NopCloser(bytes.NewReader(bdata)), nil)
+		mdata, err := os.ReadFile("testdata/httpd/convox2.yml")
 		require.NoError(t, err)
 		// p.On("BuildUpdate", "app1", "build1", structs.BuildUpdateOptions{Manifest: options.String(string(mdata))}).Return(fxBuildStarted(), nil).Once()
 		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
@@ -292,7 +292,7 @@ func TestBuildGeneration2Options(t *testing.T) {
 		e.On("Execute", "docker", "build", "-t", "rack1/app1:web.build1", mock.AnythingOfType("string")).Return([]byte("building convox-env\n"), nil)
 		e.On("Execute", "docker", "push", "push1:web.build1").Return([]byte("pushing\n"), nil)
 		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			data, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "Authenticating host1: login-success\nBuilding: .\nbuild1\nbuild2\nRunning: docker tag 63b602b07e75429dbf1ab14132f20c9e5a649f2f rack1/app1:web.build1\nInjecting: convox-env\nRunning: docker tag rack1/app1:web.build1 push1:web.build1\nRunning: docker push push1:web.build1\n", string(data))
 		})

--- a/pkg/build/docker.go
+++ b/pkg/build/docker.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -143,7 +142,7 @@ func (bb *Build) injectConvoxEnv(tag string) error {
 		epdfs += fmt.Sprintf("CMD %s\n", cmdb)
 	}
 
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -154,7 +153,7 @@ func (bb *Build) injectConvoxEnv(tag string) error {
 
 	epdf := filepath.Join(tmp, "Dockerfile")
 
-	if err := ioutil.WriteFile(epdf, []byte(epdfs), 0644); err != nil {
+	if err := os.WriteFile(epdf, []byte(epdfs), 0644); err != nil {
 		return err
 	}
 

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -232,7 +231,7 @@ func AppsImport(rack sdk.Interface, c *stdcli.Context) error {
 		if c.Reader().IsTerminal() {
 			return fmt.Errorf("pipe a file into this command or specify --file")
 		}
-		r = ioutil.NopCloser(c.Reader())
+		r = io.NopCloser(c.Reader())
 	}
 
 	defer r.Close()
@@ -399,7 +398,7 @@ func AppsWait(rack sdk.Interface, c *stdcli.Context) error {
 }
 
 func appExport(rack sdk.Interface, c *stdcli.Context, app string, w io.Writer) error {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -423,7 +422,7 @@ func appExport(rack sdk.Interface, c *stdcli.Context, app string, w io.Writer) e
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(tmp, "app.json"), data, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "app.json"), data, 0600); err != nil {
 		return err
 	}
 
@@ -437,7 +436,7 @@ func appExport(rack sdk.Interface, c *stdcli.Context, app string, w io.Writer) e
 			return err
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(tmp, "env"), []byte(r.Env), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(tmp, "env"), []byte(r.Env), 0600); err != nil {
 			return err
 		}
 
@@ -477,7 +476,7 @@ func appExport(rack sdk.Interface, c *stdcli.Context, app string, w io.Writer) e
 }
 
 func appImport(rack sdk.Interface, c *stdcli.Context, app string, r io.Reader) error {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -494,7 +493,7 @@ func appImport(rack sdk.Interface, c *stdcli.Context, app string, r io.Reader) e
 
 	var a structs.App
 
-	data, err := ioutil.ReadFile(filepath.Join(tmp, "app.json"))
+	data, err := os.ReadFile(filepath.Join(tmp, "app.json"))
 	if err != nil {
 		return err
 	}
@@ -538,7 +537,7 @@ func appImport(rack sdk.Interface, c *stdcli.Context, app string, r io.Reader) e
 	}
 
 	if _, err := os.Stat(env); !os.IsNotExist(err) {
-		data, err := ioutil.ReadFile(env)
+		data, err := os.ReadFile(env)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -4,7 +4,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -233,13 +232,13 @@ func TestAppsExport(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("AppGet", "app1").Return(fxApp(), nil)
 		i.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
-		bdata, err := ioutil.ReadFile("testdata/build.tgz")
+		bdata, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildExport", "app1", "build1", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			args.Get(2).(io.Writer).Write(bdata)
 		})
 
-		tmp, err := ioutil.TempDir("", "")
+		tmp, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmp)
 
@@ -264,15 +263,15 @@ func TestAppsExport(t *testing.T) {
 		err = helpers.Unarchive(gz, tmp)
 		require.NoError(t, err)
 
-		data, err := ioutil.ReadFile(filepath.Join(tmp, "app.json"))
+		data, err := os.ReadFile(filepath.Join(tmp, "app.json"))
 		require.NoError(t, err)
 		require.Equal(t, "{\"generation\":\"2\",\"locked\":false,\"name\":\"app1\",\"release\":\"release1\",\"router\":\"\",\"status\":\"running\",\"parameters\":{\"ParamFoo\":\"value1\",\"ParamOther\":\"value2\"}}", string(data))
 
-		data, err = ioutil.ReadFile(filepath.Join(tmp, "env"))
+		data, err = os.ReadFile(filepath.Join(tmp, "env"))
 		require.NoError(t, err)
 		require.Equal(t, "FOO=bar\nBAZ=quux", string(data))
 
-		data, err = ioutil.ReadFile(filepath.Join(tmp, "build.tgz"))
+		data, err = os.ReadFile(filepath.Join(tmp, "build.tgz"))
 		require.NoError(t, err)
 		require.Equal(t, bdata, data)
 	})
@@ -283,10 +282,10 @@ func TestAppsImport(t *testing.T) {
 		i.On("AppCreate", "app1", structs.AppCreateOptions{Generation: options.String("2")}).Return(fxApp(), nil)
 		i.On("AppGet", "app1").Return(&structs.App{Status: "creating"}, nil).Twice()
 		i.On("AppGet", "app1").Return(fxApp(), nil).Twice()
-		bdata, err := ioutil.ReadFile("testdata/build.tgz")
+		bdata, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildImport", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, bdata, rdata)
 		})
@@ -337,10 +336,10 @@ func TestAppsImportNoParams(t *testing.T) {
 		i.On("AppCreate", "app1", structs.AppCreateOptions{Generation: options.String("2")}).Return(fxApp(), nil)
 		i.On("AppGet", "app1").Return(&structs.App{Status: "creating"}, nil).Twice()
 		i.On("AppGet", "app1").Return(fxApp(), nil).Twice()
-		bdata, err := ioutil.ReadFile("testdata/build.tgz")
+		bdata, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildImport", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, bdata, rdata)
 		})
@@ -366,10 +365,10 @@ func TestAppsImportSameParams(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("AppCreate", "app1", structs.AppCreateOptions{Generation: options.String("2")}).Return(fxApp(), nil)
 		i.On("AppGet", "app1").Return(fxApp(), nil).Twice()
-		bdata, err := ioutil.ReadFile("testdata/build.tgz")
+		bdata, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildImport", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, bdata, rdata)
 		})

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 
@@ -44,7 +44,7 @@ func authenticator(c *stdcli.Context) stdsdk.Authenticator {
 			}
 			defer ares.Body.Close()
 
-			dres, err := ioutil.ReadAll(ares.Body)
+			dres, err := io.ReadAll(ares.Body)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -189,7 +188,7 @@ func finalizeBuildLogs(rack structs.Provider, c *stdcli.Context, b *structs.Buil
 	}
 	defer r.Close()
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}
@@ -272,7 +271,7 @@ func BuildsImport(rack sdk.Interface, c *stdcli.Context) error {
 		if c.Reader().IsTerminal() {
 			return fmt.Errorf("pipe a file into this command or specify --file")
 		}
-		r = ioutil.NopCloser(c.Reader())
+		r = io.NopCloser(c.Reader())
 	}
 
 	defer r.Close()

--- a/pkg/cli/builds_test.go
+++ b/pkg/cli/builds_test.go
@@ -3,7 +3,7 @@ package cli_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -151,12 +151,12 @@ func TestBuildsError(t *testing.T) {
 
 func TestBuildsExport(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		data, err := ioutil.ReadFile("testdata/build.tgz")
+		data, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildExport", "app1", "build1", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			args.Get(2).(io.Writer).Write(data)
 		})
-		tmpd, err := ioutil.TempDir("", "")
+		tmpd, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		tmpf := filepath.Join(tmpd, "export.tgz")
 
@@ -165,7 +165,7 @@ func TestBuildsExport(t *testing.T) {
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{"Exporting build... OK"})
-		tdata, err := ioutil.ReadFile(tmpf)
+		tdata, err := os.ReadFile(tmpf)
 		require.NoError(t, err)
 		require.Equal(t, data, tdata)
 	})
@@ -173,7 +173,7 @@ func TestBuildsExport(t *testing.T) {
 
 func TestBuildsExportStdout(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		data, err := ioutil.ReadFile("testdata/build.tgz")
+		data, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildExport", "app1", "build1", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			args.Get(2).(io.Writer).Write(data)
@@ -201,11 +201,11 @@ func TestBuildsExportError(t *testing.T) {
 
 func TestBuildsImport(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		data, err := ioutil.ReadFile("testdata/build.tgz")
+		data, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("SystemGet").Return(fxSystem(), nil)
 		i.On("BuildImport", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, data, rdata)
 		})
@@ -233,11 +233,11 @@ func TestBuildsImportError(t *testing.T) {
 
 func TestBuildsImportClassic(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		data, err := ioutil.ReadFile("testdata/build.tgz")
+		data, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("SystemGet").Return(fxSystemClassic(), nil)
 		i.On("BuildImportMultipart", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, data, rdata)
 		})

--- a/pkg/cli/certs.go
+++ b/pkg/cli/certs.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/convox/rack/pkg/helpers"
 	"github.com/convox/rack/pkg/options"
@@ -105,12 +105,12 @@ func CertsImport(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	pub, err := ioutil.ReadFile(c.Arg(0))
+	pub, err := os.ReadFile(c.Arg(0))
 	if err != nil {
 		return err
 	}
 
-	key, err := ioutil.ReadFile(c.Arg(1))
+	key, err := os.ReadFile(c.Arg(1))
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func CertsImport(rack sdk.Interface, c *stdcli.Context) error {
 	var opts structs.CertificateCreateOptions
 
 	if cf := c.String("chain"); cf != "" {
-		chain, err := ioutil.ReadFile(cf)
+		chain, err := os.ReadFile(cf)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -48,7 +47,7 @@ func testClientWait(t *testing.T, wait time.Duration, fn func(*cli.Engine, *mock
 
 	e.Client = i
 
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	e.Settings = tmp
 	// defer os.RemoveAll(tmp)
@@ -96,7 +95,7 @@ func testExecuteContext(ctx context.Context, e *cli.Engine, cmd string, stdin io
 }
 
 func testLogs(logs []string) io.ReadCloser {
-	return ioutil.NopCloser(strings.NewReader(fmt.Sprintf("%s\n", strings.Join(logs, "\n"))))
+	return io.NopCloser(strings.NewReader(fmt.Sprintf("%s\n", strings.Join(logs, "\n"))))
 }
 
 type result struct {

--- a/pkg/cli/cp_test.go
+++ b/pkg/cli/cp_test.go
@@ -3,7 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,10 +39,10 @@ func TestCpUploadError(t *testing.T) {
 
 func TestCpDownload(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		tmpd, err := ioutil.TempDir("", "")
+		tmpd, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		tmpf := filepath.Join(tmpd, "file")
-		data, err := ioutil.ReadFile("testdata/file.tar")
+		data, err := os.ReadFile("testdata/file.tar")
 		require.NoError(t, err)
 		i.On("FilesDownload", "app1", "0123456789", "/tmp/file").Return(bytes.NewReader(data), nil)
 
@@ -51,9 +51,9 @@ func TestCpDownload(t *testing.T) {
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{""})
-		odata, err := ioutil.ReadFile("testdata/file")
+		odata, err := os.ReadFile("testdata/file")
 		require.NoError(t, err)
-		ddata, err := ioutil.ReadFile(tmpf)
+		ddata, err := os.ReadFile(tmpf)
 		require.NoError(t, err)
 		require.Equal(t, odata, ddata)
 	})
@@ -61,7 +61,7 @@ func TestCpDownload(t *testing.T) {
 
 func TestCpDownloadError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		tmpd, err := ioutil.TempDir("", "")
+		tmpd, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		tmpf := filepath.Join(tmpd, "file")
 		i.On("FilesDownload", "app1", "0123456789", "/tmp/file").Return(nil, fmt.Errorf("err1"))

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -82,7 +81,7 @@ func EnvEdit(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -110,7 +109,7 @@ func EnvEdit(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/exec_test.go
+++ b/pkg/cli/exec_test.go
@@ -3,7 +3,6 @@ package cli_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -19,7 +18,7 @@ func TestExec(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		opts := structs.ProcessExecOptions{Tty: options.Bool(false)}
 		i.On("ProcessExec", "app1", "0123456789", "bash", mock.Anything, opts).Return(4, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(3).(io.Reader))
+			data, err := io.ReadAll(args.Get(3).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(3).(io.Writer).Write([]byte("out"))

--- a/pkg/cli/instances_test.go
+++ b/pkg/cli/instances_test.go
@@ -3,7 +3,6 @@ package cli_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -71,7 +70,7 @@ func TestInstancesSsh(t *testing.T) {
 		i.On("SystemGet").Return(fxSystem(), nil)
 		opts := structs.InstanceShellOptions{}
 		i.On("InstanceShell", "instance1", mock.Anything, opts).Return(4, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			data, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(1).(io.Writer).Write([]byte("out"))
@@ -104,7 +103,7 @@ func TestInstancesSshClassic(t *testing.T) {
 		i.On("SystemGet").Return(fxSystemClassic(), nil)
 		opts := structs.InstanceShellOptions{}
 		i.On("InstanceShellClassic", "instance1", mock.Anything, opts).Return(4, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			data, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(1).(io.Writer).Write([]byte("out"))

--- a/pkg/cli/login_test.go
+++ b/pkg/cli/login_test.go
@@ -2,10 +2,10 @@ package cli_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,11 +32,11 @@ func TestLogin(t *testing.T) {
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{fmt.Sprintf("Authenticating with %s... OK", tsu.Host)})
 
-		data, err := ioutil.ReadFile(filepath.Join(e.Settings, "auth"))
+		data, err := os.ReadFile(filepath.Join(e.Settings, "auth"))
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("{\n  \"%s\": \"password\"\n}", tsu.Host), string(data))
 
-		data, err = ioutil.ReadFile(filepath.Join(e.Settings, "host"))
+		data, err = os.ReadFile(filepath.Join(e.Settings, "host"))
 		require.NoError(t, err)
 		require.Equal(t, tsu.Host, string(data))
 	})

--- a/pkg/cli/proxy_test.go
+++ b/pkg/cli/proxy_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"testing"
@@ -57,7 +56,7 @@ func TestProxy(t *testing.T) {
 
 		cn.Write([]byte("in"))
 
-		data, err := ioutil.ReadAll(cn)
+		data, err := io.ReadAll(cn)
 		require.NoError(t, err)
 		require.Equal(t, "out", string(data))
 
@@ -103,7 +102,7 @@ func TestProxyError(t *testing.T) {
 
 		cn.Write([]byte("in"))
 
-		data, _ := ioutil.ReadAll(cn)
+		data, _ := io.ReadAll(cn)
 		require.Len(t, data, 0)
 
 		cancel()

--- a/pkg/cli/rack_test.go
+++ b/pkg/cli/rack_test.go
@@ -3,10 +3,10 @@ package cli_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -103,11 +103,11 @@ func TestRackInstall(t *testing.T) {
 			"line2",
 		})
 
-		data, err := ioutil.ReadFile(filepath.Join(e.Settings, "auth"))
+		data, err := os.ReadFile(filepath.Join(e.Settings, "auth"))
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("{\n  \"%s\": \"password\"\n}", tsu.Host), string(data))
 
-		data, err = ioutil.ReadFile(filepath.Join(e.Settings, "host"))
+		data, err = os.ReadFile(filepath.Join(e.Settings, "host"))
 		require.NoError(t, err)
 		require.Equal(t, tsu.Host, string(data))
 	})

--- a/pkg/cli/racks_test.go
+++ b/pkg/cli/racks_test.go
@@ -2,7 +2,6 @@ package cli_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -33,7 +32,7 @@ func TestRacks(t *testing.T) {
 		tsu, err := url.Parse(ts.URL)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
+		err = os.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
 		require.NoError(t, err)
 
 		me := &mockstdcli.Executor{}
@@ -75,7 +74,7 @@ func TestRacksLocalDisable(t *testing.T) {
 		tsu, err := url.Parse(ts.URL)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
+		err = os.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
 		require.NoError(t, err)
 
 		me := &mockstdcli.Executor{}
@@ -109,7 +108,7 @@ func TestRacksError(t *testing.T) {
 		tsu, err := url.Parse(ts.URL)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
+		err = os.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
 		require.NoError(t, err)
 
 		me := &mockstdcli.Executor{}

--- a/pkg/cli/resources_test.go
+++ b/pkg/cli/resources_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"testing"
@@ -115,7 +114,7 @@ func TestResourcesProxy(t *testing.T) {
 
 		cn.Write([]byte("in"))
 
-		data, err := ioutil.ReadAll(cn)
+		data, err := io.ReadAll(cn)
 		require.NoError(t, err)
 		require.Equal(t, "out", string(data))
 
@@ -385,7 +384,7 @@ func TestRackResourcesProxy(t *testing.T) {
 
 		cn.Write([]byte("in"))
 
-		data, err := ioutil.ReadAll(cn)
+		data, err := io.ReadAll(cn)
 		require.NoError(t, err)
 		require.Equal(t, "out", string(data))
 

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -3,7 +3,6 @@ package cli_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -23,7 +22,7 @@ func TestRun(t *testing.T) {
 		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
 		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
 		i.On("ProcessExec", "app1", "pid1", "bash", mock.Anything, opts).Return(4, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(3).(io.Reader))
+			data, err := io.ReadAll(args.Get(3).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(3).(io.Writer).Write([]byte("out"))
@@ -55,7 +54,7 @@ func TestRunClassic(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(fxSystemClassic(), nil)
 		i.On("ProcessRunAttached", "app1", "web", mock.Anything, 7200, structs.ProcessRunOptions{Command: options.String("bash")}).Return(4, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			data, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(2).(io.Writer).Write([]byte("out"))

--- a/pkg/cli/switch_test.go
+++ b/pkg/cli/switch_test.go
@@ -2,10 +2,10 @@ package cli_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -31,7 +31,7 @@ func TestSwitch(t *testing.T) {
 		tsu, err := url.Parse(ts.URL)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
+		err = os.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
 		require.NoError(t, err)
 
 		res, err := testExecute(e, "switch foo", nil)
@@ -40,7 +40,7 @@ func TestSwitch(t *testing.T) {
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{"Switched to test/foo"})
 
-		data, err := ioutil.ReadFile(filepath.Join(e.Settings, "racks"))
+		data, err := os.ReadFile(filepath.Join(e.Settings, "racks"))
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("{\n  \"%s\": \"test/foo\"\n}", tsu.Host), string(data))
 	})
@@ -62,7 +62,7 @@ func TestSwitchUnknown(t *testing.T) {
 		tsu, err := url.Parse(ts.URL)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
+		err = os.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
 		require.NoError(t, err)
 
 		res, err := testExecute(e, "switch rack1", nil)

--- a/pkg/cli/test_test.go
+++ b/pkg/cli/test_test.go
@@ -2,7 +2,6 @@ package cli_test
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -30,7 +29,7 @@ func TestTest(t *testing.T) {
 		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
 		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
 		i.On("ProcessExec", "app1", "pid1", "make test", mock.Anything, opts).Return(0, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(3).(io.Reader))
+			data, err := io.ReadAll(args.Get(3).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(3).(io.Writer).Write([]byte("out"))
@@ -69,7 +68,7 @@ func TestTestFail(t *testing.T) {
 		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
 		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
 		i.On("ProcessExec", "app1", "pid1", "make test", mock.Anything, opts).Return(4, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(3).(io.Reader))
+			data, err := io.ReadAll(args.Get(3).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(3).(io.Writer).Write([]byte("out"))

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -32,7 +32,7 @@ func Update(rack sdk.Interface, c *stdcli.Context) error {
 		target = v
 	}
 
-	if (target == current) {
+	if target == current {
 		c.Writef("No update to be performed\n")
 		return nil
 	}

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -2,7 +2,7 @@ package cli_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,7 +18,7 @@ func TestVersion(t *testing.T) {
 		me.On("Execute", "kubectl", "get", "ns", "--selector=system=convox,type=rack", "--output=name").Return([]byte("namespace/dev\n"), nil)
 		e.Executor = me
 
-		err := ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte("host1"), 0644)
+		err := os.WriteFile(filepath.Join(e.Settings, "host"), []byte("host1"), 0644)
 		require.NoError(t, err)
 
 		i.On("SystemGet").Return(fxSystem(), nil)
@@ -40,7 +40,7 @@ func TestVersionError(t *testing.T) {
 		me.On("Execute", "kubectl", "get", "ns", "--selector=system=convox,type=rack", "--output=name").Return([]byte("namespace/dev\n"), nil)
 		e.Executor = me
 
-		err := ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte("host1"), 0644)
+		err := os.WriteFile(filepath.Join(e.Settings, "host"), []byte("host1"), 0644)
 		require.NoError(t, err)
 
 		i.On("SystemGet").Return(nil, fmt.Errorf("err1"))

--- a/pkg/generate/method.go
+++ b/pkg/generate/method.go
@@ -3,7 +3,7 @@ package generate
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"regexp"
 	"sort"
@@ -43,7 +43,7 @@ type Route struct {
 func Methods() ([]Method, error) {
 	ms := []Method{}
 
-	data, err := ioutil.ReadFile("pkg/structs/provider.go")
+	data, err := os.ReadFile("pkg/structs/provider.go")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helpers/aws.go
+++ b/pkg/helpers/aws.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -271,7 +270,7 @@ func CloudformationUpdate(cf cloudformationiface.CloudFormationAPI, stack string
 		}
 		defer res.Body.Close()
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err
 		}

--- a/pkg/helpers/file.go
+++ b/pkg/helpers/file.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -19,7 +18,7 @@ func WriteFile(filename string, data []byte, mode os.FileMode) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filename, data, mode); err != nil {
+	if err := os.WriteFile(filename, data, mode); err != nil {
 		return err
 	}
 

--- a/pkg/helpers/http.go
+++ b/pkg/helpers/http.go
@@ -1,7 +1,7 @@
 package helpers
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -14,7 +14,7 @@ func Get(url string) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helpers/linux.go
+++ b/pkg/helpers/linux.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 )
 
@@ -22,7 +22,7 @@ func LinuxRelease() (string, error) {
 func linuxReleaseAttributes() (map[string]string, error) {
 	attrs := map[string]string{}
 
-	data, err := ioutil.ReadFile("/etc/os-release")
+	data, err := os.ReadFile("/etc/os-release")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helpers/tar.go
+++ b/pkg/helpers/tar.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,7 +75,7 @@ func Tarball(dir string) ([]byte, error) {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join(sym, ".dockerignore"))
+	data, err := os.ReadFile(filepath.Join(sym, ".dockerignore"))
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
@@ -108,7 +107,7 @@ func Tarball(dir string) ([]byte, error) {
 		return nil, err
 	}
 
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func Unarchive(r io.Reader, target string) error {

--- a/pkg/helpers/test.go
+++ b/pkg/helpers/test.go
@@ -2,9 +2,9 @@ package helpers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func Testdata(name string) ([]byte, error) {
-	return ioutil.ReadFile(fmt.Sprintf("testdata/%s.yml", name))
+	return os.ReadFile(fmt.Sprintf("testdata/%s.yml", name))
 }

--- a/pkg/manifest1/build.go
+++ b/pkg/manifest1/build.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -132,7 +132,7 @@ func (m *Manifest) Build(dir, appName string, s Stream, opts BuildOptions) error
 func buildArgs(dockerfile string) ([]string, error) {
 	args := []string{}
 
-	data, err := ioutil.ReadFile(dockerfile)
+	data, err := os.ReadFile(dockerfile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manifest1/exec.go
+++ b/pkg/manifest1/exec.go
@@ -24,18 +24,18 @@ type Exec struct{}
 
 var DefaultRunner Runner = new(Exec)
 
-//Run synchronously calls the command and pipes the output to the stream,
+// Run synchronously calls the command and pipes the output to the stream,
 func (e *Exec) Run(s Stream, cmd *exec.Cmd, opts RunnerOptions) error {
 	return run(s, cmd, opts)
 }
 
-//RunAsync synchronously calls the command and pipes the output to the stream,
+// RunAsync synchronously calls the command and pipes the output to the stream,
 func (e *Exec) RunAsync(s Stream, cmd *exec.Cmd, done chan error, opts RunnerOptions) {
 	RunAsync(s, cmd, done, opts)
 }
 
-//CombinedOutput synchronously calls the command and returns the output,
-//useful for internal checks
+// CombinedOutput synchronously calls the command and returns the output,
+// useful for internal checks
 func (e *Exec) CombinedOutput(cmd *exec.Cmd) ([]byte, error) {
 	return cmd.CombinedOutput()
 }

--- a/pkg/manifest1/manifest.go
+++ b/pkg/manifest1/manifest.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -78,7 +78,7 @@ func Load(data []byte) (*Manifest, error) {
 
 // Load a Manifest from a file
 func LoadFile(path string) (*Manifest, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manifest1/run.go
+++ b/pkg/manifest1/run.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -56,7 +55,7 @@ func (r *Run) Start() error {
 	}
 
 	if denv := filepath.Join(r.Dir, ".env"); exists(denv) {
-		data, err := ioutil.ReadFile(denv)
+		data, err := os.ReadFile(denv)
 		if err != nil {
 			return err
 		}

--- a/pkg/manifest1/service.go
+++ b/pkg/manifest1/service.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"
@@ -189,7 +188,7 @@ func (s *Service) SyncPaths() (map[string]string, error) {
 		dockerFile = s.Dockerfile
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join(s.Build.Context, coalesce(dockerFile, "Dockerfile")))
+	data, err := os.ReadFile(filepath.Join(s.Build.Context, coalesce(dockerFile, "Dockerfile")))
 	if err != nil {
 		return nil, err
 	}
@@ -518,8 +517,8 @@ func (s Service) RegistryImage(appName, buildId string, outputs map[string]strin
 	return fmt.Sprintf("%s/%s-%s:%s", os.Getenv("REGISTRY_HOST"), appName, s.Name, buildId)
 }
 
-//ExtraHostsMap is a convenience method to allow for easier use of the hosts in
-//AWS templates
+// ExtraHostsMap is a convenience method to allow for easier use of the hosts in
+// AWS templates
 func (s Service) ExtraHostsMap() map[string]string {
 	res := map[string]string{}
 	for _, str := range s.ExtraHosts {

--- a/pkg/router/http_test.go
+++ b/pkg/router/http_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -27,7 +26,7 @@ func TestHTTPNoHost(t *testing.T) {
 
 		require.Equal(t, 502, res.StatusCode)
 
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, []byte("no route\n"), data)
 	})
@@ -56,7 +55,7 @@ func TestHTTPRequest(t *testing.T) {
 
 		require.Equal(t, 200, res.StatusCode)
 
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, []byte("valid"), data)
 	})
@@ -74,7 +73,7 @@ func TestHTTPRequestError(t *testing.T) {
 
 		require.Equal(t, 502, res.StatusCode)
 
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, []byte("invalid target: ://invalid\n"), data)
 	})
@@ -103,7 +102,7 @@ func TestHTTPRequestHTTPS(t *testing.T) {
 
 		require.Equal(t, 200, res.StatusCode)
 
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, []byte("valid"), data)
 	})
@@ -125,7 +124,7 @@ func TestHTTPRequestPost(t *testing.T) {
 
 			require.Equal(t, "7", r.Header.Get("Content-Length"))
 
-			data, err := ioutil.ReadAll(r.Body)
+			data, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			require.Equal(t, []byte("foo=bar"), data)
 
@@ -140,7 +139,7 @@ func TestHTTPRequestPost(t *testing.T) {
 
 		require.Equal(t, 200, res.StatusCode)
 
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, []byte("valid"), data)
 	})
@@ -171,7 +170,7 @@ func TestHTTPRequestExistingForwardHeaders(t *testing.T) {
 
 		require.Equal(t, 200, res.StatusCode)
 
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, []byte("valid"), data)
 	})
@@ -211,7 +210,7 @@ func TestHTTPRequestRedirect(t *testing.T) {
 
 		require.Equal(t, 200, res.StatusCode)
 
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, []byte("valid"), data)
 	})

--- a/pkg/start/gen2.go
+++ b/pkg/start/gen2.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -78,7 +77,7 @@ func (s *Start) Start2(ctx context.Context, w io.Writer, opts Options2) error {
 		}
 	}
 
-	data, err := ioutil.ReadFile(helpers.CoalesceString(opts.Manifest, "convox.yml"))
+	data, err := os.ReadFile(helpers.CoalesceString(opts.Manifest, "convox.yml"))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -182,7 +181,7 @@ func (s *Start) Start2(ctx context.Context, w io.Writer, opts Options2) error {
 		return errors.WithStack(err)
 	}
 
-	if (opts.Sync) {
+	if opts.Sync {
 		for _, s := range m.Services {
 			if !services[s.Name] {
 				continue
@@ -547,7 +546,7 @@ func buildDockerfile(m *manifest.Manifest, root, service string) ([]byte, error)
 		return nil, errors.WithStack(fmt.Errorf("no such file: %s", filepath.Join(s.Build.Path, s.Build.Manifest)))
 	}
 
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func buildIgnores(root, service string) ([]string, error) {

--- a/pkg/start/gen2_test.go
+++ b/pkg/start/gen2_test.go
@@ -3,7 +3,7 @@ package start_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -31,7 +31,7 @@ func TestStart2(t *testing.T) {
 	p.On("AppGet", "app1").Return(&structs.App{Name: "app1", Generation: "2"}, nil)
 	p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release1"}}, nil)
 	p.On("ReleaseGet", "app1", "release1").Return(&structs.Release{}, nil)
-	p.On("AppLogs", "app1", structs.LogsOptions{Prefix: options.Bool(true), Since: options.Duration(1 * time.Second)}).Return(ioutil.NopCloser(strings.NewReader(logs)), nil)
+	p.On("AppLogs", "app1", structs.LogsOptions{Prefix: options.Bool(true), Since: options.Duration(1 * time.Second)}).Return(io.NopCloser(strings.NewReader(logs)), nil)
 
 	e := &exec.MockInterface{}
 	start.Exec = e
@@ -95,10 +95,10 @@ func TestStart2Options(t *testing.T) {
 	p.On("ReleaseGet", "app1", "release1").Return(&structs.Release{}, nil)
 	p.On("ObjectStore", "app1", "", mock.Anything, structs.ObjectStoreOptions{}).Return(&structs.Object{Url: "object://app1/object1.tgz"}, nil)
 	p.On("BuildCreate", "app1", "object://app1/object1.tgz", structs.BuildCreateOptions{Development: options.Bool(true), Manifest: options.String("convox2.yml")}).Return(&structs.Build{Id: "build1"}, nil)
-	p.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(ioutil.NopCloser(strings.NewReader(buildLogs)), nil)
+	p.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(io.NopCloser(strings.NewReader(buildLogs)), nil)
 	p.On("BuildGet", "app1", "build1").Return(&structs.Build{Id: "build1", Release: "release1", Status: "complete"}, nil)
 	p.On("ReleasePromote", "app1", "release1", structs.ReleasePromoteOptions{Development: options.Bool(true), Force: options.Bool(true), Idle: options.Bool(false), Min: options.Int(0), Timeout: options.Int(300)}).Return(nil)
-	p.On("AppLogs", "app1", structs.LogsOptions{Prefix: options.Bool(true), Since: options.Duration(1 * time.Second)}).Return(ioutil.NopCloser(strings.NewReader(appLogs)), nil).Once()
+	p.On("AppLogs", "app1", structs.LogsOptions{Prefix: options.Bool(true), Since: options.Duration(1 * time.Second)}).Return(io.NopCloser(strings.NewReader(appLogs)), nil).Once()
 	p.On("ReleasePromote", "app1", "old", structs.ReleasePromoteOptions{Development: options.Bool(false), Force: options.Bool(true)}).Return(nil)
 
 	e := &exec.MockInterface{}

--- a/pkg/sync/templates.go
+++ b/pkg/sync/templates.go
@@ -10,7 +10,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -147,11 +146,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error
@@ -182,6 +183,7 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"changed": &bintree{changed, map[string]*bintree{}},
 }}
@@ -200,7 +202,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}
@@ -232,4 +234,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/pkg/test/awsutil/awsutil.go
+++ b/pkg/test/awsutil/awsutil.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strings"
@@ -48,7 +47,7 @@ func NewHandler(c []Cycle) *Handler {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		panic(err)
 	}
@@ -105,7 +104,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func formatBody(r io.Reader) string {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -3,7 +3,7 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -33,7 +33,7 @@ func Server(t *testing.T, stubs ...Http) *httptest.Server {
 					w.Write(serverError(err.Error()))
 				}
 
-				rb, err := ioutil.ReadAll(r.Body)
+				rb, err := io.ReadAll(r.Body)
 
 				if err != nil {
 					w.WriteHeader(503)

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -168,7 +167,7 @@ func (p *Provider) BuildExport(app, id string, w io.Writer) error {
 		return err
 	}
 
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Error(err)
 		return err
@@ -499,7 +498,7 @@ func (p *Provider) BuildLogs(app, id string, opts structs.LogsOptions) (io.ReadC
 		case "object":
 			return p.ObjectFetch(app, u.Path)
 		default:
-			return ioutil.NopCloser(strings.NewReader(b.Logs)), nil
+			return io.NopCloser(strings.NewReader(b.Logs)), nil
 		}
 	}
 
@@ -679,7 +678,7 @@ func (p *Provider) buildAuth(build *structs.Build) (string, error) {
 			}
 
 			server, err := ensureRegistryProtocol(r.Server)
-			if (err != nil) {
+			if err != nil {
 				return "", err
 			}
 
@@ -689,7 +688,7 @@ func (p *Provider) buildAuth(build *structs.Build) (string, error) {
 			}
 		default:
 			server, err := ensureRegistryProtocol(r.Server)
-			if (err != nil) {
+			if err != nil {
 				return "", err
 			}
 			auth[server] = authEntry{
@@ -729,7 +728,7 @@ func ensureRegistryProtocol(repo string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if (len(u.Scheme) == 0) {
+	if len(u.Scheme) == 0 {
 		u.Scheme = "https"
 	}
 	return u.String(), nil

--- a/provider/aws/builds_test.go
+++ b/provider/aws/builds_test.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -173,7 +172,7 @@ func TestBuildExport(t *testing.T) {
 	assert.Equal(t, "build.json", h.Name)
 	assert.Equal(t, int64(437), h.Size)
 
-	data, err := ioutil.ReadAll(tr)
+	data, err := io.ReadAll(tr)
 	assert.NoError(t, err)
 
 	var build structs.Build

--- a/provider/aws/capacity_test.go
+++ b/provider/aws/capacity_test.go
@@ -3,8 +3,8 @@ package aws_test
 import (
 	"testing"
 
-	"github.com/convox/rack/pkg/test/awsutil"
 	"github.com/convox/rack/pkg/structs"
+	"github.com/convox/rack/pkg/test/awsutil"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -11,7 +12,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"math/rand"
 	"net/url"
@@ -21,8 +22,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	crand "crypto/rand"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -200,7 +199,7 @@ func generateId(prefix string, size int) string {
 }
 
 func buildTemplate(name, section string, data interface{}) (string, error) {
-	d, err := ioutil.ReadFile(fmt.Sprintf("provider/aws/templates/%s.tmpl", name))
+	d, err := os.ReadFile(fmt.Sprintf("provider/aws/templates/%s.tmpl", name))
 	if err != nil {
 		return "", err
 	}
@@ -1151,7 +1150,7 @@ func (p *Provider) s3Get(bucket, key string) ([]byte, error) {
 		return nil, err
 	}
 
-	return ioutil.ReadAll(res.Body)
+	return io.ReadAll(res.Body)
 }
 
 func (p *Provider) s3Delete(bucket, key string) error {
@@ -1238,8 +1237,9 @@ func (p *Provider) taskDefinitionRelease(arn string) (string, error) {
 }
 
 // updateStack updates a stack
-//   template is url to a template or empty string to reuse previous
-//   changes is a list of parameter changes to make (does not need to include every param)
+//
+//	template is url to a template or empty string to reuse previous
+//	changes is a list of parameter changes to make (does not need to include every param)
 func (p *Provider) updateStack(name string, template []byte, changes map[string]string, tags map[string]string, id string) error {
 	cache.Clear("describeStacks", nil)
 	cache.Clear("describeStacks", name)

--- a/provider/aws/index.go
+++ b/provider/aws/index.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -96,7 +95,7 @@ func (p *Provider) downloadItem(bucket, hash string, item structs.IndexItem, dir
 		return err
 	}
 
-	err = ioutil.WriteFile(file, data, item.Mode)
+	err = os.WriteFile(file, data, item.Mode)
 
 	if err != nil {
 		return err

--- a/provider/aws/instances_test.go
+++ b/provider/aws/instances_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/convox/rack/pkg/test/awsutil"
 	"github.com/convox/rack/pkg/structs"
+	"github.com/convox/rack/pkg/test/awsutil"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/provider/aws/lambda/formation/handler/ecs.go
+++ b/provider/aws/lambda/formation/handler/ecs.go
@@ -2,7 +2,7 @@ package handler
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -414,7 +414,7 @@ func fetchEnvironment(req Request, env string) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func fetchEnvironmentS3(req Request, bucket, key string) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	return ioutil.ReadAll(res.Body)
+	return io.ReadAll(res.Body)
 }
 
 func generateId(prefix string, size int) string {

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"sort"
@@ -101,7 +100,7 @@ func (p *Provider) ProcessExec(app, pid, command string, rw io.ReadWriter, opts 
 	err = dc.StartExec(eres.ID, docker.StartExecOptions{
 		Detach:       false,
 		Tty:          tty,
-		InputStream:  ioutil.NopCloser(rw),
+		InputStream:  io.NopCloser(rw),
 		OutputStream: rw,
 		ErrorStream:  rw,
 		RawTerminal:  true,

--- a/provider/aws/resource.go
+++ b/provider/aws/resource.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -415,7 +415,7 @@ func (p *Provider) SystemResourceLink(name, app string) (*structs.Resource, erro
 }
 
 func (p *Provider) SystemResourceTypes() (structs.ResourceTypes, error) {
-	files, err := ioutil.ReadDir("provider/aws/templates/resource/")
+	files, err := os.ReadDir("provider/aws/templates/resource/")
 	if err != nil {
 		return nil, err
 	}
@@ -660,7 +660,7 @@ func (p *Provider) deleteSyslogInterfaces(r *structs.Resource) error {
 	return nil
 }
 
-//resourceApps returns the apps that have been linked with a resource (ignoring apps that have been delete out of band)
+// resourceApps returns the apps that have been linked with a resource (ignoring apps that have been delete out of band)
 func (p *Provider) resourceApps(s structs.Resource) (structs.Apps, error) {
 	stacks, err := p.describeStacks(&cloudformation.DescribeStacksInput{
 		StackName: aws.String(p.rackStack(s.Name)),

--- a/provider/aws/system.go
+++ b/provider/aws/system.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -555,7 +555,7 @@ func (p *Provider) SystemUpdate(opts structs.SystemUpdateOptions) error {
 
 	if opts.Version != nil {
 		if *opts.Version == "dev" {
-			data, err := ioutil.ReadFile("provider/aws/formation/rack.json")
+			data, err := os.ReadFile("provider/aws/formation/rack.json")
 			if err != nil {
 				return err
 			}
@@ -568,7 +568,7 @@ func (p *Provider) SystemUpdate(opts structs.SystemUpdateOptions) error {
 			}
 			defer res.Body.Close()
 
-			data, err := ioutil.ReadAll(res.Body)
+			data, err := io.ReadAll(res.Body)
 			if err != nil {
 				return err
 			}
@@ -635,7 +635,7 @@ func cloudformationProgress(stack, token string, template []byte, w io.Writer) e
 	cf := cloudformation.New(s)
 
 	if w == nil {
-		w = ioutil.Discard
+		w = io.Discard
 	}
 
 	events := map[string]cloudformation.StackEvent{}

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -146,7 +145,7 @@ func (p *Provider) BuildExport(app, id string, w io.Writer) error {
 		return err
 	}
 
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -274,7 +273,7 @@ func (p *Provider) BuildImport(app string, r io.Reader) (*structs.Build, error) 
 		}
 
 		if header.Name == "build.json" {
-			data, err := ioutil.ReadAll(tr)
+			data, err := io.ReadAll(tr)
 			if err != nil {
 				return nil, err
 			}
@@ -439,8 +438,6 @@ func (p *Provider) buildAuth(b *structs.Build) ([]byte, error) {
 		Password string
 	}
 
-
-
 	auth := map[string]authEntry{}
 
 	rs, err := p.RegistryList()
@@ -451,7 +448,7 @@ func (p *Provider) buildAuth(b *structs.Build) ([]byte, error) {
 	for _, r := range rs {
 
 		server, err := ensureRegistryProtocol(r.Server)
-		if (err != nil) {
+		if err != nil {
 			return nil, err
 		}
 
@@ -473,7 +470,7 @@ func (p *Provider) buildAuth(b *structs.Build) ([]byte, error) {
 		}
 
 		server, err := ensureRegistryProtocol(repo)
-		if (err != nil) {
+		if err != nil {
 			return nil, err
 		}
 
@@ -496,7 +493,7 @@ func ensureRegistryProtocol(repo string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if (len(u.Scheme) == 0) {
+	if len(u.Scheme) == 0 {
 		u.Scheme = "https"
 	}
 	return u.String(), nil

--- a/provider/k8s/file.go
+++ b/provider/k8s/file.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"io"
-	"io/ioutil"
 
 	ac "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -28,7 +27,7 @@ func (p *Provider) FilesDelete(app, pid string, files []string) error {
 		return err
 	}
 
-	if err := exec.Stream(remotecommand.StreamOptions{Stdout: ioutil.Discard}); err != nil {
+	if err := exec.Stream(remotecommand.StreamOptions{Stdout: io.Discard}); err != nil {
 		return err
 	}
 

--- a/provider/kaws/system.go
+++ b/provider/kaws/system.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -395,7 +394,7 @@ func checkKubectl() error {
 }
 
 func writeKubeConfig(outputs map[string]string) (string, error) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", err
 	}
@@ -428,7 +427,7 @@ users:
         - "-i"
         - %s`, outputs["ClusterEndpoint"], outputs["ClusterCertificateAuthority"], outputs["Cluster"]))
 
-	if err := ioutil.WriteFile(config, data, 0644); err != nil {
+	if err := os.WriteFile(config, data, 0644); err != nil {
 		return "", err
 	}
 

--- a/provider/local/storage.go
+++ b/provider/local/storage.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/boltdb/bolt"
@@ -126,7 +125,7 @@ func (s *Storage) Write(key string, v interface{}) error {
 
 	switch t := v.(type) {
 	case io.Reader:
-		data, err = ioutil.ReadAll(t)
+		data, err = io.ReadAll(t)
 	default:
 		data, err = json.Marshal(v)
 	}

--- a/provider/local/system_darwin.go
+++ b/provider/local/system_darwin.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -65,7 +64,7 @@ func removeOriginalRack(name string) error {
 }
 
 func trustCertificate(name string, data []byte) error {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -74,7 +73,7 @@ func trustCertificate(name string, data []byte) error {
 
 	defer os.Remove(crt)
 
-	if err := ioutil.WriteFile(crt, data, 0600); err != nil {
+	if err := os.WriteFile(crt, data, 0600); err != nil {
 		return err
 	}
 

--- a/provider/local/system_windows.go
+++ b/provider/local/system_windows.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +58,7 @@ func removeOriginalRack(name string) error {
 }
 
 func trustCertificate(name string, data []byte) error {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -68,7 +67,7 @@ func trustCertificate(name string, data []byte) error {
 
 	defer os.Remove(crt)
 
-	if err := ioutil.WriteFile(crt, data, 0600); err != nil {
+	if err := os.WriteFile(crt, data, 0600); err != nil {
 		return err
 	}
 

--- a/sdk/auth.go
+++ b/sdk/auth.go
@@ -2,7 +2,7 @@ package sdk
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 
 	"github.com/convox/stdsdk"
 )
@@ -18,7 +18,7 @@ func (c *Client) Auth() (string, error) {
 		Id string
 	}
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}

--- a/sdk/compat.go
+++ b/sdk/compat.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"strconv"
 
@@ -50,7 +49,7 @@ func (c *Client) BuildCreateUpload(app string, r io.Reader, opts structs.BuildCr
 		ro.Params["config"] = ro.Params["manifest"]
 	}
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +66,7 @@ func (c *Client) BuildCreateUpload(app string, r io.Reader, opts structs.BuildCr
 }
 
 func (c *Client) BuildImportMultipart(app string, r io.Reader) (*structs.Build, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`)
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`