### PR TITLE
Adding policy to cloudformation stack role of GEN-1 app

### DIFF
--- a/provider/aws/formation/g1/app.json.tmpl
+++ b/provider/aws/formation/g1/app.json.tmpl
@@ -171,6 +171,21 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "PassRolePolicy",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "iam:PassRole"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
           }
         ]
       }

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -1299,6 +1299,21 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "PassRolePolicy",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "iam:PassRole"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
           }
         ]
       }


### PR DESCRIPTION
### What is the feature/fix?
Gen-1 apps have a param - "TaskRole" to attach a IAM role to the ECS Task running the container. Currently due to insufficient permissions to assign IAM roles, the cloudformation stack isn't able to attach the IAM role with permissions to the task definition. This fix attaches the necessary policy of 'iam:PassRole' to the IAM role attached to CloudFormation stack.