### PR TITLE
Create build instance policy parameter

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -157,6 +157,7 @@
         { "Condition": "ThirdAvailabilityZone" }
       ]
     },
+    "UseBuildInstancePolicy": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "BuildInstancePolicy" }, "" ] } ] },
     "WhiteListCIDRs": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WhiteList" }, "" ] } ] }
   },
   "Mappings": {
@@ -583,6 +584,11 @@
       "Type": "String",
       "Description": "Instance type for a dedicated build cluster",
       "Default": "t3.small"
+    },
+    "BuildInstancePolicy": {
+      "Default": "",
+      "Description": "ARN of an additional IAM policy to add to the cluster build instances",
+      "Type": "String"
     },
     "BuildMemory": {
       "Type": "String",
@@ -1465,6 +1471,32 @@
         "Roles": [ { "Ref": "InstancesRole" } ]
       }
     },
+    "BuildInstancesRole": {
+      "Condition": "UseBuildInstancePolicy",
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [ { "Effect": "Allow", "Principal": { "Service": [ "ec2.amazonaws.com" ] }, "Action": [ "sts:AssumeRole" ] } ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/convox/",
+        "ManagedPolicyArns": [
+          { "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role" },
+          { "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AutoScalingFullAccess" },
+          { "Ref": "CMKPolicy" },
+          { "Ref": "BuildInstancePolicy" }
+        ]
+      }
+    },
+    "BuildInstancesProfile": {
+      "Condition": "UseBuildInstancePolicy",
+      "DependsOn": "ApiRole",
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "Path": "/convox/",
+        "Roles": [ { "Ref": "BuildInstancesRole" } ]
+      }
+    },
     "BuildCluster": {
       "Condition": "DedicatedBuilder",
       "Type": "AWS::ECS::Cluster"
@@ -1495,7 +1527,7 @@
             { "Ref": "AWS::NoValue" }
           ] }
         ],
-        "IamInstanceProfile": { "Ref": "InstancesProfile" },
+        "IamInstanceProfile": { "Fn::If": [ "UseBuildInstancePolicy", { "Ref": "BuildInstancesProfile" }, { "Ref": "InstancesProfile" } ] },
         "ImageId": {
           "Fn::If": [
             "BlankAmi",


### PR DESCRIPTION
### What is the feature/fix?

The build instance policy will be used by the BuildCluster instances. If not specified, it will use instance profile/policy to keep existing policy working.

### Does it has a breaking change?

No, existing policy will still be used, only if the user sets the new parameter then the build cluster will be updated.

### How to use/test it?

Create/update a rack with `BuildInstancePolicy`, for testing purpose, use `arn:aws:iam::aws:policy/AmazonEC2FullAccess`.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
