### PR TITLE
Fix rack sync name flag

### DIFF
--- a/pkg/helpers/aws.go
+++ b/pkg/helpers/aws.go
@@ -537,7 +537,7 @@ func writeLogEvents(w io.Writer, events []*cloudwatchlogs.FilteredLogEvent, opts
 }
 
 func NewSession() (*session.Session, error) {
-	s, err := session.NewSession(&aws.Config{
+	config := &aws.Config{
 		MaxRetries: aws.Int(MAX_RETRY),
 		Retryer: client.DefaultRetryer{
 			NumMaxRetries:    MAX_RETRY,
@@ -546,7 +546,17 @@ func NewSession() (*session.Session, error) {
 			MinThrottleDelay: 10 * time.Second,
 			MaxThrottleDelay: 60 * time.Second,
 		},
-	})
+	}
+	if os.Getenv("AWS_REGION") != "" || os.Getenv("AWS_DEFAULT_REGION") != "" {
+		region := os.Getenv("AWS_DEFAULT_REGION")
+		if region == "" {
+			region = os.Getenv("AWS_REGION")
+		}
+
+		config.Region = aws.String(region)
+	}
+
+	s, err := session.NewSession(config)
 
 	return s, err
 }


### PR DESCRIPTION
### What is the feature/fix?

Change the description to inform that the --name flag will ONLY display the rack URL

In case it's needed to set/sync you can use only

### Does it has a breaking change?

No, it fixes `convox rack sync --name` command introduced on https://github.com/convox/rack/pull/3543

### How to use/test it?

Update the CLI and use `convox rack sync --name `

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
