### PR TITLE
Add option to put convox lambda's in vpc if rack is private for security requirements

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -20,6 +20,8 @@
     "InternalDomains": { "Fn::Equals": [ { "Ref": "InternalDomains" }, "Yes" ] },
     "Isolate": { "Fn::And": [ { "Condition": "Private" }, { "Fn::Equals": [ { "Ref": "Isolate" }, "Yes" ] } ] },
     "IsolateServices": { "Fn::Or": [ { "Condition": "FargateServicesEither" }, { "Condition": "Isolate" } ] },
+    "PlaceLambdaInVpcCond": { "Fn::Equals": [ { "Ref": "PlaceLambdaInVpc" }, "Yes" ] },
+    "PrivateAndPlaceLambdaInVpc": { "Fn::And": [ { "Condition": "Private" }, { "Condition": "PlaceLambdaInVpcCond" } ] },
     "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] },
     "RackUrl": { "Fn::Equals": [ { "Ref": "RackUrl" }, "Yes" ] }
   },
@@ -118,6 +120,12 @@
       "Default": "7",
       "Description": "Number of days to keep logs (blank for unlimited)",
       "Type": "String"
+    },
+    "PlaceLambdaInVpc": {
+      "Type": "String",
+      "Description": "Place convox related lambdas in vpc if rack is private",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ]
     },
     "Private": {
       "Type": "String",
@@ -471,7 +479,16 @@
             "  });",
             "};"
           ] ] }
-        }
+        },
+        "VpcConfig": { "Fn::If": [ "PrivateAndPlaceLambdaInVpc",
+          {
+            "SecurityGroupIds": [
+              { "Fn::ImportValue": { "Fn::Sub": "${Rack}:InstancesSecurityGroup" }}
+            ],
+            "SubnetIds": [{ "Fn::ImportValue": { "Fn::Sub": "${Rack}:SubnetPrivate0" } }, { "Fn::ImportValue": { "Fn::Sub": "${Rack}:SubnetPrivate1" } }]
+          },
+          { "Ref": "AWS::NoValue" }
+        ]}
       }
     },
     "TimerRole": {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -130,6 +130,8 @@
     "Internal": { "Fn::Equals": [ { "Ref": "Internal" }, "Yes" ] },
     "InternetGateway": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "InternetGateway" }, "" ] } ] },
     "NotExistingVpcAndBlankInternetGateway": { "Fn::Not": [ { "Condition": "ExistingVpcAndBlankInternetGateway" } ] },
+    "PlaceLambdaInVpcCond": { "Fn::Equals": [ { "Ref": "PlaceLambdaInVpc" }, "Yes" ] },
+    "PrivateAndPlaceLambdaInVpc": { "Fn::And": [ { "Condition": "PrivateInstances" }, { "Condition": "PlaceLambdaInVpcCond" } ] },
     "Private": { "Fn::Or": [ { "Condition": "PrivateBuild" }, { "Condition": "PrivateInstances" } ] },
     "PrivateAndThirdAvailabilityZoneAndHighAvailability": {
       "Fn::And": [ { "Condition": "Private" }, { "Condition": "ThirdAvailabilityZone" }, { "Condition": "HighAvailability" } ]
@@ -870,6 +872,12 @@
       "MaxLength": "50",
       "NoEcho": true
     },
+    "PlaceLambdaInVpc": {
+      "Type": "String",
+      "Description": "Place lambda in vpc",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ]
+    },
     "Private": {
       "Type": "String",
       "Description": "Create non publicly routable resources",
@@ -1246,7 +1254,16 @@
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "CustomTopicRole", "Arn" ] },
         "Runtime": "nodejs16.x",
-        "Timeout": "300"
+        "Timeout": "300",
+        "VpcConfig": { "Fn::If": [ "PrivateAndPlaceLambdaInVpc",
+          {
+            "SecurityGroupIds": [
+              { "Fn::If": [ "BlankInstanceSecurityGroup", { "Ref": "InstancesSecurity" }, { "Ref": "InstanceSecurityGroup" }]}
+            ],
+            "SubnetIds": [{ "Ref": "SubnetPrivate0" }, { "Ref": "SubnetPrivate1" }]
+          },
+          { "Ref": "AWS::NoValue" }]
+        }
       }
     },
     "Vpc": {
@@ -2297,7 +2314,16 @@
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
         "Runtime": "provided.al2",
-        "Timeout": "60"
+        "Timeout": "60",
+        "VpcConfig": { "Fn::If": [ "PrivateAndPlaceLambdaInVpc",
+          {
+            "SecurityGroupIds": [
+              { "Fn::If": [ "BlankInstanceSecurityGroup", { "Ref": "InstancesSecurity" }, { "Ref": "InstanceSecurityGroup" }]}
+            ],
+            "SubnetIds": [{ "Ref": "SubnetPrivate0" }, { "Ref": "SubnetPrivate1" }]
+          },
+          { "Ref": "AWS::NoValue" }]
+        }
       }
     },
     "InstancesAutoscalerPermission": {
@@ -2419,7 +2445,16 @@
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "InstancesLifecycleHandlerRole", "Arn" ] },
         "Runtime": "provided.al2",
-        "Timeout": "300"
+        "Timeout": "300",
+        "VpcConfig": { "Fn::If": [ "PrivateAndPlaceLambdaInVpc",
+          {
+            "SecurityGroupIds": [
+              { "Fn::If": [ "BlankInstanceSecurityGroup", { "Ref": "InstancesSecurity" }, { "Ref": "InstanceSecurityGroup" }]}
+            ],
+            "SubnetIds": [{ "Ref": "SubnetPrivate0" }, { "Ref": "SubnetPrivate1" }]
+          },
+          { "Ref": "AWS::NoValue" }]
+        }
       }
     },
     "InstancesLifecycleHandlerPermission": {

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -369,9 +369,15 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		return err
 	}
 
+	lambdaInVpc, err := p.stackParameter(p.Rack, "PlaceLambdaInVpc")
+	if err != nil {
+		return err
+	}
+
 	updates := map[string]string{
 		"LogBucket":         p.LogBucket,
 		"LogDriver":         p.LogDriver,
+		"PlaceLambdaInVpc":  lambdaInVpc,
 		"Private":           private,
 		"SyslogDestination": p.SyslogDestination,
 		"SyslogFormat":      p.SyslogFormat,


### PR DESCRIPTION
### What is the feature/fix?

Add option to put convox lambda's in vpc if rack is private for security requirements

issue: https://app.asana.com/0/1203637156732418/1206477197857608/f

### Does it has a breaking change?

no

### How to use/test it?

If rack is private, then the set the rack param to Yes: `PlaceLambdaInVpc`

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
