### PR TITLE
Use same redis version for rack resource and app resource

### DIFF
--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -38,7 +38,7 @@
     },
     "Version": {
       "Type": "String",
-      "Default": "2.8"
+      "Default": "3.2.6"
     }
   },
   "Outputs": {


### PR DESCRIPTION
### What is the feature/fix?

New redis resources are failing to install because version 6.8 is not supported anymore. 
Update the app resource version to 3.2.6 (the same version used by the redis at rack level)

### Does it has a breaking change?

No

### How to use/test it?

Deploy an app with redis resource using the default version

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
