### PR TITLE
Add option to enable readonly root fs for ecs

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -66,6 +66,11 @@
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
     },
+    "EnableContainerReadonlyRootFilesystem": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ]
+    },
     "FargateServices": {
       "Type": "String",
       "Default": "No",

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -376,6 +376,7 @@
             "Certificate": { "Ref": "Balancer{{ upper .Name }}Certificate" },
           {{ end }}
           "CircuitBreaker": { "Ref": "CircuitBreaker" },
+          "EnableContainerReadonlyRootFilesystem": { "Ref": "EnableContainerReadonlyRootFilesystem" },
           "Count": { "Fn::Select": [ 0, { "Ref": "{{ upper .Name }}Formation" } ] },
           "Cpu": { "Fn::Select": [ 1, { "Ref": "{{ upper .Name }}Formation" } ] },
           "Fargate": { "Fn::If": [ "Service{{ upper .Name }}Fargate", "Yes", { "Fn::If": [ "Service{{ upper .Name }}FargateSpot", "Spot", "No" ] } ] },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -3966,9 +3966,12 @@
               "InitProcessEnabled": "true"
             },
             "Memory": { "Ref": "BuildMemory" },
+            "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
             "MountPoints": [
               { "SourceVolume": "config", "ContainerPath": "/etc/sysconfig/docker" },
-              { "SourceVolume": "docker", "ContainerPath": "/var/run/docker.sock" }
+              { "SourceVolume": "docker", "ContainerPath": "/var/run/docker.sock" },
+              { "SourceVolume": "home", "ContainerPath": "/root/" },
+              { "SourceVolume": "temp", "ContainerPath": "/tmp/" }
             ],
             "Name": "build",
             "Secrets": [{
@@ -3982,7 +3985,9 @@
         "TaskRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
         "Volumes": [
           { "Name": "config", "Host": { "SourcePath": "/etc/sysconfig/docker" } },
-          { "Name": "docker", "Host": { "SourcePath": "/var/run/docker.sock" } }
+          { "Name": "docker", "Host": { "SourcePath": "/var/run/docker.sock" } },
+          { "Name": "home" },
+          { "Name": "temp" }
         ]
       }
     },
@@ -4093,13 +4098,21 @@
               ]
             },
             "Memory": { "Ref": "ApiMonitorMemory" },
-            "MountPoints": [ { "SourceVolume": "docker", "ContainerPath": "/var/run/docker.sock" } ],
+            "MountPoints": [
+              { "SourceVolume": "docker", "ContainerPath": "/var/run/docker.sock" },
+              { "SourceVolume": "home", "ContainerPath": "/root/" },
+              { "SourceVolume": "temp", "ContainerPath": "/tmp/" }
+            ],
             "Name": "monitor"
           }
         ],
         "Family": { "Fn::Sub": "${AWS::StackName}-monitor" },
         "TaskRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
-        "Volumes": [ { "Name": "docker", "Host": { "SourcePath": "/var/run/docker.sock" } } ]
+        "Volumes": [
+          { "Name": "docker", "Host": { "SourcePath": "/var/run/docker.sock" } },
+          { "Name": "home" },
+          { "Name": "temp" }
+        ]
       }
     },
     "ApiWebTasks": {
@@ -4233,7 +4246,11 @@
               ]
             },
             "MemoryReservation": { "Ref": "ApiWebMemory" },
-            "MountPoints": [ { "SourceVolume": "docker", "ContainerPath": "/var/run/docker.sock" } ],
+            "MountPoints": [
+              { "SourceVolume": "docker", "ContainerPath": "/var/run/docker.sock" },
+              { "SourceVolume": "home", "ContainerPath": "/root/" },
+              { "SourceVolume": "temp", "ContainerPath": "/tmp/" }
+            ],
             "Name": "web",
             "PortMappings": { "Fn::If": [ "PrivateApi",
               [ { "HostPort": "4100", "ContainerPort": "5443", "Protocol": "tcp" } ],
@@ -4248,7 +4265,11 @@
         "ExecutionRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
         "Family": { "Fn::Sub": "${AWS::StackName}-web" },
         "TaskRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
-        "Volumes": [ { "Name": "docker", "Host": { "SourcePath": "/var/run/docker.sock" } } ]
+        "Volumes": [
+          { "Name": "docker", "Host": { "SourcePath": "/var/run/docker.sock" } },
+          { "Name": "home" },
+          { "Name": "temp" }
+        ]
       }
     },
     "DynamoBuilds": {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -171,6 +171,7 @@
     "PublicInstanceInclude": { "Fn::Or": [ { "Fn::Equals": [ { "Ref": "InstancesIpToIncludInWhiteListing" }, "Both" ] }, { "Fn::Equals": [ { "Ref": "InstancesIpToIncludInWhiteListing" }, "Workload" ] } ] },
     "PublicInstancesAndWhiteList": { "Fn::And": [ { "Condition": "PublicInstances" }, { "Condition": "WhiteListCIDRs" }, {"Condition": "PublicInstanceInclude"} ] },
     "PublicRouter": { "Fn::Equals": [ { "Ref": "InternalOnly" }, "No" ] },
+    "EnableContainerReadonlyRootFilesystem": { "Fn::Equals": [ { "Ref": "EnableContainerReadonlyRootFilesystem" }, "Yes" ] },
     "RegionHasEFS": { "Fn::Equals": [
       { "Fn::FindInMap": [ "RegionConfig", { "Ref": "AWS::Region" }, "EFS" ] },
       "Yes"
@@ -713,6 +714,11 @@
       "Type": "Number",
       "Default": "1",
       "Description": "How often to poll ECS for service events in seconds. Longer intervals may alleviate rate limiting / throttling from ECS."
+    },
+    "EnableContainerReadonlyRootFilesystem": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ]
     },
     "EncryptEbs": {
       "Type": "String",
@@ -3887,6 +3893,7 @@
         "ContainerDefinitions": [
           {
             "Cpu": { "Ref": "BuildCpu" },
+            "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
             "DockerLabels": {
               "convox.release": { "Ref": "Version" },
               "rack.ApiBalancerSecurity": { "Ref": "ApiBalancerSecurity" },
@@ -3987,6 +3994,7 @@
           {
             "Command": [ "/go/bin/monitor" ],
             "Cpu": "64",
+            "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
             "DockerLabels": {
               "convox.release": { "Ref": "Version" },
               "rack.ApiBalancerSecurity": { "Ref": "ApiBalancerSecurity" },
@@ -4102,6 +4110,7 @@
           {
             "Command": [ "/go/bin/rack" ],
             "Cpu": { "Ref": "ApiCpu" },
+            "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
             "DockerLabels": {
               "convox.release": { "Ref": "Version" },
               "rack.AsgSpot": { "Fn::If": [ "SpotInstances", { "Ref": "SpotInstances" }, { "Ref": "AWS::NoValue" } ] },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -3893,7 +3893,6 @@
         "ContainerDefinitions": [
           {
             "Cpu": { "Ref": "BuildCpu" },
-            "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
             "DockerLabels": {
               "convox.release": { "Ref": "Version" },
               "rack.ApiBalancerSecurity": { "Ref": "ApiBalancerSecurity" },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -717,6 +717,7 @@
     },
     "EnableContainerReadonlyRootFilesystem": {
       "Type": "String",
+      "Description": "Enable container readonly root filesystem. Enabling this will remove write access to the root filesystem.",
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
     },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -16,6 +16,7 @@
       "IsolateServices": { "Fn::Or": [ { "Condition": "FargateEither" }, { "Condition": "Isolate" } ] },
       "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] },
       "RackUrl": { "Fn::Equals": [ { "Ref": "RackUrl" }, "Yes" ] },
+      "ReadonlyRootFilesystem": { "Fn::Equals": [ { "Ref": "ReadonlyRootFilesystem" }, "Yes" ] },
       "RouteHttp": { "Fn::Equals": [ { "Ref": "RedirectHttps" }, "No" ] },
       "TaskTags": { "Fn::Equals": [ { "Ref": "TaskTags" }, "Yes" ] }
     },
@@ -62,6 +63,11 @@
       },
       "Cpu": {
         "Type": "Number"
+      },
+      "EnableContainerReadonlyRootFilesystem": {
+        "Type": "String",
+        "Default": "No",
+        "AllowedValues": [ "Yes", "No" ]
       },
       "Fargate": {
         "Type": "String",
@@ -120,6 +126,11 @@
         "Type": "String"
       },
       "RackUrl": {
+        "Type": "String",
+        "Default": "No",
+        "AllowedValues": [ "Yes", "No" ]
+      },
+      "ReadonlyRootFilesystem": {
         "Type": "String",
         "Default": "No",
         "AllowedValues": [ "Yes", "No" ]
@@ -748,6 +759,7 @@
             }
           ],
           "Cpu": { "Fn::If": [ "FargateEither", { "Ref": "Cpu" }, { "Ref": "AWS::NoValue" } ] },
+          "ReadonlyRootFilesystem": { "Fn::If": [ "ReadonlyRootFilesystem", "true", "false" ] },
           "ExecutionRoleArn": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
           "Family": { "Fn::Sub": "${AWS::StackName}-service-{{.Name}}" },
           "Memory": { "Fn::If": [ "FargateEither", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -635,6 +635,7 @@
                 "Command": [ {{ range . }} {{ safe . }}, {{ end }} { "Ref": "AWS::NoValue" } ],
               {{ end }}
               "Cpu": { "Ref": "Cpu" },
+              "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
               "DockerLabels": { "convox.app": "{{$.App}}", "convox.generation": "2", "convox.process.type": "service", "convox.release": "{{$.Release.Id}}" },
               "Environment": [
                 {{ range $k, $v := .EnvironmentDefaults }}
@@ -754,7 +755,6 @@
             }
           ],
           "Cpu": { "Fn::If": [ "FargateEither", { "Ref": "Cpu" }, { "Ref": "AWS::NoValue" } ] },
-          "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
           "ExecutionRoleArn": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
           "Family": { "Fn::Sub": "${AWS::StackName}-service-{{.Name}}" },
           "Memory": { "Fn::If": [ "FargateEither", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -16,7 +16,7 @@
       "IsolateServices": { "Fn::Or": [ { "Condition": "FargateEither" }, { "Condition": "Isolate" } ] },
       "Private": { "Fn::Equals": [ { "Ref": "Private" }, "Yes" ] },
       "RackUrl": { "Fn::Equals": [ { "Ref": "RackUrl" }, "Yes" ] },
-      "ReadonlyRootFilesystem": { "Fn::Equals": [ { "Ref": "ReadonlyRootFilesystem" }, "Yes" ] },
+      "EnableContainerReadonlyRootFilesystem": { "Fn::Equals": [ { "Ref": "EnableContainerReadonlyRootFilesystem" }, "Yes" ] },
       "RouteHttp": { "Fn::Equals": [ { "Ref": "RedirectHttps" }, "No" ] },
       "TaskTags": { "Fn::Equals": [ { "Ref": "TaskTags" }, "Yes" ] }
     },
@@ -126,11 +126,6 @@
         "Type": "String"
       },
       "RackUrl": {
-        "Type": "String",
-        "Default": "No",
-        "AllowedValues": [ "Yes", "No" ]
-      },
-      "ReadonlyRootFilesystem": {
         "Type": "String",
         "Default": "No",
         "AllowedValues": [ "Yes", "No" ]
@@ -759,7 +754,7 @@
             }
           ],
           "Cpu": { "Fn::If": [ "FargateEither", { "Ref": "Cpu" }, { "Ref": "AWS::NoValue" } ] },
-          "ReadonlyRootFilesystem": { "Fn::If": [ "ReadonlyRootFilesystem", "true", "false" ] },
+          "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
           "ExecutionRoleArn": { "Fn::GetAtt": [ "ExecutionRole", "Arn" ] },
           "Family": { "Fn::Sub": "${AWS::StackName}-service-{{.Name}}" },
           "Memory": { "Fn::If": [ "FargateEither", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },

--- a/provider/aws/formation/timer.json.tmpl
+++ b/provider/aws/formation/timer.json.tmpl
@@ -7,7 +7,8 @@
       "FargateEither": { "Fn::Or": [ { "Condition": "FargateBase" }, { "Condition": "FargateSpot" } ] },
       "FargateBase": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
       "FargateSpot": { "Fn::Equals": [ { "Ref": "Fargate" }, "Spot" ] },
-      "RackUrl": { "Fn::Equals": [ { "Ref": "RackUrl" }, "Yes" ] }
+      "RackUrl": { "Fn::Equals": [ { "Ref": "RackUrl" }, "Yes" ] },
+      "ReadonlyRootFilesystem": { "Fn::Equals": [ { "Ref": "ReadonlyRootFilesystem" }, "Yes" ] }
     },
     "Outputs": {
       "Fargate": {
@@ -23,6 +24,11 @@
       },
       "ExecutionRole": {
         "Type": "String"
+      },
+      "EnableContainerReadonlyRootFilesystem": {
+        "Type": "String",
+        "Default": "No",
+        "AllowedValues": [ "Yes", "No" ]
       },
       "Fargate": {
         "Type": "String",
@@ -49,6 +55,11 @@
         "Type": "String"
       },
       "RackUrl": {
+        "Type": "String",
+        "Default": "No",
+        "AllowedValues": [ "Yes", "No" ]
+      },
+      "ReadonlyRootFilesystem": {
         "Type": "String",
         "Default": "No",
         "AllowedValues": [ "Yes", "No" ]
@@ -162,6 +173,7 @@
               {
                 "Command": [ "sh", "-c", {{ safe $.Timer.Command }} ],
                 "Cpu": { "Ref": "Cpu" },
+                "ReadonlyRootFilesystem": { "Fn::If": [ "ReadonlyRootFilesystem", "true", "false" ] },
                 "DockerLabels": { "convox.app": "{{$.App}}", "convox.generation": "2", "convox.process.type": "timer", "convox.release": "{{$.Release.Id}}" },
                 "Environment": [
                   {{ range $k, $v := .EnvironmentDefaults }}

--- a/provider/aws/formation/timer.json.tmpl
+++ b/provider/aws/formation/timer.json.tmpl
@@ -8,7 +8,7 @@
       "FargateBase": { "Fn::Equals": [ { "Ref": "Fargate" }, "Yes" ] },
       "FargateSpot": { "Fn::Equals": [ { "Ref": "Fargate" }, "Spot" ] },
       "RackUrl": { "Fn::Equals": [ { "Ref": "RackUrl" }, "Yes" ] },
-      "ReadonlyRootFilesystem": { "Fn::Equals": [ { "Ref": "ReadonlyRootFilesystem" }, "Yes" ] }
+      "EnableContainerReadonlyRootFilesystem": { "Fn::Equals": [ { "Ref": "EnableContainerReadonlyRootFilesystem" }, "Yes" ] }
     },
     "Outputs": {
       "Fargate": {
@@ -55,11 +55,6 @@
         "Type": "String"
       },
       "RackUrl": {
-        "Type": "String",
-        "Default": "No",
-        "AllowedValues": [ "Yes", "No" ]
-      },
-      "ReadonlyRootFilesystem": {
         "Type": "String",
         "Default": "No",
         "AllowedValues": [ "Yes", "No" ]
@@ -173,7 +168,6 @@
               {
                 "Command": [ "sh", "-c", {{ safe $.Timer.Command }} ],
                 "Cpu": { "Ref": "Cpu" },
-                "ReadonlyRootFilesystem": { "Fn::If": [ "ReadonlyRootFilesystem", "true", "false" ] },
                 "DockerLabels": { "convox.app": "{{$.App}}", "convox.generation": "2", "convox.process.type": "timer", "convox.release": "{{$.Release.Id}}" },
                 "Environment": [
                   {{ range $k, $v := .EnvironmentDefaults }}
@@ -272,6 +266,7 @@
             {{ end }}
           ],
           "Cpu": { "Fn::If": [ "FargateEither", { "Ref": "Cpu" }, { "Ref": "AWS::NoValue" } ] },
+          "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
           "ExecutionRoleArn": { "Ref": "ExecutionRole" },
           "Family": { "Fn::Sub": "${AWS::StackName}-timer-{{.Name}}" },
           "Memory": { "Fn::If": [ "FargateEither", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },

--- a/provider/aws/formation/timer.json.tmpl
+++ b/provider/aws/formation/timer.json.tmpl
@@ -168,6 +168,7 @@
               {
                 "Command": [ "sh", "-c", {{ safe $.Timer.Command }} ],
                 "Cpu": { "Ref": "Cpu" },
+                "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
                 "DockerLabels": { "convox.app": "{{$.App}}", "convox.generation": "2", "convox.process.type": "timer", "convox.release": "{{$.Release.Id}}" },
                 "Environment": [
                   {{ range $k, $v := .EnvironmentDefaults }}
@@ -266,7 +267,6 @@
             {{ end }}
           ],
           "Cpu": { "Fn::If": [ "FargateEither", { "Ref": "Cpu" }, { "Ref": "AWS::NoValue" } ] },
-          "ReadonlyRootFilesystem": { "Fn::If": [ "EnableContainerReadonlyRootFilesystem", "true", "false" ] },
           "ExecutionRoleArn": { "Ref": "ExecutionRole" },
           "Family": { "Fn::Sub": "${AWS::StackName}-timer-{{.Name}}" },
           "Memory": { "Fn::If": [ "FargateEither", { "Ref": "Memory" }, { "Ref": "AWS::NoValue" } ] },

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -374,13 +374,19 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		return err
 	}
 
+	readonlyRootFilesystem, err := p.stackParameter(p.Rack, "EnableContainerReadonlyRootFilesystem")
+	if err != nil {
+		return err
+	}
+
 	updates := map[string]string{
-		"LogBucket":         p.LogBucket,
-		"LogDriver":         p.LogDriver,
-		"PlaceLambdaInVpc":  lambdaInVpc,
-		"Private":           private,
-		"SyslogDestination": p.SyslogDestination,
-		"SyslogFormat":      p.SyslogFormat,
+		"LogBucket":                             p.LogBucket,
+		"LogDriver":                             p.LogDriver,
+		"PlaceLambdaInVpc":                      lambdaInVpc,
+		"Private":                               private,
+		"SyslogDestination":                     p.SyslogDestination,
+		"SyslogFormat":                          p.SyslogFormat,
+		"EnableContainerReadonlyRootFilesystem": readonlyRootFilesystem,
 	}
 
 	if m.Params != nil {


### PR DESCRIPTION
### What is the feature/fix?

Add option to enable readonly root fs for ecs

```
 "EnableContainerReadonlyRootFilesystem": Enable container readonly root filesystem. Enabling this will remove write access to 

| Default value  | `No`       |
| Allowed values  | `Yes`, `No` |
```