### PR TITLE
Remove ExistingGatewayAttachment on installing into existing VPC

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -1084,15 +1084,6 @@
         "VpcId": { "Ref": "Vpc" }
       }
     },
-    "ExistingGatewayAttachment": {
-      "Type": "AWS::EC2::VPCGatewayAttachment",
-      "Condition": "ExistingVpcAndInternetGateway",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "InternetGatewayId": { "Ref": "InternetGateway" },
-        "VpcId": { "Ref": "ExistingVpc" }
-      }
-    },
     "Nat0": {
       "Condition": "Private",
       "Type": "AWS::EC2::NatGateway",


### PR DESCRIPTION
### What is the feature/fix?

AWS changed the behavior for existing for VPC Gateway attachment, even previous versions are not working anymore (I couldn't find any notes on that, I came at this conclusion by testing old releases)

### Does it has a breaking change?

No.

### How to use/test it?

Create a first rack (it can be the default settings), then try to install using the same VPC and IG, see https://docsv2.convox.com/reference/vpc-configurations#installing-into-an-existing-vpc

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
