### PR TITLE
DesiredCapacity cannot be negative

### DIFF
--- a/provider/aws/lambda/autoscale/handler.go
+++ b/provider/aws/lambda/autoscale/handler.go
@@ -313,6 +313,11 @@ func desiredCapacity(largest, total *Metrics) (int64, error) {
 		desired = 3
 	}
 
+	// minimum for non-HA rack is 1
+	if desired <= 0 {
+		desired = 1
+	}
+
 	debug("desired = %+v\n", desired)
 	return desired, nil
 }


### PR DESCRIPTION
### What is the feature/fix?

When the rack is scheduled down, the lambda is trying to set a negative number. On scaling up it can result in some errors because the parameter is incorrect.

Preventing the lambda to set incorrect value will solve the problem, the minimum should be 1 for the desired instance.

### Does it has a breaking change?

No, only changes in a specific case.

### How to use/test it?

- Create a new rack using the RC version `20221013193040-desired-capacity-schedule-action`
- Set the ScheduleRackScale down and up:  `convox rack params set ScheduleRackScaleDown="35 14 * * *" ScheduleRackScaleUp="45 14 * * *"`
- Wait to be scaled down...
- Search in the lambda logs for any invalid parameter exception (log should be on CloudWatch > `/aws/lambda/RACKNAME-InstancesAutoscaler-SOMEID`)

### Checklist
- [ ] ~~New coverage tests~~
- [x] Unit tests passing
- [ ] E2E tests passing
- [ ] ~~E2E downgrade/update test passing~~
- [ ] ~~Documentation updated~~
- [x] No warnings or errors on Deepsource/Codecov
