### PR TITLE
Dynamodb deletion protection and point in recovery for security

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -714,6 +714,12 @@
       "Default": "1",
       "Description": "How often to poll ECS for service events in seconds. Longer intervals may alleviate rate limiting / throttling from ECS."
     },
+    "EnableS3Versioning": {
+      "Type": "String",
+      "Description": "Enable s3 bucket versioning. This affects all the buckets created for this rack.",
+      "Default": "Suspended",
+      "AllowedValues": [ "Enabled", "Suspended"]
+    },
     "EncryptEbs": {
       "Type": "String",
       "Description": "Enable encryption at rest for EBS volumes",
@@ -4365,9 +4371,13 @@
             }
           } ]
         },
+        "VersioningConfiguration": { "Status" : {"Ref": "EnableS3Versioning" } },
         "LifecycleConfiguration": { "Fn::If": [ "BlankLogRetention",
-          { "Ref": "AWS::NoValue" },
-          { "Rules": [ { "ExpirationInDays": { "Ref": "LogRetention" }, "Status": "Enabled" } ] }
+          { "Rules": [ { "NoncurrentVersionExpiration": { "NewerNoncurrentVersions" : 1, "NoncurrentDays" : 365 }, "Status": "Enabled" } ] },
+          { "Rules": [ 
+            { "ExpirationInDays": { "Ref": "LogRetention" }, "Status": "Enabled" },
+            { "NoncurrentVersionExpiration": { "NewerNoncurrentVersions" : 1, "NoncurrentDays" : 365 }, "Status": "Enabled" }
+            ] }
         ] },
         "PublicAccessBlockConfiguration": {
           "BlockPublicAcls": true,
@@ -4463,6 +4473,8 @@
             }
           } ]
         },
+        "VersioningConfiguration": { "Status" : {"Ref": "EnableS3Versioning" } },
+        "LifecycleConfiguration": { "Rules": [ { "NoncurrentVersionExpiration": { "NewerNoncurrentVersions" : 1, "NoncurrentDays" : 365 }, "Status": "Enabled" } ] },
         "LoggingConfiguration": {
           "DestinationBucketName": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
           "LogFilePrefix": { "Fn::Sub": "convox/logs/${AWS::StackName}/s3/" }
@@ -4529,9 +4541,10 @@
             "ServerSideEncryptionByDefault": { "SSEAlgorithm": "aws:kms" }
           } ]
         },
+        "VersioningConfiguration": { "Status" : {"Ref": "EnableS3Versioning" } },
         "LifecycleConfiguration": { "Fn::If": [ "BlankLogRetention",
-          { "Ref": "AWS::NoValue" },
-          { "Rules": [ { "ExpirationInDays": { "Ref": "LogRetention" }, "Status": "Enabled" } ] }
+          { "Rules": [ { "NoncurrentVersionExpiration": { "NewerNoncurrentVersions" : 1, "NoncurrentDays" : 365 }, "Status": "Enabled" } ] },
+          { "Rules": [ { "ExpirationInDays": { "Ref": "LogRetention" }, "Status": "Enabled" }, { "NoncurrentVersionExpiration": { "NewerNoncurrentVersions" : 1, "NoncurrentDays" : 365 }, "Status": "Enabled" } ] }
         ] },
         "PublicAccessBlockConfiguration": {
           "BlockPublicAcls": true,

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -709,6 +709,18 @@
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
     },
+    "DynamoDbTableDeletionProtectionEnabled": {
+      "Type": "String",
+      "Description": "Determines if a dynamodb table is protected from deletion. When enabled, the table cannot be deleted by any user or process. This setting is disabled by default.",
+      "Default": "false",
+      "AllowedValues": [ "true", "false" ]
+    },
+    "DynamoDbTablePointInTimeRecoveryEnabled" : {
+      "Type": "String",
+      "Description": "Indicates whether point in time recovery is enabled or disabled on the dynamodb table.",
+      "Default": "false",
+      "AllowedValues": [ "true", "false" ]
+    },
     "EcsPollInterval": {
       "Type": "Number",
       "Default": "1",
@@ -4259,6 +4271,8 @@
           { "AttributeName": "created", "AttributeType": "S" }
         ],
         "BillingMode": "PAY_PER_REQUEST",
+        "DeletionProtectionEnabled": { "Ref": "DynamoDbTableDeletionProtectionEnabled" },
+        "PointInTimeRecoverySpecification": { "PointInTimeRecoveryEnabled": { "Ref": "DynamoDbTablePointInTimeRecoveryEnabled" } },
         "KeySchema": [ { "AttributeName": "id", "KeyType": "HASH" } ],
         "GlobalSecondaryIndexes": [ {
           "IndexName": "app.created",
@@ -4277,6 +4291,8 @@
           { "AttributeName": "created", "AttributeType": "S" }
         ],
         "BillingMode": "PAY_PER_REQUEST",
+        "DeletionProtectionEnabled": { "Ref": "DynamoDbTableDeletionProtectionEnabled" },
+        "PointInTimeRecoverySpecification": { "PointInTimeRecoveryEnabled": { "Ref": "DynamoDbTablePointInTimeRecoveryEnabled" } },
         "KeySchema": [ { "AttributeName": "id", "KeyType": "HASH" } ],
         "GlobalSecondaryIndexes": [{
           "IndexName": "app.created",


### PR DESCRIPTION
### What is the feature/fix?

Dynamodb deletion protection and point in recovery for security

```
"DynamoDbTableDeletionProtectionEnabled": Determines if a dynamodb table is protected from deletion. When enabled, the table cannot be deleted by any user or process. This setting is disabled by default.

DynamoDbTablePointInTimeRecoveryEnabled" : "Indicates whether point in time recovery is enabled or disabled on the dynamodb table."

```
