### PR TITLE
Remove duplicated command registration

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -67,10 +67,6 @@ func init() {
 		Validate: stdcli.Args(0),
 	})
 
-	register("rack sync", "sync v2 rack API url", RackSync, stdcli.CommandOptions{
-		Flags: []stdcli.Flag{flagRack, stdcli.StringFlag("name", "n", "rack name. Use it for non console managed racks")},
-	})
-
 	registerWithoutProvider("rack uninstall", "uninstall a rack", RackUninstall, stdcli.CommandOptions{
 		Flags:    append(stdcli.OptionFlags(structs.SystemUninstallOptions{})),
 		Usage:    "<type> <name>",


### PR DESCRIPTION
### What is the feature/fix?

The `rack sync` command is declared twice.

### Does it has a breaking change?

No

### How to use/test it?

Download the new CLI and run `convox`, the rack sync should only appear once.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
