### PR TITLE
added resource env variables in service for convox run command - fix/convox-run-resource-env-vars

### DIFF
--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -1123,7 +1123,12 @@ func (p *Provider) generateTaskDefinition2(app, service string, opts structs.Pro
 					return nil, err
 				}
 
-				senv[fmt.Sprintf("%s_URL", strings.Replace(strings.ToUpper(r), "-", "_", -1))] = stackOutputs(rs)["Url"]
+				ResourceEnvVariables := map[string]string{"URL":"Url","NAME":"Name","HOST":"Host","PASS":"Pass","PORT":"Port","USER":"User"}
+				ResourceName := strings.Replace(strings.ToUpper(r), "-", "_", -1)
+
+				for k,v := range ResourceEnvVariables{
+					senv[fmt.Sprintf("%s_%s", ResourceName, k)] = stackOutputs(rs)[v]
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### What is the feature/fix?
Added all resource specific env variables to the service created in convox run command. 
Now these variables are added automatically in the ECS Task definition for the service - 
X_URL=
X_USER=
X_PASS=
X_HOST=
X_PORT=
X_NAME=
where X is one of the resource types.