### PR TITLE
Add log configuration build task

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -4002,6 +4002,34 @@
                 { "Ref": "BuildImage" }
               ]
             },
+            "LogConfiguration": {
+              "Fn::If": [
+                "EnableSyslog",
+                {
+                  "LogDriver": "syslog",
+                  "Options": {
+                    "syslog-address": { "Ref": "SyslogDestination" },
+                    "syslog-format": { "Ref": "SyslogFormat" }
+                  }
+                },
+                {
+                  "Fn::If": [
+                    "EnableCloudWatch",
+                    {
+                      "LogDriver": "awslogs",
+                      "Options": {
+                        "awslogs-region": { "Ref": "AWS::Region" },
+                        "awslogs-group": { "Ref": "LogGroup" },
+                        "awslogs-stream-prefix": "build"
+                      }
+                    },
+                    {
+                      "Ref": "AWS::NoValue"
+                    }
+                  ]
+                }
+              ]
+            },
             "LinuxParameters": {
               "InitProcessEnabled": "true"
             },


### PR DESCRIPTION
### What is the feature/fix?

This will add logging configuration to build task definitions. Not having logging configuration is flagged by aws security scan. So adding this as best practices. 

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
