### PR TITLE
Use SSM Parameter store to keep the API Password on task definition

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -31,7 +31,7 @@
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] },
     "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "LogDriver" }, "CloudWatch" ] },
     "EnableSyslog": { "Fn::Equals": [ { "Ref": "LogDriver" }, "Syslog" ] },
-    "EncryptEbs" : { "Fn::Equals": [ { "Ref": "EncryptEbs" }, "Yes" ] },
+    "EncryptEbs": { "Fn::Equals": [ { "Ref": "EncryptEbs" }, "Yes" ] },
     "ExistingVpc": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "ExistingVpc" }, "" ] } ] },
     "ExistingVpcAndBlankInternetGateway": {
       "Fn::And": [ { "Condition": "ExistingVpc" }, { "Condition": "BlankInternetGateway" } ]
@@ -143,7 +143,7 @@
     "RegionHasEFSAndThirdAvailabilityZoneAndHighAvailability": {
       "Fn::And": [ { "Condition": "RegionHasEFS" }, { "Condition": "ThirdAvailabilityZone" }, { "Condition": "HighAvailability" } ]
     },
-    "SetScheduleRackScale": { "Fn::Not" : [{
+    "SetScheduleRackScale": { "Fn::Not": [{
       "Fn::And": [
         { "Fn::Equals": [ { "Ref": "ScheduleRackScaleDown" }, "" ] },
         { "Fn::Equals": [ { "Ref": "ScheduleRackScaleUp" }, "" ] }
@@ -355,7 +355,7 @@
       }
     },
     "NotificationTopic": {
-      "Value" : { "Ref": "NotificationTopic" }
+      "Value": { "Ref": "NotificationTopic" }
     },
     "OnDemandMinCount": {
       "Value": { "Ref": "OnDemandMinCount" }
@@ -2959,6 +2959,14 @@
         }
       }
     },
+    "RackApiSecret": {
+      "Type": "AWS::SSM::Parameter",
+      "Properties": {
+        "Name": { "Fn::Sub": "${AWS::StackName}RackApiSecret" },
+        "Type": "String",
+        "Value": { "Ref": "Password" }
+      }
+    },
     "ApiRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -2987,6 +2995,24 @@
                     "lambda:GetFunction"
                   ],
                   "Resource": "*"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "SecretApiRole",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "ssm:GetParameters",
+                    "kms:Decrypt"
+                  ],
+                  "Resource": [
+                    { "Fn::Sub": "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}RackApiSecret" }
+                  ]
                 }
               ]
             }
@@ -3072,7 +3098,6 @@
               { "Name": "NO_PROXY", "Value": "169.254.169.254,169.254.170.2,/var/run/docker.sock" },
               { "Name": "HTTP_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "HTTPS_PROXY", "Value": { "Ref": "HttpProxy" } },
-              { "Name": "PASSWORD", "Value": { "Ref": "Password" } },
               { "Name": "PROVIDER", "Value": "aws" },
               { "Name": "RACK", "Value": { "Ref": "AWS::StackName" } },
               { "Name": "STACK_ID", "Value": { "Ref": "AWS::StackId" } }
@@ -3098,9 +3123,14 @@
               { "SourceVolume": "config", "ContainerPath": "/etc/sysconfig/docker" },
               { "SourceVolume": "docker", "ContainerPath": "/var/run/docker.sock" }
             ],
-            "Name": "build"
+            "Name": "build",
+            "Secrets": [{
+              "Name": "PASSWORD",
+              "ValueFrom": { "Fn::Sub": "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}RackApiSecret" }
+            }]
           }
         ],
+        "ExecutionRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
         "Family": { "Fn::Sub": "${AWS::StackName}-build" },
         "TaskRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
         "Volumes": [
@@ -3303,7 +3333,6 @@
               { "Name": "NO_PROXY", "Value": "169.254.169.254,169.254.170.2,/var/run/docker.sock" },
               { "Name": "HTTP_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "HTTPS_PROXY", "Value": { "Ref": "HttpProxy" } },
-              { "Name": "PASSWORD", "Value": { "Ref": "Password" } },
               { "Name": "PROVIDER", "Value": "aws" },
               { "Name": "RACK", "Value": { "Ref": "AWS::StackName" } },
               { "Name": "STACK_ID", "Value": { "Ref": "AWS::StackId" } }
@@ -3352,9 +3381,14 @@
             "PortMappings": { "Fn::If": [ "PrivateApi",
               [ { "HostPort": "4100", "ContainerPort": "5443", "Protocol": "tcp" } ],
               [ { "HostPort": "4000", "ContainerPort": "5443", "Protocol": "tcp" } ]
-            ] }
+            ] },
+            "Secrets": [{
+              "Name": "PASSWORD",
+              "ValueFrom": { "Fn::Sub": "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}RackApiSecret" }
+            }]
           }
         ],
+        "ExecutionRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
         "Family": { "Fn::Sub": "${AWS::StackName}-web" },
         "TaskRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
         "Volumes": [ { "Name": "docker", "Host": { "SourcePath": "/var/run/docker.sock" } } ]


### PR DESCRIPTION
### What is the feature/fix?

Instead of passing the API password to the rack as plain text, it will store the password on SSM Parameter Store and then pass it as a secret to the task definition.

AWS charges to keep and use the Secret Manager, it would increase the user cost to store the password, the SSM is a cheaper alternative.

### Does it has a breaking change?

No

### How to use/test it?

Update/create a rack using the RC, then use it normally, it should not interfere in the user experience.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
