### PR TITLE
Ignore release test for forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,11 @@ defaults:
   filter-releases-any: &filter-releases-any
     filters:
       branches:
-        ignore: /.*/
+        ignore:
+          - /.*/
+          # don't run release if pull request is from forked PR
+          # it can expose the env vars
+          - /pull\/[0-9]+/
       tags:
         only: /[0-9]{14}.*/
   filter-releases-master: &filter-releases-master
@@ -16,11 +20,6 @@ defaults:
         ignore: /.*/
       tags:
         only: /[0-9]{14}/
-  filter-forked-prs: &filter-forked-prs
-    filters:
-      branches:
-        # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-        ignore: /pull\/[0-9]+/
 
 workflows:
   version: 2
@@ -46,9 +45,7 @@ workflows:
                 - master
   test:
     jobs:
-      - test:
-          <<: *filter-forked-prs
-          <<: *filter-releases-any
+      - test
   release:
     jobs:
       - ci:


### PR DESCRIPTION
We don't expose env vars for forked PRs, so we won't run the release process on them. 
The `ci` job will not run on forked PRs. The `test` job will always run.