### PR TITLE
Create new Api Policy with the missing permissions

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2927,7 +2927,7 @@
         "Path": "/convox/"
       }
     },
-    "ApiPolicy": {
+    "ApiPolicyV2": {
       "Type": "AWS::IAM::ManagedPolicy",
       "Properties": {
         "Path": "/convox/",
@@ -2937,9 +2937,41 @@
             {
               "Effect": "Allow",
               "Action": [
-                "iam:*Role",
+                "iam:AttachRolePolicy",
+                "iam:CreateAccessKey",
+                "iam:CreatePolicy",
+                "iam:CreatePolicyVersion",
+                "iam:CreateRole",
+                "iam:CreateUser",
+                "iam:DeletePolicy",
+                "iam:DeletePolicyVersion",
+                "iam:DeleteRole",
+                "iam:DeleteRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:DeleteUser",
+                "iam:DeleteUserPolicy",
+                "iam:GetInstanceProfile",
+                "iam:GetPolicy",
+                "iam:GetPolicyVersion",
+                "iam:GetRole",
+                "iam:GetRolePolicy",
+                "iam:GetUser",
+                "iam:GetUserPolicy",
+                "iam:ListAccessKeys",
                 "iam:ListPolicyVersions",
-                "iam:*Policy"
+                "iam:ListRoles",
+                "iam:ListUsers",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
+                "iam:PutUserPolicy",
+                "iam:SetDefaultPolicyVersion",
+                "iam:TagPolicy",
+                "iam:TagRole",
+                "iam:TagUser",
+                "iam:UntagPolicy",
+                "iam:UntagRole",
+                "iam:UntagUser",
+                "iam:UpdateAssumeRolePolicy"
               ],
               "Resource": [
                 { "Fn::Sub": "arn:${AWS::Partition}:iam::*:instance-profile/convox/*" },
@@ -2952,7 +2984,6 @@
               "Effect": "Allow",
               "Action": [
                 "iam:DeleteServerCertificate",
-                "iam:DetachRolePolicy",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "iam:UploadServerCertificate"
@@ -2983,7 +3014,7 @@
         },
         "ManagedPolicyArns": [
           { "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/PowerUserAccess" },
-          { "Ref": "ApiPolicy" },
+          { "Ref": "ApiPolicyV2" },
           { "Ref": "CMKPolicy" }
         ],
         "Path": "/convox/",

--- a/provider/aws/templates/resource/mysql.tmpl
+++ b/provider/aws/templates/resource/mysql.tmpl
@@ -55,7 +55,7 @@
       },
       "EngineVersion": {
         "Description": "Version of MySQL",
-        "Default": "5.7.16",
+        "Default": "5.7",
         "Type": "String"
       },
       "Subnets": {


### PR DESCRIPTION
### What is the feature/fix?

Add the missing permissions for Api Policy as `ApiPolicyV2`. The old api policy does not have the permission to create new policy versions, but it has to create new policies.

### Does it has a breaking change?

No.

### How to use/test it?

Run `convox rack update {RC}` on a rack with [20230322142551](https://github.com/convox/rack/releases/tag/untagged-c577a03c5528a0a4fac6) or [20230302000800](https://github.com/convox/rack/releases/tag/untagged-cf57ff8ae32778585073).

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
