### PR TITLE
Include the Spot instances when creating the schedule rack option

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2009,9 +2009,8 @@
       "Condition": "SpotInstancesAndSetScheduleRack",
       "Properties":{
         "AutoScalingGroupName": { "Ref": "SpotInstances" },
-        "DesiredCapacity": "1",
-        "MaxSize":"2",
-        "MinSize":"1",
+        "MinSize": "0",
+        "MaxSize": "1000",
         "Recurrence": { "Ref": "ScheduleRackScaleUp" }
       }
     },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -135,6 +135,7 @@
     ] },
     "SpotInstances": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SpotInstanceBid"}, "" ] } ] },
     "SpotInstancesAndHA": { "Fn::And": [ { "Condition": "SpotInstances" }, { "Condition": "HighAvailability" } ] },
+    "SpotInstancesAndSetScheduleRack": { "Fn::And": [ { "Condition": "SpotInstances" }, { "Condition": "SetScheduleRackScale" } ] },
     "SwapEnabled": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SwapSize" }, "0" ] } ] },
     "ThirdAvailabilityZone": { "Fn::And": [
       { "Fn::Equals": [ { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "ThirdAvailabilityZone" ] }, "Yes" ] },
@@ -1986,6 +1987,28 @@
       "Condition": "SetScheduleRackScale",
       "Properties":{
         "AutoScalingGroupName": { "Ref": "BuildInstances" },
+        "DesiredCapacity": "1",
+        "MaxSize":"2",
+        "MinSize":"1",
+        "Recurrence": { "Ref": "ScheduleRackScaleUp" }
+      }
+    },
+    "SpotScheduleRackScaleDown":{
+      "Type":"AWS::AutoScaling::ScheduledAction",
+      "Condition": "SpotInstancesAndSetScheduleRack",
+      "Properties":{
+        "AutoScalingGroupName": { "Ref": "SpotInstances" },
+        "DesiredCapacity": "0",
+        "MaxSize": "0",
+        "MinSize": "0",
+        "Recurrence": { "Ref": "ScheduleRackScaleDown" }
+      }
+    },
+    "SpotScheduleRackScaleUp":{
+      "Type":"AWS::AutoScaling::ScheduledAction",
+      "Condition": "SpotInstancesAndSetScheduleRack",
+      "Properties":{
+        "AutoScalingGroupName": { "Ref": "SpotInstances" },
         "DesiredCapacity": "1",
         "MaxSize":"2",
         "MinSize":"1",


### PR DESCRIPTION
### What is the feature/fix?

Set the feature of scheduling the rack down/up on SpotInstances ASG, in case SpotInstanceBid is set.

### Does it has a breaking change?

No

### How to use/test it?

1. Set the [SpotInstanceBid](https://docsv2.convox.com/reference/rack-parameters#spotinstancebid)
2. Set the [ScheduleRackScaleDown & ScheduleRackScaleUp](https://docsv2.convox.com/reference/rack-parameters#schedulerackscaledown-schedulerackscaleup)
3. Check on the ASG page (AWS) if all three groups are set to 0.

### Checklist
- [ ] ~~New coverage tests~~
- [x] Unit tests passing
- [x] E2E tests passing
- [ ] ~~E2E downgrade/update test passing~~
- [ ] ~~Documentation updated~~
- [x] No warnings or errors on Deepsource/Codecov
