### PR TITLE
Add DedicatedBuilder condition to BuildLaunchTemplate

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -1524,6 +1524,7 @@
       "Type": "AWS::ECS::Cluster"
     },
     "BuildLaunchTemplate": {
+      "Condition": "DedicatedBuilder",
       "Type" : "AWS::EC2::LaunchTemplate",
       "Properties" : {
         "LaunchTemplateData" : {


### PR DESCRIPTION
### What is the feature/fix?

BuildLaunchTemplate will only be created if the rack has dedicated builder set. Add DedicatedBuilder condition to BuildLaunchTemplate.

### Does it has a breaking change?

No, it's a fix

### How to use/test it?

- Install a new rack with the latest release with `BuildInstance` as empty.
- Try to update the rack to this RC (to be created).

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
