### PR TITLE
Save racks installed locally through the CLI

### DIFF
--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -23,4 +23,6 @@ chmod +x ${GOPATH}/bin/convox
 
 # set ci@convox.com as id
 mkdir -p ~/.convox/
-echo ci@convox.com > ~/.convox/id
+
+# convox config dir path
+echo ci@convox.com > ~/.config/convox2/id

--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -20,9 +20,3 @@ curl -Ls https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/lin
 # download appropriate cli version
 curl -o ${GOPATH}/bin/convox https://convox.s3.amazonaws.com/release/${VERSION}/cli/linux/convox
 chmod +x ${GOPATH}/bin/convox
-
-# set ci@convox.com as id
-mkdir -p ~/.convox/
-
-# convox config dir path
-echo ci@convox.com > ~/.config/convox2/id

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -12,3 +12,7 @@ else
 fi
 
 convox instances
+
+# set ci@convox.com as id
+# convox config dir path
+echo ci@convox.com > ~/.config/convox2/id

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -22,6 +22,7 @@ root="$(cd $(dirname ${0:-})/..; pwd)"
 set -ex
 
 provider=$(convox api get /system | jq -r .provider)
+source $(dirname $0)/env.sh
 
 # cli
 convox version
@@ -32,6 +33,8 @@ convox rack
 sleep 15
 convox rack logs --no-follow | grep service/
 convox rack ps | grep rack
+
+convox racks | grep ${RACK_NAME}
 
 # rack (provider-specific)
 case $provider in

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/convox/exec v0.0.0-20180905012044-cc13d277f897
 	github.com/convox/logger v0.0.0-20180522214415-e39179955b52
 	github.com/convox/stdapi v1.1.3-0.20221110171947-8d98f61e61ed
-	github.com/convox/stdcli v0.0.0-20221110070640-8f8fb17bfe20
+	github.com/convox/stdcli v0.0.0-20230203181735-23ed17b69b51
 	github.com/convox/stdsdk v0.0.0-20190422120437-3e80a397e377
 	github.com/convox/version v0.0.0-20160822184233-ffefa0d565d2
 	github.com/docker/docker v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/convox/logger v0.0.0-20180522214415-e39179955b52 h1:HTaloo6by+4NE1A1m
 github.com/convox/logger v0.0.0-20180522214415-e39179955b52/go.mod h1:IcbSD+Pq+bQV2z/otiMCHLAYBrDR/jPFopFatrWjlMM=
 github.com/convox/stdapi v1.1.3-0.20221110171947-8d98f61e61ed h1:lsw6qfOktQBaF0FEb32+ogvB1S/H3m1W341TuOQ5jnc=
 github.com/convox/stdapi v1.1.3-0.20221110171947-8d98f61e61ed/go.mod h1:7hoZ3oU4j6Zv3V1wRpgUO5eWc+480zYTpYxuTKAbugc=
-github.com/convox/stdcli v0.0.0-20221110070640-8f8fb17bfe20 h1:9t+oXf7ycnO1Cz9AnIEqPLdvbE0b0Yf9Pe5NOukvRN0=
-github.com/convox/stdcli v0.0.0-20221110070640-8f8fb17bfe20/go.mod h1:kLknwv4KTN9f9fZ2DDvG/L9ndXkcijaexIZ0enACvSc=
+github.com/convox/stdcli v0.0.0-20230203181735-23ed17b69b51 h1:03Yia3LZwsHUovVEPFDGUrTAUg9N844Wvv9PiFQuR0Y=
+github.com/convox/stdcli v0.0.0-20230203181735-23ed17b69b51/go.mod h1:kLknwv4KTN9f9fZ2DDvG/L9ndXkcijaexIZ0enACvSc=
 github.com/convox/stdsdk v0.0.0-20190422120437-3e80a397e377 h1:PuSJ72MD0mYsMCTvTQ1YydIbQUWtEykNHyweI/vA0PY=
 github.com/convox/stdsdk v0.0.0-20190422120437-3e80a397e377/go.mod h1:y1vtmkDKBkWSQ6e2gPXAyz1NCuWZ2x3vrP/SFeDDNco=
 github.com/convox/version v0.0.0-20160822184233-ffefa0d565d2 h1:tdp/1KHBnbne0yT1yuKnAdOTBHRue9yQ4oON8rzGgZc=

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -206,6 +206,44 @@ func localRacks(c *stdcli.Context) ([]rack, error) {
 	return racks, nil
 }
 
+func selfManagedRacks(c *stdcli.Context) ([]rack, error) {
+	racks := []rack{}
+
+	data, err := c.SettingRead("self-managed")
+	if err != nil {
+		return nil, err
+	}
+	var rs map[string]string
+
+	if err := json.Unmarshal([]byte(data), &rs); err != nil {
+		return nil, err
+	}
+
+	for name := range rs {
+		racks = append(racks, rack{
+			Name:   name,
+			Status: "running",
+		})
+	}
+
+	return racks, nil
+}
+
+func selfManagedRackHost(c *stdcli.Context) map[string]string {
+	data, err := c.SettingRead("self-managed")
+	if err != nil {
+		return map[string]string{}
+	}
+
+	var rs map[string]string
+
+	if err := json.Unmarshal([]byte(data), &rs); err != nil {
+		return map[string]string{}
+	}
+
+	return rs
+}
+
 func matchRack(c *stdcli.Context, name string) (*rack, error) {
 	rs, err := racks(c)
 	if err != nil {
@@ -251,6 +289,9 @@ func racks(c *stdcli.Context) ([]rack, error) {
 	}
 
 	rs = append(rs, lrs...)
+
+	sfr, _ := selfManagedRacks(c)
+	rs = append(rs, sfr...)
 
 	sort.Slice(rs, func(i, j int) bool {
 		return rs[i].Name < rs[j].Name

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -188,8 +188,8 @@ func RackInstall(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	if host, _ := c.SettingRead("host"); host == "" {
-		c.SettingWrite("host", u.Host)
+	if err := c.SettingWrite("host", u.Host); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -188,8 +188,12 @@ func RackInstall(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	if err := c.SettingWrite("host", u.Host); err != nil {
+	if err := c.SettingWriteKey("self-managed", *opts.Name, u.Host); err != nil {
 		return err
+	}
+
+	if host, _ := c.SettingRead("host"); host == "" {
+		c.SettingWrite("host", u.Host)
 	}
 
 	return nil
@@ -427,6 +431,7 @@ func RackSync(rack sdk.Interface, c *stdcli.Context) error {
 
 func RackUninstall(rack sdk.Interface, c *stdcli.Context) error {
 	var opts structs.SystemUninstallOptions
+	name := c.Arg(1)
 
 	if err := c.Options(&opts); err != nil {
 		return err
@@ -445,7 +450,9 @@ func RackUninstall(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	if err := p.SystemUninstall(c.Arg(1), c, opts); err != nil {
+	c.SettingDeleteKey("self-managed", name)
+
+	if err := p.SystemUninstall(name, c, opts); err != nil {
 		return err
 	}
 

--- a/pkg/cli/switch.go
+++ b/pkg/cli/switch.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/convox/rack/sdk"
 	"github.com/convox/stdcli"
@@ -25,7 +26,17 @@ func Switch(rack sdk.Interface, c *stdcli.Context) error {
 			return err
 		}
 
-		rs := hostRacks(c)
+		var rs map[string]string
+		if len(strings.Split(r.Name, "/")) > 1 {
+			rs = hostRacks(c)
+		} else {
+			rs = selfManagedRackHost(c)
+
+			hostname := rs[r.Name]
+			if err := c.SettingWrite("host", hostname); err != nil {
+				return err
+			}
+		}
 
 		rs[host] = r.Name
 

--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -38,7 +38,7 @@
     },
     "Version": {
       "Type": "String",
-      "Default": "2.8"
+      "Default": "3.2.6"
     }
   },
   "Outputs": {

--- a/vendor/github.com/convox/stdcli/context.go
+++ b/vendor/github.com/convox/stdcli/context.go
@@ -193,6 +193,10 @@ func (c *Context) SettingWriteKey(name, key, value string) error {
 	return c.engine.SettingWriteKey(name, key, value)
 }
 
+func (c *Context) SettingDeleteKey(name, key string) error {
+	return c.engine.SettingDeleteKey(name, key)
+}
+
 func (c *Context) Table(columns ...string) *Table {
 	return &Table{Columns: columns, Context: c}
 }

--- a/vendor/github.com/convox/stdcli/setting.go
+++ b/vendor/github.com/convox/stdcli/setting.go
@@ -129,6 +129,30 @@ func (e *Engine) SettingWriteKey(name, key, value string) error {
 	return e.SettingWrite(name, string(data))
 }
 
+func (e *Engine) SettingDeleteKey(name, key string) error {
+	s, err := e.SettingRead(name)
+	if err != nil {
+		return err
+	}
+
+	data := []byte(coalesce(s, "{}"))
+
+	var kv map[string]string
+
+	if err := json.Unmarshal(data, &kv); err != nil {
+		return err
+	}
+
+	delete(kv, key)
+
+	data, err = json.MarshalIndent(kv, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return e.SettingWrite(name, string(data))
+}
+
 func (e *Engine) localSettingDir() string {
 	return fmt.Sprintf(".%s", e.Name)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -126,7 +126,7 @@ github.com/convox/logger
 # github.com/convox/stdapi v1.1.3-0.20221110171947-8d98f61e61ed
 ## explicit; go 1.12
 github.com/convox/stdapi
-# github.com/convox/stdcli v0.0.0-20221110070640-8f8fb17bfe20
+# github.com/convox/stdcli v0.0.0-20230203181735-23ed17b69b51
 ## explicit; go 1.13
 github.com/convox/stdcli
 # github.com/convox/stdsdk v0.0.0-20190422120437-3e80a397e377


### PR DESCRIPTION
### What is the feature/fix?

When a rack is installed using the CLI locally, not through the console or local rack, the installation finishes but don't keep the rack host anywhere. The CLI now will store the racks installed through it in the `self-managed` file.

### Does it has a breaking change?

No, however past racks installed using the CLI won't be recoverable, only if the user creates the rack entry on `self-managed`.

### How to use/test it?

1. Login into a console (e.g. console.convox.com)
2. Install the rack through the RC CLI (to be created).
3. Check if the rack is listed on `convox racks`
4. Switch to the new rack
5. Uninstall it
6. Run `convox racks` and the rack should not be on the list

### Checklist
- [x] New coverage tests
- [x] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
