### PR TITLE
added /var/lib/docker/container path to volume allow list

### DIFF
--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -427,6 +427,8 @@ func volumeFrom(app, s string) string {
 		return v
 	case "/var/run/docker.sock":
 		return v
+	case "/var/lib/docker/containers/":
+		return v
 	default:
 		return path.Join("/volumes", app, v)
 	}


### PR DESCRIPTION
This is to allow log file tailing by log collectors that runs inside a container. See: https://docs.datadoghq.com/containers/docker/log/?tab=containerinstallation for an example usage.

I hope that this is a place for changes to gen2.