### PR TITLE
Add option for RDS parameter group name

### DIFF
--- a/provider/aws/formation/resource/mariadb.json.tmpl
+++ b/provider/aws/formation/resource/mariadb.json.tmpl
@@ -3,6 +3,7 @@
   "Conditions": {
     "BlankEncrypted": { "Fn::Equals": [ { "Ref": "Encrypted" }, "" ] },
     "BlankIops": { "Fn::Equals": [ { "Ref": "Iops" }, "0" ] },
+    "BlankParameterGroupName": { "Fn::Equals": [ { "Ref": "ParameterGroupName" }, "" ] },
     "BlankPreferredBackupWindow": { "Fn::Equals": [ { "Ref": "PreferredBackupWindow" }, "" ] }
   },
   "Parameters": {
@@ -42,6 +43,10 @@
       "MinLength": "8",
       "NoEcho": true,
       "Type": "String"
+    },
+    "ParameterGroupName": {
+      "Type" : "String",
+      "Default": ""
     },
     "PreferredBackupWindow": {
       "Type": "String",
@@ -100,12 +105,13 @@
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
         "DBName": "app",
-        "DBParameterGroupName": { "Fn::Sub": [ "default.mariadb${Base}", {
-          "Base": { "Fn::Join": [ ".", [
-            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
-            { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
-          ] ] }
-        } ] },
+        "DBParameterGroupName": { "Fn::If": [ "BlankParameterGroupName", { "Fn::Sub": [ "default.mariadb${Base}", {
+            "Base": { "Fn::Join": [ ".", [
+              { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
+              { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+            ] ] }
+          } ] },
+        { "Ref": "ParameterGroupName" } ] },
         "DBSubnetGroupName": { "Ref": "SubnetGroup" },
         "DeletionProtection": { "Ref": "DeletionProtection" },
         "Engine": "mariadb",

--- a/provider/aws/formation/resource/mysql.json.tmpl
+++ b/provider/aws/formation/resource/mysql.json.tmpl
@@ -3,6 +3,7 @@
   "Conditions": {
     "BlankEncrypted": { "Fn::Equals": [ { "Ref": "Encrypted" }, "" ] },
     "BlankIops": { "Fn::Equals": [ { "Ref": "Iops" }, "0" ] },
+    "BlankParameterGroupName": { "Fn::Equals": [ { "Ref": "ParameterGroupName" }, "" ] },
     "BlankPreferredBackupWindow": { "Fn::Equals": [ { "Ref": "PreferredBackupWindow" }, "" ] }
   },
   "Parameters": {
@@ -42,6 +43,10 @@
       "MinLength": "8",
       "NoEcho": true,
       "Type": "String"
+    },
+    "ParameterGroupName": {
+      "Type" : "String",
+      "Default": ""
     },
     "PreferredBackupWindow": {
       "Type": "String",
@@ -100,12 +105,13 @@
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
         "DBName": "app",
-        "DBParameterGroupName": { "Fn::Sub": [ "default.mysql${Base}", {
-          "Base": { "Fn::Join": [ ".", [
-            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
-            { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
-          ] ] }
-        } ] },
+        "DBParameterGroupName": { "Fn::If": [ "BlankParameterGroupName", { "Fn::Sub": [ "default.mysql${Base}", {
+            "Base": { "Fn::Join": [ ".", [
+              { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
+              { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+            ] ] }
+          } ] },
+        { "Ref": "ParameterGroupName" } ] },
         "DBSubnetGroupName": { "Ref": "SubnetGroup" },
         "DeletionProtection": { "Ref": "DeletionProtection" },
         "Engine": "mysql",

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -4,6 +4,7 @@
     "BlankEncrypted": { "Fn::Equals": [ { "Ref": "Encrypted" }, "" ] },
     "BlankIops": { "Fn::Equals": [ { "Ref": "Iops" }, "0" ] },
     "BlankPreferredBackupWindow": { "Fn::Equals": [ { "Ref": "PreferredBackupWindow" }, "" ] },
+    "BlankParameterGroupName": { "Fn::Equals": [ { "Ref": "ParameterGroupName" }, "" ] },
     "Version9": { "Fn::Equals": [ { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }, "9" ] }
   },
   "Parameters": {
@@ -43,6 +44,10 @@
       "MinLength": "8",
       "NoEcho": true,
       "Type": "String"
+    },
+    "ParameterGroupName": {
+      "Type" : "String",
+      "Default": ""
     },
     "PreferredBackupWindow": {
       "Type": "String",
@@ -101,15 +106,15 @@
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
         "DBName": "app",
-        "DBParameterGroupName": { "Fn::Sub": [ "default.postgres${Base}", {
-          "Base": { "Fn::If": [ "Version9",
-            { "Fn::Join": [ ".", [
-              { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
-              { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
-            ] ] },
-            { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
-          ] }
-        } ] },
+        "DBParameterGroupName": { "Fn::If": [ "BlankParameterGroupName", { "Fn::If": [ "Version9",
+              { "Fn::Join": [ ".", [
+                { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
+                { "Fn::Select": [ 1, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+              ] ] },
+              { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }
+            ] }
+          } ] },
+        { "Ref": "ParameterGroupName" } ] },
         "DBSubnetGroupName": { "Ref": "SubnetGroup" },
         "DeletionProtection": { "Ref": "DeletionProtection" },
         "Engine": "postgres",


### PR DESCRIPTION
### What is the feature/fix?

Add option to provide RDS parameter group name

https://app.asana.com/0/1203637156732418/1206363800602402/f


### Does it has a breaking change?

no

### How to use/test it?

** Describe how to test or use the feature **

```
 resources:
   mdb:
     type: mysql
     options:
       parameterGroupName: <name>
```

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
