### PR TITLE
Removed app specific unique params when importing/exporting to avoid error

### DIFF
--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -412,7 +412,7 @@ func appExport(rack sdk.Interface, c *stdcli.Context, app string, w io.Writer) e
 	}
 
 	// Remove app unique parameters before exporting app
-	uniqueParams := []string{"Rack","LogBucket","ResourcePassword"}
+	uniqueParams := []string{"Rack","LogBucket","ResourcePassword","ParamPassword"}
 
 	for _,param := range uniqueParams{
 		delete(a.Parameters, param);
@@ -587,6 +587,7 @@ func appImport(rack sdk.Interface, c *stdcli.Context, app string, r io.Reader) e
 		for k, v := range a.Parameters {
 			if v != ae.Parameters[k] {
 				change = true
+				break
 			}
 		}
 

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -576,10 +576,16 @@ func appImport(rack sdk.Interface, c *stdcli.Context, app string, r io.Reader) e
 
 		change := false
 
+		// Remove app unique parameters from being copied over
+		uniqueParams := []string{"Rack","LogBucket","ResourcePassword"}
+
+		for _,val := range uniqueParams{
+			delete(a.Parameters, val);
+		}
+
 		for k, v := range a.Parameters {
 			if v != ae.Parameters[k] {
 				change = true
-				break
 			}
 		}
 

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -411,10 +411,11 @@ func appExport(rack sdk.Interface, c *stdcli.Context, app string, w io.Writer) e
 		return err
 	}
 
-	for k, v := range a.Parameters {
-		if v == "****" {
-			delete(a.Parameters, k)
-		}
+	// Remove app unique parameters before exporting app
+	uniqueParams := []string{"Rack","LogBucket","ResourcePassword"}
+
+	for _,param := range uniqueParams{
+		delete(a.Parameters, param);
 	}
 
 	data, err := json.Marshal(a)
@@ -579,8 +580,8 @@ func appImport(rack sdk.Interface, c *stdcli.Context, app string, r io.Reader) e
 		// Remove app unique parameters from being copied over
 		uniqueParams := []string{"Rack","LogBucket","ResourcePassword"}
 
-		for _,val := range uniqueParams{
-			delete(a.Parameters, val);
+		for _,param := range uniqueParams{
+			delete(a.Parameters, param);
 		}
 
 		for k, v := range a.Parameters {


### PR DESCRIPTION
### What is the feature/fix?

Encountered error where some app parameters which are unique to every app, were being copied while doing app import, this caused failure in copying app parameters while using `convox apps import` . To resolve this before importing app parameters, we are removing the unique parameters.