### PR TITLE
EFS resource for volumes

### DIFF
--- a/examples/httpd/convox.yml
+++ b/examples/httpd/convox.yml
@@ -17,16 +17,31 @@ resources:
     type: memcached
   redis:
     type: redis
+  sharedvolume:
+    type: efs
+    options:
+      path: "/app/httpd"
 services:
   web:
     build: .
     port: 80
+    volumes:
+      # Persistent volumes
+      - /my/shared/data
+      - /var/www/html
+      # Host Volumes
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup/
+      - /proc/:/host/proc/
+      - /var/run/docker.sock:/var/run/docker.sock
+      # EFS Resource (shared volumes)
+      - sharedvolume:/app/httpd
     resources:
       - postgres
       - mysql
       - mariadb
       - memcached
       - redis
+      - sharedvolume
 timers:
   example:
     command: /usr/local/apache2/timer-cmd.sh

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -379,13 +379,22 @@
           "RackUrl": { "Ref": "RackUrl" },
           "RedirectHttps": { "Ref": "RedirectHttps" },
           "Registry": { "Ref": "Registry" },
-          {{ range .Resources }}
-            "Resource{{ upper . }}": { "Fn::GetAtt": [ "Resource{{ upper . }}", "Outputs.Url" ] },
-            "Resource{{ upper . }}User": { "Fn::GetAtt": [ "Resource{{ upper . }}", "Outputs.User" ] },
-            "Resource{{ upper . }}Pass": { "Fn::GetAtt": [ "Resource{{ upper . }}", "Outputs.Pass" ] },
-            "Resource{{ upper . }}Host": { "Fn::GetAtt": [ "Resource{{ upper . }}", "Outputs.Host" ] },
-            "Resource{{ upper . }}Port": { "Fn::GetAtt": [ "Resource{{ upper . }}", "Outputs.Port" ] },
-            "Resource{{ upper . }}Name": { "Fn::GetAtt": [ "Resource{{ upper . }}", "Outputs.Name" ] },
+          {{ range $name := .Resources }}
+            {{ range $resource := $.Manifest.Resources }}
+              {{ if eq $name $resource.Name }}
+                {{ if eq $resource.Type "efs" }}
+                  "Resource{{ upper $name }}FileSystemId": { "Fn::GetAtt": [ "Resource{{ upper $name }}", "Outputs.FileSystemId" ] },
+                  "Resource{{ upper $name }}AccessPointId": { "Fn::GetAtt": [ "Resource{{ upper $name }}", "Outputs.AccessPointId" ] },
+                {{ else }}
+                  "Resource{{ upper $name }}": { "Fn::GetAtt": [ "Resource{{ upper $name }}", "Outputs.Url" ] },
+                  "Resource{{ upper $name }}User": { "Fn::GetAtt": [ "Resource{{ upper $name }}", "Outputs.User" ] },
+                  "Resource{{ upper $name }}Pass": { "Fn::GetAtt": [ "Resource{{ upper $name }}", "Outputs.Pass" ] },
+                  "Resource{{ upper $name }}Host": { "Fn::GetAtt": [ "Resource{{ upper $name }}", "Outputs.Host" ] },
+                  "Resource{{ upper $name }}Port": { "Fn::GetAtt": [ "Resource{{ upper $name }}", "Outputs.Port" ] },
+                  "Resource{{ upper $name }}Name": { "Fn::GetAtt": [ "Resource{{ upper $name }}", "Outputs.Name" ] },
+                {{ end }}
+              {{ end }}
+            {{ end }}
           {{ end }}
           "Role": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
           "Settings": { "Ref": "Settings" },

--- a/provider/aws/formation/resource/efs.json.tmpl
+++ b/provider/aws/formation/resource/efs.json.tmpl
@@ -12,7 +12,7 @@
   },
   "Parameters": {
     "AutoMinorVersionUpgrade": {
-      "Type" : "String",
+      "Type": "String",
       "Default": ""
     },
     "Encrypted": {
@@ -29,15 +29,29 @@
     },
     "Path": {
       "Type": "String",
-      "Default": "/path"
+      "Default": "/"
     },
     "Rack": {
-      "MinLength": "1",
       "Type": "String"
     }
   },
   "Outputs": {
-    "FileSystemId": { "Value": { "Fn::GetAtt": [ "FileSystem", "FileSystemId" ] } }
+    "AccessPointId": {
+      "Value": {
+        "Fn::GetAtt": [
+          "AccessPoint",
+          "AccessPointId"
+        ]
+      }
+    },
+    "FileSystemId": {
+      "Value": {
+        "Fn::GetAtt": [
+          "FileSystem",
+          "FileSystemId"
+        ]
+      }
+    }
   },
   "Resources": {
     "AccessPoint": {
@@ -47,6 +61,11 @@
           "Ref": "FileSystem"
         },
         "RootDirectory": {
+          "CreationInfo": {
+            "OwnerGid": "1000",
+            "OwnerUid": "1000",
+            "Permissions": "0777"
+          },
           "Path": {
             "Ref": "Path"
           }
@@ -111,13 +130,14 @@
     "MountTargetSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "FileSystem Security Group",
+        "GroupDescription": {
+          "Fn::Sub": "${Rack} ${AWS::StackName} EFS SG"
+        },
         "VpcId": {
           "Fn::ImportValue": {
             "Fn::Sub": "${Rack}:Vpc"
           }
         },
-        "GroupName": "EFS Resource SG",
         "SecurityGroupIngress": [
           {
             "IpProtocol": "tcp",
@@ -132,7 +152,7 @@
         ]
       }
     },
-    "MountTarget1": {
+    "MountTarget0": {
       "Type": "AWS::EFS::MountTarget",
       "Properties": {
         "FileSystemId": {
@@ -150,7 +170,7 @@
         ]
       }
     },
-    "MountTarget2": {
+    "MountTarget1": {
       "Type": "AWS::EFS::MountTarget",
       "Properties": {
         "FileSystemId": {
@@ -159,6 +179,24 @@
         "SubnetId": {
           "Fn::ImportValue": {
             "Fn::Sub": "${Rack}:Subnet1"
+          }
+        },
+        "SecurityGroups": [
+          {
+            "Ref": "MountTargetSecurityGroup"
+          }
+        ]
+      }
+    },
+    "MountTarget2": {
+      "Type": "AWS::EFS::MountTarget",
+      "Properties": {
+        "FileSystemId": {
+          "Ref": "FileSystem"
+        },
+        "SubnetId": {
+          "Fn::ImportValue": {
+            "Fn::Sub": "${Rack}:Subnet2"
           }
         },
         "SecurityGroups": [

--- a/provider/aws/formation/resource/efs.json.tmpl
+++ b/provider/aws/formation/resource/efs.json.tmpl
@@ -1,0 +1,172 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "Encrypted": {
+      "Fn::Equals": [
+        {
+          "Ref": "Encrypted"
+        },
+        "true"
+      ]
+    }
+  },
+  "Parameters": {
+    "AutoMinorVersionUpgrade": {
+      "Type" : "String",
+      "Default": ""
+    },
+    "Encrypted": {
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues": [
+        "true",
+        "false"
+      ]
+    },
+    "Password": {
+      "Type": "String",
+      "Default": ""
+    },
+    "Path": {
+      "Type": "String",
+      "Default": "/path"
+    },
+    "Rack": {
+      "MinLength": "1",
+      "Type": "String"
+    }
+  },
+  "Outputs": {
+    "FileSystemId": { "Value": { "Fn::GetAtt": [ "FileSystem", "FileSystemId" ] } }
+  },
+  "Resources": {
+    "AccessPoint": {
+      "Type": "AWS::EFS::AccessPoint",
+      "Properties": {
+        "FileSystemId": {
+          "Ref": "FileSystem"
+        },
+        "RootDirectory": {
+          "Path": {
+            "Ref": "Path"
+          }
+        }
+      }
+    },
+    "EncryptionKey": {
+      "Type": "AWS::KMS::Key",
+      "Condition": "Encrypted",
+      "Properties": {
+        "Description": {
+          "Ref": "AWS::StackName"
+        },
+        "KeyPolicy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "Allow administration of the key",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+                }
+              },
+              "Action": [
+                "kms:*"
+              ],
+              "Resource": "*"
+            }
+          ]
+        },
+        "PendingWindowInDays": "7"
+      }
+    },
+    "FileSystem": {
+      "Type": "AWS::EFS::FileSystem",
+      "Properties": {
+        "Encrypted": {
+          "Ref": "Encrypted"
+        },
+        "FileSystemTags": [
+          {
+            "Key": "Rack",
+            "Value": {
+              "Ref": "Rack"
+            }
+          }
+        ],
+        "KmsKeyId": {
+          "Fn::If": [
+            "Encrypted",
+            {
+              "Ref": "EncryptionKey"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      }
+    },
+    "MountTargetSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "FileSystem Security Group",
+        "VpcId": {
+          "Fn::ImportValue": {
+            "Fn::Sub": "${Rack}:Vpc"
+          }
+        },
+        "GroupName": "EFS Resource SG",
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": 2049,
+            "ToPort": 2049,
+            "CidrIp": {
+              "Fn::ImportValue": {
+                "Fn::Sub": "${Rack}:VpcCidr"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "MountTarget1": {
+      "Type": "AWS::EFS::MountTarget",
+      "Properties": {
+        "FileSystemId": {
+          "Ref": "FileSystem"
+        },
+        "SubnetId": {
+          "Fn::ImportValue": {
+            "Fn::Sub": "${Rack}:Subnet0"
+          }
+        },
+        "SecurityGroups": [
+          {
+            "Ref": "MountTargetSecurityGroup"
+          }
+        ]
+      }
+    },
+    "MountTarget2": {
+      "Type": "AWS::EFS::MountTarget",
+      "Properties": {
+        "FileSystemId": {
+          "Ref": "FileSystem"
+        },
+        "SubnetId": {
+          "Fn::ImportValue": {
+            "Fn::Sub": "${Rack}:Subnet1"
+          }
+        },
+        "SecurityGroups": [
+          {
+            "Ref": "MountTargetSecurityGroup"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -127,31 +127,44 @@
       "Registry": {
         "Type": "String"
       },
-      {{ range .Resources }}
-        "Resource{{ upper .}}": {
-          "Type": "String",
-          "NoEcho": "true"
-        },
-        "Resource{{ upper .}}User": {
-          "Type": "String",
-          "NoEcho": "true"
-        },
-        "Resource{{ upper .}}Pass": {
-          "Type": "String",
-          "NoEcho": "true"
-        },
-        "Resource{{ upper .}}Host": {
-          "Type": "String",
-          "NoEcho": "true"
-        },
-        "Resource{{ upper .}}Port": {
-          "Type": "String",
-          "NoEcho": "true"
-        },
-        "Resource{{ upper .}}Name": {
-          "Type": "String",
-          "NoEcho": "true"
-        },
+      {{ range $name := .Resources }}
+        {{ range $resource := $.Manifest.Resources }}
+          {{ if eq $name $resource.Name }}
+            {{ if eq $resource.Type "efs" }}
+              "Resource{{ upper $name }}AccessPointId": {
+                "Type": "String"
+              },
+              "Resource{{ upper $name }}FileSystemId": {
+                "Type": "String"
+              },
+            {{ else }}
+              "Resource{{ upper $name }}": {
+                "Type": "String",
+                "NoEcho": "true"
+              },
+              "Resource{{ upper $name }}User": {
+                "Type": "String",
+                "NoEcho": "true"
+              },
+              "Resource{{ upper $name }}Pass": {
+                "Type": "String",
+                "NoEcho": "true"
+              },
+              "Resource{{ upper $name }}Host": {
+                "Type": "String",
+                "NoEcho": "true"
+              },
+              "Resource{{ upper $name }}Port": {
+                "Type": "String",
+                "NoEcho": "true"
+              },
+              "Resource{{ upper $name }}Name": {
+                "Type": "String",
+                "NoEcho": "true"
+              },
+            {{ end }}
+          {{ end }}
+        {{ end }}
       {{ end }}
       "Role": {
         "Type": "String"
@@ -598,13 +611,19 @@
                     "https://{{$.App}}-{{.}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router . $.Manifest }}Host" } }
                   ] ] } },
                 {{ end }}
-                {{ range .Resources }}
-                  { "Name": "{{ envname . }}_URL", "Value": { "Ref": "Resource{{ upper . }}" } },
-                  { "Name": "{{ envname . }}_USER", "Value": { "Ref": "Resource{{ upper . }}User" } },
-                  { "Name": "{{ envname . }}_PASS", "Value": { "Ref": "Resource{{ upper . }}Pass" } },
-                  { "Name": "{{ envname . }}_HOST", "Value": { "Ref": "Resource{{ upper . }}Host" } },
-                  { "Name": "{{ envname . }}_PORT", "Value": { "Ref": "Resource{{ upper . }}Port" } },
-                  { "Name": "{{ envname . }}_NAME", "Value": { "Ref": "Resource{{ upper . }}Name" } },
+                {{ range $name := .Resources }}
+                  {{ range $resource := $.Manifest.Resources }}
+                    {{ if eq $name $resource.Name }}
+                      {{ if not (eq $resource.Type "efs") }}
+                        { "Name": "{{ envname $name }}_URL", "Value": { "Ref": "Resource{{ upper $name }}" } },
+                        { "Name": "{{ envname $name }}_USER", "Value": { "Ref": "Resource{{ upper $name }}User" } },
+                        { "Name": "{{ envname $name }}_PASS", "Value": { "Ref": "Resource{{ upper $name }}Pass" } },
+                        { "Name": "{{ envname $name }}_HOST", "Value": { "Ref": "Resource{{ upper $name }}Host" } },
+                        { "Name": "{{ envname $name }}_PORT", "Value": { "Ref": "Resource{{ upper $name }}Port" } },
+                        { "Name": "{{ envname $name }}_NAME", "Value": { "Ref": "Resource{{ upper $name }}Name" } },
+                      {{ end }}
+                    {{ end }}
+                  {{ end }}
                 {{ end }}
                 { "Name": "AWS_REGION", "Value": { "Ref": "AWS::Region" } },
                 { "Name": "APP", "Value": "{{$.App}}" },
@@ -661,6 +680,16 @@
                 {{ range $i, $v := .Volumes }}
                   { "SourceVolume": "volume-{{$i}}", "ContainerPath": "{{ volumeTo $v }}" },
                 {{ end }}
+                {{ range $name := .Resources }}
+                  {{ range $resource := $.Manifest.Resources }}
+                    {{ if and (eq $name $resource.Name) (eq $resource.Type "efs") }}
+                      {
+                        "ContainerPath": "/bitnami",
+                        "SourceVolume": "{{ $resource.Name }}"
+                      },
+                    {{ end }}
+                  {{ end }}
+                {{ end }}
                 { "Ref": "AWS::NoValue" }
               ],
               "Name": "{{.Name}}",
@@ -694,6 +723,23 @@
           "Volumes": [
             {{ range $i, $v := .Volumes }}
               { "Name": "volume-{{$i}}", "Host": { "SourcePath": "{{ volumeFrom $.App $v }}" } },
+            {{ end }}
+            {{ range $name := .Resources }}
+              {{ range $resource := $.Manifest.Resources }}
+                {{ if and (eq $name $resource.Name) (eq $resource.Type "efs") }}
+                  {
+                    "Name": "{{ $name }}",
+                    "EFSVolumeConfiguration": {
+                      "FilesystemId": { "Ref": "Resource{{ upper $name }}FileSystemId" },
+                      "TransitEncryption": "ENABLED",
+                      "AuthorizationConfig": {
+                        "AccessPointId": { "Ref": "Resource{{ upper $name }}AccessPointId" },
+                        "IAM": "DISABLED"
+                      }
+                    }
+                  },
+                {{ end }}
+              {{ end }}
             {{ end }}
             { "Ref": "AWS::NoValue" }
           ]

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -595,6 +595,7 @@
       "Tasks": {
         "Type": "AWS::ECS::TaskDefinition",
         "Properties": {
+          {{ $resources := .Resources }}
           "ContainerDefinitions": [
             {
               {{ with .Command }}
@@ -678,16 +679,21 @@
               "Memory": { "Ref": "Memory" },
               "MountPoints": [
                 {{ range $i, $v := .Volumes }}
-                  { "SourceVolume": "volume-{{$i}}", "ContainerPath": "{{ volumeTo $v }}" },
-                {{ end }}
-                {{ range $name := .Resources }}
-                  {{ range $resource := $.Manifest.Resources }}
-                    {{ if and (eq $name $resource.Name) (eq $resource.Type "efs") }}
-                      {
-                        "ContainerPath": "/bitnami",
-                        "SourceVolume": "{{ $resource.Name }}"
-                      },
+                  {{ $volume := splitVolumeLabel $v }}
+                  {{ $name :=  (index $volume 0)}}
+
+                  {{ if stringContains $name $resources }}
+                    {{ range $r := $.Manifest.Resources }}
+                      {{ if and (eq $name $r.Name) (eq $r.Type "efs") }}
+                        {
+                          "ContainerPath": "{{ index $volume 1 }}",
+                          "SourceVolume": "{{ $r.Name }}"
+                        },
+                      {{ end }}
                     {{ end }}
+
+                  {{ else }}
+                    { "SourceVolume": "volume-{{$i}}", "ContainerPath": "{{ volumeTo $v }}" },
                   {{ end }}
                 {{ end }}
                 { "Ref": "AWS::NoValue" }
@@ -722,23 +728,28 @@
           "TaskRoleArn": { "Ref": "Role" },
           "Volumes": [
             {{ range $i, $v := .Volumes }}
-              { "Name": "volume-{{$i}}", "Host": { "SourcePath": "{{ volumeFrom $.App $v }}" } },
-            {{ end }}
-            {{ range $name := .Resources }}
-              {{ range $resource := $.Manifest.Resources }}
-                {{ if and (eq $name $resource.Name) (eq $resource.Type "efs") }}
-                  {
-                    "Name": "{{ $name }}",
-                    "EFSVolumeConfiguration": {
-                      "FilesystemId": { "Ref": "Resource{{ upper $name }}FileSystemId" },
-                      "TransitEncryption": "ENABLED",
-                      "AuthorizationConfig": {
-                        "AccessPointId": { "Ref": "Resource{{ upper $name }}AccessPointId" },
-                        "IAM": "DISABLED"
+              {{ $volume := splitVolumeLabel $v }}
+              {{ $name :=  (index $volume 0)}}
+
+              {{ if stringContains $name $resources }}
+                {{ range $r := $.Manifest.Resources }}
+                  {{ if and (eq $name $r.Name) (eq $r.Type "efs") }}
+                    {
+                      "Name": "{{ $name }}",
+                      "EFSVolumeConfiguration": {
+                        "FilesystemId": { "Ref": "Resource{{ upper $name }}FileSystemId" },
+                        "TransitEncryption": "ENABLED",
+                        "AuthorizationConfig": {
+                          "AccessPointId": { "Ref": "Resource{{ upper $name }}AccessPointId" },
+                          "IAM": "DISABLED"
+                        }
                       }
-                    }
-                  },
+                    },
+                  {{ end }}
                 {{ end }}
+
+              {{ else }}
+                { "Name": "volume-{{$i}}", "Host": { "SourcePath": "{{ volumeFrom $.App $v }}" } },
               {{ end }}
             {{ end }}
             { "Ref": "AWS::NoValue" }

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -444,6 +444,15 @@ func volumeTo(s string) string {
 	return fmt.Sprintf("invalid volume %q", s)
 }
 
+func splitVolumeLabel(s string) []string {
+	return strings.SplitN(s, ":", 2)
+}
+
+func stringContains(main string, subs []string) bool {
+	joinedS := strings.Join(subs, ";-;")
+	return strings.Contains(joinedS, main)
+}
+
 func dashName(name string) string {
 	// Myapp -> myapp; MyApp -> my-app
 	re := regexp.MustCompile("([a-z])([A-Z])") // lower case letter followed by upper case

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -285,8 +285,8 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 			"Manifest":       tp["Manifest"],
 			"Password":       p.Password,
 			"Release":        tp["Release"],
-			"WildcardDomain": tp["WildcardDomain"],
 			"Service":        s,
+			"WildcardDomain": tp["WildcardDomain"],
 		}
 
 		sarn, err := p.serviceArn(r.App, s.Name)

--- a/provider/aws/template.go
+++ b/provider/aws/template.go
@@ -114,6 +114,12 @@ func formationHelpers() template.FuncMap {
 		"volumeTo": func(s string) string {
 			return volumeTo(s)
 		},
+		"splitVolumeLabel": func(s string) []string {
+			return splitVolumeLabel(s)
+		},
+		"stringContains": func(main string, subs []string) bool {
+			return stringContains(main, subs)
+		},
 		// generation 1
 		"coalesce": func(ss ...string) string {
 			for _, s := range ss {
@@ -147,6 +153,7 @@ func formationHelpers() template.FuncMap {
 		},
 	}
 }
+
 func formationTemplate(name string, data interface{}) ([]byte, error) {
 	var buf bytes.Buffer
 


### PR DESCRIPTION
### What is the feature/fix?

A new way to have a persistent volume can be accessed between services (across instances and AZs). The EFS resource will allocate a new EFS volume that can be linked to services and used in the volumes. 

### Add screenshot or video (optional)

```
resources:
  sharedvolume:
    type: efs
    options:
      path: "/bitnami"

environment:
  - PORT=3000
  - ENVIRONMENT=master
services:
  web:
    build: .
    port: 3000
    volumes:
      - /my/shared/data
      - /var/www/html
      - /sys/fs/cgroup/:/host/sys/fs/cgroup/
      - /proc/:/host/proc/
      - /var/run/docker.sock:/var/run/docker.sock
      - testvolume:/app
      - sharedvolume:/bitnami
    resources:
      - sharedvolume
```

### Does it has a breaking change?

No.

### How to use/test it?

Install a rack with the RC version (to be created, declare the EFS resource, link the resource in the service and use it in the volumes. You can see a snippet above.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
