### PR TITLE
Add param to shorten internal router domain to avoid character limit exceed

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -16,7 +16,7 @@
     "BlankInstanceRunCommand": { "Fn::Equals": [ { "Ref": "InstanceRunCommand" }, "" ] },
     "BlankInstanceSecurityGroup": { "Fn::Equals": [ {"Ref": "InstanceSecurityGroup" }, "" ] },
     "BlankBuildInstanceSecurityGroup": { "Fn::Equals": [ {"Ref": "BuildInstanceSecurityGroup" }, "" ] },
-    "BlankInternalSuffix": { "Fn::Equals": [ { "Ref": "InternalSuffix"}, "" ] },
+    "BlankInternalRouterSuffix": { "Fn::Equals": [ { "Ref": "InternalRouterSuffix"}, "" ] },
     "BlankInternetGateway": { "Fn::Equals": [ { "Ref": "InternetGateway"}, "" ] },
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "BlankLogBucket": { "Fn::Equals": [ { "Ref": "LogBucket" }, "" ] },
@@ -757,7 +757,7 @@
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
     },
-    "InternalSuffix": {
+    "InternalRouterSuffix": {
       "Type": "String",
       "Description": "Suffix for internal router",
       "Default": "-rti"
@@ -3426,7 +3426,7 @@
           { "Key": "access_logs.s3.prefix", "Value": { "Fn::Sub": "convox/logs/${AWS::StackName}/alb" } },
           { "Key": "idle_timeout.timeout_seconds", "Value": "3600" }
         ],
-        "Name": { "Fn::If": [ "BlankInternalSuffix", { "Ref": "AWS::NoValue" }, { "Fn::Sub": "${AWS::StackName}${InternalSuffix}" } ] },
+        "Name": { "Fn::If": [ "BlankInternalRouterSuffix", {"Fn::Select":[3,{"Fn::Split":["-",{"Fn::Select":[2,{"Fn::Split":["/",{"Ref":"AWS::StackId"}]}]}]}]}, { "Fn::Sub": "${AWS::StackName}${InternalRouterSuffix}" } ] },
         "Scheme": "internal",
         "Subnets": { "Fn::If": [ "Private",
           [

--- a/provider/aws/telemetry.go
+++ b/provider/aws/telemetry.go
@@ -29,7 +29,7 @@ var (
 		"ClientId",
 		"ExistingVpc",
 		"HttpProxy",
-		"InternalSuffix",
+		"InternalRouterSuffix",
 		"InstanceBootCommand",
 		"InstanceRunCommand",
 		"InstancePolicy",


### PR DESCRIPTION
### What is the feature/fix?

- When rack name is long, turning on internal router gives domain name character limit exceeded error. Set `InternalRouterSuffix=""` to resolve that error

https://app.asana.com/0/1203637156732418/1205259849182934/f


