### PR TITLE
Specify policies to be used by each service

### DIFF
--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -22,6 +22,7 @@ type Service struct {
 	Init        bool               `yaml:"init,omitempty"`
 	Internal    bool               `yaml:"internal,omitempty"`
 	Links       []string           `yaml:"links,omitempty"`
+	Policies    []string           `yaml:"policies,omitempty"`
 	Port        ServicePort        `yaml:"port,omitempty"`
 	Privileged  bool               `yaml:"privileged,omitempty"`
 	Resources   []string           `yaml:"resources,omitempty"`

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -330,6 +330,9 @@
       },
       "ManagedPolicyArns": [
         { "Fn::If": [ "BlankIamPolicy", { "Ref": "AWS::NoValue" }, { "Ref": "IamPolicy" } ] },
+        {{ range $name := .Policies }}
+          { "Ref": "{{ . }}" },
+        {{ end }}
         { "Fn::ImportValue": { "Fn::Sub": "${Rack}:CMKPolicy" } }
       ],
       "Path": "/convox/",

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -330,9 +330,6 @@
       },
       "ManagedPolicyArns": [
         { "Fn::If": [ "BlankIamPolicy", { "Ref": "AWS::NoValue" }, { "Ref": "IamPolicy" } ] },
-        {{ range $name := .Policies }}
-          { "Ref": "{{ . }}" },
-        {{ end }}
         { "Fn::ImportValue": { "Fn::Sub": "${Rack}:CMKPolicy" } }
       ],
       "Path": "/convox/",
@@ -377,6 +374,7 @@
           "InternalDomains": { "Ref": "InternalDomains" },
           "Isolate": { "Fn::If": [ "IsolateServices", "Yes", "No" ] },
           "Memory": { "Fn::Select": [ 2, { "Ref": "{{ upper .Name }}Formation" } ] },
+          "Policies": "{{ join .Policies "," }}",
           "Private": { "Ref": "Private" },
           "Rack": { "Ref": "Rack" },
           "RackUrl": { "Ref": "RackUrl" },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -3,6 +3,7 @@
     "AWSTemplateFormatVersion" : "2010-09-09",
     "Conditions": {
       "CircuitBreaker": { "Fn::Equals": [ { "Ref": "CircuitBreaker" }, "Yes" ] },
+      "DedicatedRole": { "Fn::Not":[{"Fn::Equals":[{"Ref":"Policies"},""]} ] },
       "EC2Launch": { "Fn::Not": [ { "Condition": "FargateEither" } ] },
       "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "LogDriver" }, "CloudWatch" ] },
       "EnableSyslog": { "Fn::Equals": [ { "Ref": "LogDriver" }, "Syslog" ] },
@@ -105,6 +106,10 @@
       },
       "Memory": {
         "Type": "Number"
+      },
+      "Policies": {
+        "Description": "It will create a new role to be used instead of 'Role' parameter.",
+        "Type": "String"
       },
       "Private": {
         "Type": "String",
@@ -592,6 +597,28 @@
           "TaskDefinition": { "Ref": "Tasks" }
         }
       },
+      "DedicatedRole": {
+        "Condition": "DedicatedRole",
+        "Type": "AWS::IAM::Role",
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Statement": [ { "Effect": "Allow", "Principal": { "Service": [ "ecs-tasks.amazonaws.com" ] }, "Action": [ "sts:AssumeRole" ] } ],
+            "Version": "2012-10-17"
+          },
+          "ManagedPolicyArns": {"Fn::Split":[",",{"Fn::Join":[",",[{"Ref":"Policies"},{"Fn::ImportValue":{"Fn::Sub":"${Rack}:CMKPolicy"}}]]}]},
+          "Path": "/convox/",
+          "Policies": [ {
+            "PolicyName": "convox-env",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                { "Effect": "Allow", "Action": "s3:GetObject", "Resource": { "Fn::Sub": "arn:${AWS::Partition}:s3:::${Settings}/*" } },
+                { "Effect": "Allow", "Action": "kms:Decrypt", "Resource": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:EncryptionKey" } } }
+              ]
+            }
+          } ]
+        }
+      },
       "Tasks": {
         "Type": "AWS::ECS::TaskDefinition",
         "Properties": {
@@ -725,7 +752,7 @@
           "Memory": { "Fn::If": [ "FargateEither", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },
           "NetworkMode": { "Fn::If": [ "IsolateServices", "awsvpc", { "Ref": "AWS::NoValue" } ] },
           "RequiresCompatibilities": [ { "Fn::If": [ "FargateEither", "FARGATE", { "Ref": "AWS::NoValue" } ] } ],
-          "TaskRoleArn": { "Ref": "Role" },
+          "TaskRoleArn": { "Fn::If": [ "DedicatedRole", { "Fn::GetAtt": [ "DedicatedRole", "Arn" ] }, { "Ref": "Role" } ] },
           "Volumes": [
             {{ range $i, $v := .Volumes }}
               {{ $volume := splitVolumeLabel $v }}


### PR DESCRIPTION
### What is the feature/fix?

Create a role that will use the defined policies on that service. It overrides the [IamPolicy](https://docsv2.convox.com/reference/app-parameters#iampolicy) just for that service (it will not be used if `policies` is defined on convox.yml`).

Priority:

1. DedicatedRole (at service level, if specified)
2. IamPolicy

### Does it has a breaking change?

No, current ServiceRoles are not affected by the change.

### How to use/test it?

- Create a rack with the RC installed.
- Deploy an app with the following yml:

```
services:
  web:
    policies:
      - arn:aws:iam::aws:policy/AdministratorAccess
    build: .
    port: 3000
  api:
    build: .
    port: 3000
```

- Check on IAM if the policies were created correctly.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
