### PR TITLE
fix: TimerLauncher failing after nodejs upgrade to 20.x

### DIFF
--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -483,7 +483,7 @@
             "      }",
             "    }",
             "  };",
-            "  const client = new ECSClient({ region: 'REGION' });",
+            "  const client = new ECSClient({ region: process.env.AWS_REGION, maxAttempts: 10 });",
             "  const command = new RunTaskCommand(params);",
             "  try {",
             "    const data = await client.send(command);",

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -445,7 +445,8 @@
         "Timeout": 60,
         "Code": {
           "ZipFile": { "Fn::Join": [ "\n", [
-            "exports.handler = function(event, context, cb) {",
+            "const { ECSClient, RunTaskCommand } = require('@aws-sdk/client-ecs');",
+            "exports.handler = async function(event, context) {",
             "  var params = {",
             { "Fn::If": [ "FargateTimersBase",
               "  capacityProviderStrategy: [{capacityProvider: 'FARGATE'}],",
@@ -482,12 +483,14 @@
             "      }",
             "    }",
             "  };",
-            "  var aws = require('aws-sdk');",
-            "  var ecs = new aws.ECS({maxRetries:10});",
-            "  ecs.runTask(params, function (err, res) {",
-            "    console.log('res', res);",
-            "    cb(err);",
-            "  });",
+            "  const client = new ECSClient({ region: 'REGION' });",
+            "  const command = new RunTaskCommand(params);",
+            "  try {",
+            "    const data = await client.send(command);",
+            "    console.log('res', data);",
+            "  } catch (err) {",
+            "    console.error(err);",
+            "  }",
             "};"
           ] ] }
         },


### PR DESCRIPTION
### What is the feature/fix?

Since the update all timer functions are failing with the following error:

```
Cannot find module 'aws-sdk'\nRequire stack:\n- /var/task/index.js\n- /var/runtime/index.mjs
```

This is an attempt to fix it.

### Add screenshot or video (optional)

** Any screenshot or video capture using the feature **

### Does it has a breaking change?

** Describe the changes and if it has any breaking changes in any feature **

### How to use/test it?

** Describe how to test or use the feature **

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
