### PR TITLE
Restrict ApiPolicy acess 

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2933,13 +2933,9 @@
             {
               "Effect": "Allow",
               "Action": [
-                "iam:DeleteServerCertificate",
                 "iam:*Role",
-                "iam:GetServerCertificate",
-                "iam:ListServerCertificates",
                 "iam:ListPolicyVersions",
-                "iam:*Policy",
-                "iam:UploadServerCertificate"
+                "iam:*Policy"
               ],
               "Resource": [
                 { "Fn::Sub": "arn:${AWS::Partition}:iam::*:instance-profile/convox/*" },
@@ -2947,6 +2943,17 @@
                 { "Fn::Sub": "arn:${AWS::Partition}:iam::*:role/convox/*" },
                 { "Fn::Sub": "arn:${AWS::Partition}:iam::*:user/convox/*" }
               ]
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "iam:DeleteServerCertificate",
+                "iam:DetachRolePolicy",
+                "iam:GetServerCertificate",
+                "iam:ListServerCertificates",
+                "iam:UploadServerCertificate"
+              ],
+              "Resource": [ "*" ]
             }
           ]
         }

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2932,26 +2932,21 @@
           "Statement": [
             {
               "Effect": "Allow",
-              "Action": [ "iam:*" ],
+              "Action": [
+                "iam:DeleteServerCertificate",
+                "iam:*Role",
+                "iam:GetServerCertificate",
+                "iam:ListServerCertificates",
+                "iam:ListPolicyVersions",
+                "iam:*Policy",
+                "iam:UploadServerCertificate"
+              ],
               "Resource": [
                 { "Fn::Sub": "arn:${AWS::Partition}:iam::*:instance-profile/convox/*" },
                 { "Fn::Sub": "arn:${AWS::Partition}:iam::*:policy/convox/*" },
                 { "Fn::Sub": "arn:${AWS::Partition}:iam::*:role/convox/*" },
                 { "Fn::Sub": "arn:${AWS::Partition}:iam::*:user/convox/*" }
               ]
-            },
-            {
-              "Effect": "Allow",
-              "Action": [
-                "iam:DeleteServerCertificate",
-                "iam:DetachRolePolicy",
-                "iam:GetRole",
-                "iam:GetServerCertificate",
-                "iam:ListServerCertificates",
-                "iam:PassRole",
-                "iam:UploadServerCertificate"
-              ],
-              "Resource": [ "*" ]
             }
           ]
         }


### PR DESCRIPTION
### What is the feature/fix?

ApiPolicy and ApiRole are used by the rack api to create the services (and resources such as services roles and their assignments). The policy scope should be restricted to convox resources.

### Does it has a breaking change?

No.

### How to use/test it?

Update/Create the rack on version `20230222192752-chore-873-apipolicy-permission`, and deploy a new app.

### Checklist
- [ ] New coverage tests
- [x] Unit tests passing
- [x] E2E tests passing
- [x] E2E downgrade/update test passing
- [ ] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
