### PR TITLE
Autoscale extra for non-ha racks

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -778,6 +778,11 @@
       "Default": "3",
       "AllowedValues": [ "2", "3" ]
     },
+    "NoHAAutoscaleExtra": {
+      "Type": "Number",
+      "Description": "When HighAvailability is set to false, the autoscale will maintain a certain number of extra capacity instances running on racks that are not configured for high availability",
+      "Default": "0"
+    },
     "OnDemandMinCount": {
       "Default": "3",
       "Description": "The minimum number of on-demand instances in the runtime cluster",
@@ -2008,7 +2013,7 @@
           "Variables": {
             "ASG": { "Ref": "Instances" },
             "CLUSTER": { "Ref": "Cluster" },
-            "EXTRA": { "Fn::If": [ "HighAvailability", { "Ref": "AutoscaleExtra" }, 0]},
+            "EXTRA": { "Fn::If": [ "HighAvailability", { "Ref": "AutoscaleExtra" }, { "Ref": "NoHAAutoscaleExtra" }]},
             "HIGH_AVAILABILITY": { "Ref": "HighAvailability" },
             "REGION": { "Ref": "AWS::Region" },
             "STACK": { "Ref": "AWS::StackName" }


### PR DESCRIPTION
### What is the feature/fix?

When HighAvailability is set to false, the autoscale will maintain a certain number of extra capacity instances running on racks that are not configured for high availability

### Does it has a breaking change?

No

### How to use/test it?

** Describe how to test or use the feature **

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
