### PR TITLE
Support ECS clusters based on X2gd instances

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -108,6 +108,17 @@
             },
             ""
           ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                0,
+                { "Fn::Split": ["x2gd", { "Ref": "InstanceType" }] }
+              ]
+            },
+            ""
+          ]
         }
       ]
     },


### PR DESCRIPTION
### What is the feature/fix?

** Describe the task and what is the goal for it. **

To deploy a Convox v2 cluster onto "memory-intensive" instances. The CloudFormation template supports R6g instances, however X2gd instances are much cheaper.

** Describe the bug and the solution. **

I tried to deploy a cluster onto x2gd instances and was foiled by the mechanism for detecting when an Arm cluster is being deployed not including the x2gd family. Simply adding the x2gd (there is no x2g.* class) prefix to the existing InstanceARM conditional.

** Any additional information **

N/A

### Add screenshot or video (optional)

** Any screenshot or video capture using the feature **

N/A

### Does it has a breaking change?

No.

** Describe the changes and if it has any breaking changes in any feature **

### How to use/test it?

** Describe how to test or use the feature **

Create a new cluster on x2gd instances.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
