### PR TITLE
feat-829: Add support to restrict rack api access from certain ips

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -156,7 +156,8 @@
         { "Condition": "NotExistingVpcAndBlankInternetGateway" },
         { "Condition": "ThirdAvailabilityZone" }
       ]
-    }
+    },
+    "WhiteListCIDRs": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WhiteList" }, "" ] } ] }
   },
   "Mappings": {
     "RegionConfig": {
@@ -895,6 +896,11 @@
       "Description": "Dedicated Hardware",
       "Default": "default",
       "AllowedValues": [ "default", "dedicated" ]
+    },
+    "WhiteList": {
+      "Type": "String",
+      "Description": "Comma delimited list of CIDRs, e.g. `10.0.0.0/24,172.10.0.1/32`, to allow access to the rack api. Maximum 4 CIDR can be specified.",
+      "Default": ""
     }
   },
   "Resources": {
@@ -2789,7 +2795,11 @@
             { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "ApiBalancer", "DNSName" ] } ] } ] },
             { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "ApiBalancer", "DNSName" ] } ] } ] },
             "convox.site"
-          ] ] } ] }
+          ] ] } ] },
+          { "Fn::If": [ "WhiteListCIDRs",
+            { "Field": "source-ip", "SourceIpConfig": { "Values": { "Fn::Split": [",", { "Ref": "WhiteList" }] } } },
+            { "Ref": "AWS::NoValue" }
+          ] }
         ],
         "ListenerArn": { "Ref": "ApiBalancerListener443" },
         "Priority": "1"


### PR DESCRIPTION
### What is the feature/fix?

Add support to restrict rack api access from certain ips

https://github.com/convox/issues-private/issues/829


### Add screenshot or video (optional)

https://user-images.githubusercontent.com/12232198/212930443-544bb3a5-4d05-4218-a573-7c44dd456338.mp4



### Does it has a breaking change?

no, but if user set wrong ips, then convox console and cli will not able to access it

### How to use/test it?

- Install/update rack to this version: convox rack update 20230117133524-feat-829_whitelist_ips
- then `convox rack params set WhiteList="54.144.53.172/24"`
- and check access

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
