### PR TITLE
Change the cli default directory to avoid conflict with v3 cli

### DIFF
--- a/cmd/convox/main.go
+++ b/cmd/convox/main.go
@@ -11,7 +11,7 @@ var (
 )
 
 func main() {
-	c := cli.New("convox", version)
+	c := cli.New("convox2", version)
 
 	os.Exit(c.Execute(os.Args[1:]))
 }


### PR DESCRIPTION
### What is the feature/fix?

Change the cli default directory to avoid conflict with v3 cli

### Add screenshot or video (optional)

### Does it has a breaking change?

### How to use/test it?

- use this cli to do the operations
- if you already used older version and the default settings directory, then move the all content from `$HOME/.convox/`  to `$HOME/.config/convox2/`

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
