### PR TITLE
fix for copy command - from remote to local 

### DIFF
--- a/pkg/helpers/tar.go
+++ b/pkg/helpers/tar.go
@@ -46,7 +46,8 @@ func RebaseArchive(r io.Reader, src, dst string) (io.Reader, error) {
 			h.Name = fmt.Sprintf("/%s", h.Name)
 		}
 
-		if !strings.HasPrefix(h.Name, src) {
+		// the second check - strings.HasSuffix(h.Name, "/") is for checking if the src provided is a single file, if it is then it should not be skipped -- 
+		if !strings.HasPrefix(h.Name, src) && strings.HasSuffix(h.Name, "/")  {
 			continue
 		}
 


### PR DESCRIPTION
### What is the feature/fix?

Added fix for `convox cp` command for resolving the issue of copying files from remote to local filesystem.