### PR TITLE
Prepend the url scheme only if the resource doesn't have one

### DIFF
--- a/pkg/cli/fixtures_test.go
+++ b/pkg/cli/fixtures_test.go
@@ -239,6 +239,17 @@ func fxResource() *structs.Resource {
 	}
 }
 
+func fxResourceEmpty() *structs.Resource {
+	return &structs.Resource{
+		Name:       "resource1",
+		Parameters: map[string]string{"k1": "v1", "k2": "v2", "Url": "other.example.org/path"},
+		Status:     "status",
+		Type:       "type",
+		Url:        "example.org/path",
+		Apps:       structs.Apps{*fxApp(), *fxApp()},
+	}
+}
+
 func fxResourceType() structs.ResourceType {
 	return structs.ResourceType{
 		Name: "type1",

--- a/pkg/cli/resources.go
+++ b/pkg/cli/resources.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -11,6 +12,10 @@ import (
 	"github.com/convox/rack/pkg/structs"
 	"github.com/convox/rack/sdk"
 	"github.com/convox/stdcli"
+)
+
+const (
+	RESOURCE_URL_PATTERN = `.+:\/{2}.+`
 )
 
 func init() {
@@ -197,8 +202,13 @@ func ResourcesProxy(rack sdk.Interface, c *stdcli.Context) error {
 	}
 
 	resourceUrl := r.Url
-	if !strings.HasPrefix(r.Url, "http") {
-		resourceUrl = fmt.Sprintf("http://%s", r.Url)
+	rex, err := regexp.Compile(RESOURCE_URL_PATTERN)
+	if err == nil {
+		// Test if the string matches the resource url pattern
+		if !rex.MatchString(resourceUrl) {
+			// add the scheme to the url
+			resourceUrl = fmt.Sprintf("https://%s", resourceUrl)
+		}
 	}
 
 	u, err := url.Parse(resourceUrl)

--- a/pkg/cli/resources.go
+++ b/pkg/cli/resources.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	// RESOURCE_URL_PATTERN is used to check if the resrouce URL starts with http:// or https://
 	RESOURCE_URL_PATTERN = `.+:\/{2}.+`
 )
 
@@ -206,7 +207,7 @@ func ResourcesProxy(rack sdk.Interface, c *stdcli.Context) error {
 	if err == nil {
 		// Test if the string matches the resource url pattern
 		if !rex.MatchString(resourceUrl) {
-			// add the scheme to the url
+			// add the scheme to the url, if missing
 			resourceUrl = fmt.Sprintf("https://%s", resourceUrl)
 		}
 	}

--- a/pkg/cli/resources_test.go
+++ b/pkg/cli/resources_test.go
@@ -132,6 +132,61 @@ func TestResourcesProxy(t *testing.T) {
 	})
 }
 
+func TestResourcesProxyEmpty(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		i.On("WithContext", ctx).Return(i)
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ResourceGet", "app1", "resource1").Return(fxResourceEmpty(), nil)
+		i.On("Proxy", "example.org", 443, mock.Anything, structs.ProxyOptions{TLS: options.Bool(false)}).Return(nil).Run(func(args mock.Arguments) {
+			buf := make([]byte, 2)
+			rwc := args.Get(2).(io.ReadWriteCloser)
+			n, err := rwc.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, 2, n)
+			require.Equal(t, "in", string(buf))
+			n, err = rwc.Write([]byte("out"))
+			require.NoError(t, err)
+			require.Equal(t, 3, n)
+			rwc.Close()
+		})
+
+		port := rand.Intn(30000) + 10000
+
+		ch := make(chan *result)
+
+		go func() {
+			res, _ := testExecuteContext(ctx, e, fmt.Sprintf("resources proxy resource1 -a app1 -p %d", port), nil)
+			ch <- res
+		}()
+
+		time.Sleep(500 * time.Millisecond)
+
+		cn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+		require.NoError(t, err)
+
+		cn.Write([]byte("in"))
+
+		data, err := io.ReadAll(cn)
+		require.NoError(t, err)
+		require.Equal(t, "out", string(data))
+
+		cancel()
+
+		res := <-ch
+
+		require.NotNil(t, res)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			fmt.Sprintf("proxying localhost:%d to example.org:443", port),
+			fmt.Sprintf("connect: %d", port),
+		})
+	})
+}
+
 func TestResourcesUrl(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(fxSystem(), nil)


### PR DESCRIPTION
### What is the feature/fix?

The resource `memcached` does not have a default scheme, and when the CLI tries to parse the URL it fails. Only when the resource doesn't have the scheme, it will prepend `https://` to it so the parse can be done correctly. The `https://` is just a mock, it will not be used by the proxy.

However in other cases, the resources already have a default scheme, so we don't need to prepend anything.

### Add screenshot or video (optional)

```
$ ./convox resources proxy memcached -r company/test-v2 -a nodejs
resourceUrl:  https://tes-ca-a9w1wj3z6inb.ggqx34.cfg.use1.cache.amazonaws.com:11211
proxying localhost:11211 to tes-ca-a9w1wj3z6inb.ggqx34.cfg.use1.cache.amazonaws.com:11211
^C

$ ./convox resources proxy db -r company/test-v2 -a nodejs       
resourceUrl:  mysql://app:9da1d8b0-e918-11ed-85a0-0e0742ca01a9@test-v2-nodejs-resourcedb-dxaplp4g31i7.crsmvbsswb2b.us-east-1.rds.amazonaws.com:3306/app
proxying localhost:3306 to test-v2-nodejs-resourcedb-dxaplp4g31i7.crsmvbsswb2b.us-east-1.rds.amazonaws.com:3306
^C

$ ./convox resources proxy postgres -r company/test-v2 -a nodejs 
resourceUrl:  postgres://app:9da1d8b0-e918-11ed-85a0-0e0742ca01a9@test-v2-nodejs-resourcepostgres-no8wpe8bxfby.crsmvbsswb2b.us-east-1.rds.amazonaws.com:5432/app
proxying localhost:5432 to test-v2-nodejs-resourcepostgres-no8wpe8bxfby.crsmvbsswb2b.us-east-1.rds.amazonaws.com:5432
^C

```

### Does it has a breaking change?

No

### How to use/test it?

- Create a rack and deplot an app with mysql, memcached and postgres resource
- Run `convox resources proxy` as showed above.

### Checklist
- [x] New coverage tests
- [x] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
