### PR TITLE
Set privileged option on container definition when is set on service

### DIFF
--- a/provider/aws/formation/timer.json.tmpl
+++ b/provider/aws/formation/timer.json.tmpl
@@ -250,6 +250,7 @@
                   { "Ref": "AWS::NoValue" }
                 ],
                 "Name": "{{$.Timer.Name}}",
+                "Privileged": "{{ .Privileged }}",
                 "Ulimits": [ { "Name": "nofile", "SoftLimit": "1024000", "HardLimit": "1024000" } ]
               }
             {{ end }}


### PR DESCRIPTION
### What is the feature/fix?

Service has an option to set if it should receive privileged access.

> When this parameter is true, the container is given elevated privileges on the host container instance (similar to the root user). This parameter maps to Privileged in the [Create a container](https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate) section of the [Docker Remote API](https://docs.docker.com/engine/api/v1.35/) and the --privileged option to [docker run](https://docs.docker.com/engine/reference/run/#security-configuration). 

Set privileged option on container definition when it's set on service.

### Does it has a breaking change?

No

### How to use/test it?

- Update/install the RC in a rack
- Deploy a service with `privileged` set to true and a timer linking the service.
- Look at the container definition, on ECS, and you should see Privileged as true.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
