### PR TITLE
Add support for rds read replica

### DIFF
--- a/provider/aws/formation/resource/mariadb.json.tmpl
+++ b/provider/aws/formation/resource/mariadb.json.tmpl
@@ -4,7 +4,9 @@
     "BlankEncrypted": { "Fn::Equals": [ { "Ref": "Encrypted" }, "" ] },
     "BlankIops": { "Fn::Equals": [ { "Ref": "Iops" }, "0" ] },
     "BlankParameterGroupName": { "Fn::Equals": [ { "Ref": "ParameterGroupName" }, "" ] },
-    "BlankPreferredBackupWindow": { "Fn::Equals": [ { "Ref": "PreferredBackupWindow" }, "" ] }
+    "BlankPreferredBackupWindow": { "Fn::Equals": [ { "Ref": "PreferredBackupWindow" }, "" ] },
+    "IsReadReplica": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "ReadSourceDB" }, "" ] }]},
+    "BlankPreferredBackupWindowOrReadReplica": { "Fn::Or": [ { "Condition": "BlankPreferredBackupWindow" }, { "Condition": "IsReadReplica" } ] }
   },
   "Parameters": {
     "AutoMinorVersionUpgrade": {
@@ -56,6 +58,10 @@
       "MinLength": "1",
       "Type": "String"
     },
+    "ReadSourceDB": {
+      "Type": "String",
+      "Default": ""
+    },
     "Storage": {
       "Type": "Number",
       "Default": "20"
@@ -101,10 +107,10 @@
         "AllocatedStorage": { "Ref": "Storage" },
         "AllowMajorVersionUpgrade": "true",
         "AutoMinorVersionUpgrade": { "Ref": "AutoMinorVersionUpgrade" },
-        "BackupRetentionPeriod": { "Ref": "BackupRetentionPeriod" },
+        "BackupRetentionPeriod": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "BackupRetentionPeriod" } ] },
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
-        "DBName": "app",
+        "DBName": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, "app" ] },
         "DBParameterGroupName": { "Fn::If": [ "BlankParameterGroupName", { "Fn::Sub": [ "default.mariadb${Base}", {
             "Base": { "Fn::Join": [ ".", [
               { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
@@ -112,19 +118,20 @@
             ] ] }
           } ] },
         { "Ref": "ParameterGroupName" } ] },
-        "DBSubnetGroupName": { "Ref": "SubnetGroup" },
+        "DBSubnetGroupName": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "SubnetGroup" } ] },
         "DeletionProtection": { "Ref": "DeletionProtection" },
         "Engine": "mariadb",
         "EngineVersion": { "Ref": "Version" },
         "Iops": { "Fn::If": [ "BlankIops", { "Ref": "AWS::NoValue" }, { "Ref": "Iops" } ] },
-        "MasterUsername": "app",
-        "MasterUserPassword": { "Ref": "Password" },
+        "MasterUsername": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, "app" ] },
+        "MasterUserPassword": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "Password" } ] },
         "MultiAZ": { "Ref": "Durable" },
         "Port": "3306",
-        "PreferredBackupWindow": { "Fn::If": [ "BlankPreferredBackupWindow", { "Ref": "AWS::NoValue" }, { "Ref": "PreferredBackupWindow" } ] },
+        "PreferredBackupWindow": { "Fn::If": [ "BlankPreferredBackupWindowOrReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "PreferredBackupWindow" } ] },
         "PubliclyAccessible": "false",
         "StorageEncrypted": { "Ref": "Encrypted" },
         "StorageType": { "Fn::If": [ "BlankIops", "gp2", "io2" ] },
+        "SourceDBInstanceIdentifier": { "Fn::If": [ "IsReadReplica", { "Ref": "ReadSourceDB" }, { "Ref": "AWS::NoValue" } ] },
         "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ]
       }
     }

--- a/provider/aws/formation/resource/mysql.json.tmpl
+++ b/provider/aws/formation/resource/mysql.json.tmpl
@@ -4,7 +4,9 @@
     "BlankEncrypted": { "Fn::Equals": [ { "Ref": "Encrypted" }, "" ] },
     "BlankIops": { "Fn::Equals": [ { "Ref": "Iops" }, "0" ] },
     "BlankParameterGroupName": { "Fn::Equals": [ { "Ref": "ParameterGroupName" }, "" ] },
-    "BlankPreferredBackupWindow": { "Fn::Equals": [ { "Ref": "PreferredBackupWindow" }, "" ] }
+    "BlankPreferredBackupWindow": { "Fn::Equals": [ { "Ref": "PreferredBackupWindow" }, "" ] },
+    "IsReadReplica": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "ReadSourceDB" }, "" ] }]},
+    "BlankPreferredBackupWindowOrReadReplica": { "Fn::Or": [ { "Condition": "BlankPreferredBackupWindow" }, { "Condition": "IsReadReplica" } ] }
   },
   "Parameters": {
     "AutoMinorVersionUpgrade": {
@@ -56,6 +58,10 @@
       "MinLength": "1",
       "Type": "String"
     },
+    "ReadSourceDB": {
+      "Type": "String",
+      "Default": ""
+    },
     "Storage": {
       "Type": "Number",
       "Default": "20"
@@ -101,10 +107,10 @@
         "AllocatedStorage": { "Ref": "Storage" },
         "AllowMajorVersionUpgrade": "true",
         "AutoMinorVersionUpgrade": { "Ref": "AutoMinorVersionUpgrade" },
-        "BackupRetentionPeriod": { "Ref": "BackupRetentionPeriod" },
+        "BackupRetentionPeriod": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "BackupRetentionPeriod" } ] },
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
-        "DBName": "app",
+        "DBName": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, "app" ] },
         "DBParameterGroupName": { "Fn::If": [ "BlankParameterGroupName", { "Fn::Sub": [ "default.mysql${Base}", {
             "Base": { "Fn::Join": [ ".", [
               { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] },
@@ -112,19 +118,20 @@
             ] ] }
           } ] },
         { "Ref": "ParameterGroupName" } ] },
-        "DBSubnetGroupName": { "Ref": "SubnetGroup" },
+        "DBSubnetGroupName": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "SubnetGroup" } ] },
         "DeletionProtection": { "Ref": "DeletionProtection" },
         "Engine": "mysql",
         "EngineVersion": { "Ref": "Version" },
         "Iops": { "Fn::If": [ "BlankIops", { "Ref": "AWS::NoValue" }, { "Ref": "Iops" } ] },
-        "MasterUsername": "app",
-        "MasterUserPassword": { "Ref": "Password" },
+        "MasterUsername": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, "app" ] },
+        "MasterUserPassword": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "Password" } ] },
         "MultiAZ": { "Ref": "Durable" },
         "Port": "3306",
-        "PreferredBackupWindow": { "Fn::If": [ "BlankPreferredBackupWindow", { "Ref": "AWS::NoValue" }, { "Ref": "PreferredBackupWindow" } ] },
+        "PreferredBackupWindow": { "Fn::If": [ "BlankPreferredBackupWindowOrReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "PreferredBackupWindow" } ] },
         "PubliclyAccessible": "false",
         "StorageEncrypted": { "Ref": "Encrypted" },
         "StorageType": { "Fn::If": [ "BlankIops", "gp2", "io2" ] },
+        "SourceDBInstanceIdentifier": { "Fn::If": [ "IsReadReplica", { "Ref": "ReadSourceDB" }, { "Ref": "AWS::NoValue" } ] },
         "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ]
       }
     }

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -4,6 +4,8 @@
     "BlankEncrypted": { "Fn::Equals": [ { "Ref": "Encrypted" }, "" ] },
     "BlankIops": { "Fn::Equals": [ { "Ref": "Iops" }, "0" ] },
     "BlankPreferredBackupWindow": { "Fn::Equals": [ { "Ref": "PreferredBackupWindow" }, "" ] },
+    "IsReadReplica": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "ReadSourceDB" }, "" ] }]},
+    "BlankPreferredBackupWindowOrReadReplica": { "Fn::Or": [ { "Condition": "BlankPreferredBackupWindow" }, { "Condition": "IsReadReplica" } ] },
     "BlankParameterGroupName": { "Fn::Equals": [ { "Ref": "ParameterGroupName" }, "" ] },
     "Version9": { "Fn::Equals": [ { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Ref": "Version" } ] } ] }, "9" ] }
   },
@@ -57,6 +59,10 @@
       "MinLength": "1",
       "Type": "String"
     },
+     "ReadSourceDB": {
+      "Type": "String",
+      "Default": ""
+    },
     "Storage": {
       "Type": "Number",
       "Default": "20"
@@ -102,10 +108,10 @@
         "AllocatedStorage": { "Ref": "Storage" },
         "AllowMajorVersionUpgrade": "true",
         "AutoMinorVersionUpgrade": { "Ref": "AutoMinorVersionUpgrade" },
-        "BackupRetentionPeriod": { "Ref": "BackupRetentionPeriod" },
+        "BackupRetentionPeriod": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "BackupRetentionPeriod" } ] },
         "DBInstanceClass": { "Ref": "Class" },
         "DBInstanceIdentifier": { "Ref": "AWS::StackName" },
-        "DBName": "app",
+        "DBName": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, "app" ] },
         "DBParameterGroupName": { "Fn::If": [ "BlankParameterGroupName",
         { "Fn::Sub": [ "default.postgres${Base}", {
           "Base": { "Fn::If": [ "Version9",
@@ -118,19 +124,20 @@
         } ] }
         ,
         { "Ref": "ParameterGroupName" } ] },
-        "DBSubnetGroupName": { "Ref": "SubnetGroup" },
+        "DBSubnetGroupName": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "SubnetGroup" } ] },
         "DeletionProtection": { "Ref": "DeletionProtection" },
         "Engine": "postgres",
         "EngineVersion": { "Ref": "Version" },
         "Iops": { "Fn::If": [ "BlankIops", { "Ref": "AWS::NoValue" }, { "Ref": "Iops" } ] },
-        "MasterUsername": "app",
-        "MasterUserPassword": { "Ref": "Password" },
+        "MasterUsername": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, "app" ] },
+        "MasterUserPassword": { "Fn::If": [ "IsReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "Password" } ] },
         "MultiAZ": { "Ref": "Durable" },
         "Port": "5432",
-        "PreferredBackupWindow": { "Fn::If": [ "BlankPreferredBackupWindow", { "Ref": "AWS::NoValue" }, { "Ref": "PreferredBackupWindow" } ] },
+        "PreferredBackupWindow": { "Fn::If": [ "BlankPreferredBackupWindowOrReadReplica", { "Ref": "AWS::NoValue" }, { "Ref": "PreferredBackupWindow" } ] },
         "PubliclyAccessible": "false",
         "StorageEncrypted": { "Ref": "Encrypted" },
         "StorageType": { "Fn::If": [ "BlankIops", "gp2", "io2" ] },
+        "SourceDBInstanceIdentifier": { "Fn::If": [ "IsReadReplica", { "Ref": "ReadSourceDB" }, { "Ref": "AWS::NoValue" } ] },
         "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ]
       }
     }


### PR DESCRIPTION
### What is the feature/fix?

https://app.asana.com/0/1203637156732418/1206946200769557/f

This feature will let you deploy read replica using convox resource. Source DB has to be present before read replica.

```
  mysql-r:
    type: mysql
    options:
      readSourceDB: <db-identifier>
      class: db.t3.micro
      encrypted: true
```

you can reference existing convox db resource in the same yaml.

```
resources:
  mysql-main:
    type: mysql
    options:
      class: db.t3.micro
      encrypted: false
  mysql-r:
    type: mysql
    options:
      readSourceDB: "#convox.resources.mysql-main" 
      class: db.t3.micro
      encrypted: true
```