### PR TITLE
--no-cache build test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ release-cli: release-version package
 	make -C cmd/convox release VERSION=$(VERSION)
 
 release-image: release-version package
-	docker buildx build --platform linux/amd64 -t convox/rack:$(VERSION) --pull --push .
-	docker buildx build --platform linux/arm64 -t convox/rack:$(VERSION)-arm64 --pull --push -f Dockerfile.arm .
+	docker buildx build --platform linux/amd64 -t convox/rack:$(VERSION) --no-cache --pull --push .
+	docker buildx build --platform linux/arm64 -t convox/rack:$(VERSION)-arm64 --no-cache --pull --push -f Dockerfile.arm .
 
 release-provider: release-version package
 	make -C provider release VERSION=$(VERSION)


### PR DESCRIPTION
### What is the feature/fix?

adds --no-cache option to docker build to ensure latest included binaries are up to date.

### Add screenshot or video (optional)


### Does it has a breaking change?



### How to use/test it?

ssh into rack instance and run `curl --version`

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
