### PR TITLE
Worker monitor should not get LogGroup from Rack API service

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -73,6 +73,7 @@ type Provider struct {
 	Private             bool
 	PrivateBuild        bool
 	Rack                string
+	RackApiServiceName  string
 	SecurityGroup       string
 	SettingsBucket      string
 	SshKey              string
@@ -166,6 +167,7 @@ func (p *Provider) loadParams() error {
 	p.OnDemandMinCount = intParam(labels["rack.OnDemandMinCount"], 2)
 	p.Private = labels["rack.Private"] == "Yes"
 	p.PrivateBuild = labels["rack.PrivateBuild"] == "Yes"
+	p.RackApiServiceName = strings.ReplaceAll(labels["rack.RackApiServiceName"], ",", "|")
 	p.SecurityGroup = labels["rack.SecurityGroup"]
 	p.SettingsBucket = labels["rack.SettingsBucket"]
 	p.SpotInstances = labels["rack.SpotInstances"] == "Yes"

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -3072,6 +3072,7 @@
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
               "rack.PrivateBuild": { "Ref": "PrivateBuild" },
+              "rack.RackApiServiceName": "ServiceMonitorApi,ServiceWebApi",
               "rack.SecurityGroup": { "Fn::If": [ "BlankInstanceSecurityGroup", { "Ref": "InstancesSecurity" }, { "Ref": "InstanceSecurityGroup" } ] },
               "rack.SettingsBucket": { "Ref": "Settings" },
               "rack.SpotInstances": { "Fn::If": [ "SpotInstances", "Yes", "No" ] },

--- a/provider/aws/workers_events.go
+++ b/provider/aws/workers_events.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -173,6 +174,7 @@ func (p *Provider) handleECSEvents() {
 
 func (p *Provider) pollECSEvents() error {
 	prefix := fmt.Sprintf("%s-", p.Rack)
+	isRackApiServiceRegex := regexp.MustCompile(p.RackApiServiceName)
 
 	lreq := &ecs.ListServicesInput{
 		Cluster: aws.String(p.Cluster),
@@ -195,7 +197,7 @@ func (p *Provider) pollECSEvents() error {
 		for _, s := range sres.Services {
 			name := *s.ServiceName
 
-			if !strings.HasPrefix(name, prefix) || !strings.Contains(name, "-Service") {
+			if !strings.HasPrefix(name, prefix) || !strings.Contains(name, "-Service") || isRackApiServiceRegex.MatchString(name) {
 				continue
 			}
 


### PR DESCRIPTION
### What is the feature/fix?

Since the Monitor and Web API had their name changed to include in the beginning, the worker was mistakenly assuming that the stack was from an app.

The monitor worker should only get the LogGroup from service apps.

### Does it has a breaking change?

No.

### How to use/test it?

Install the RC and run `convox rack logs`, it shouldn't show any error.

### Checklist
- [ ] New coverage tests
- [x] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
