### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/manifest1/balancer.go
+++ b/pkg/manifest1/balancer.go
@@ -102,7 +102,7 @@ func (mb ManifestBalancer) FirstPort() string {
 
 func (mb ManifestBalancer) Ports() []string {
 	pp := mb.Entry.TCPPorts()
-	sp := make([]string, len(pp))
+	sp := make([]string, 0, len(pp))
 
 	for _, p := range pp {
 		sp = append(sp, strconv.Itoa(p.Balancer))

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -872,7 +872,7 @@ func (p *Provider) resolveLinks(a *structs.App, m *manifest1.Manifest, r *struct
 		}
 
 		entry.Exports = make(map[string]string)
-		linkableEnvs := make([]string, len(entry.Environment))
+		linkableEnvs := make([]string, 0, len(entry.Environment))
 		for _, env := range entry.Environment {
 			linkableEnvs = append(linkableEnvs, fmt.Sprintf("%s=%s", env.Name, env.Value))
 		}


### PR DESCRIPTION
### What is the feature/fix?

The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW



### Add screenshot or video (optional)

** Any screenshot or video capture using the feature **

### Does it has a breaking change?

** Describe the changes and if it has any breaking changes in any feature **

### How to use/test it?

** Describe how to test or use the feature **

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
