### PR TITLE
Fix spot replace, env value with '=' and remove sensitive information autoscaling logs

### DIFF
--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -128,7 +128,7 @@ func (s Service) EnvironmentDefaults() map[string]string {
 	defaults := map[string]string{}
 
 	for _, e := range s.Environment {
-		switch parts := strings.Split(e, "="); len(parts) {
+		switch parts := strings.SplitN(e, "=", 2); len(parts) {
 		case 2:
 			defaults[parts[0]] = parts[1]
 		}

--- a/provider/aws/lambda/autoscale/handler.go
+++ b/provider/aws/lambda/autoscale/handler.go
@@ -92,12 +92,10 @@ func autoscale(desired int64) error {
 		switch *p.ParameterKey {
 		case SCHEDULE_RACK_SCALE_DOWN_PARAM:
 			if p.ParameterValue != nil && len(*p.ParameterValue) > 0 {
-				debug("param %s value = %+v\n", *p.ParameterKey, *p.ParameterValue)
 				scaleDownExpr = *p.ParameterValue
 			}
 		case SCHEDULE_RACK_SCALE_UP_PARAM:
 			if p.ParameterValue != nil && len(*p.ParameterValue) > 0 {
-				debug("param %s value = %+v\n", *p.ParameterKey, *p.ParameterValue)
 				scaleUpExpr = *p.ParameterValue
 			}
 		}
@@ -118,9 +116,6 @@ func autoscale(desired int64) error {
 	for _, p := range res.Stacks[0].Parameters {
 		switch *p.ParameterKey {
 		case icParam:
-			debug("param %s key = %+v\n", icParam, *p.ParameterKey)
-			debug("param %s value = %+v\n", icParam, *p.ParameterValue)
-
 			if ds == *p.ParameterValue {
 				fmt.Println("no change")
 				return nil
@@ -160,9 +155,6 @@ func clusterMetrics() (*Metrics, *Metrics, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-
-		debug("ListServices page: %d\n", len(res.ServiceArns))
-
 		dres, err := ECS.DescribeServices(&ecs.DescribeServicesInput{
 			Cluster:  aws.String(os.Getenv("CLUSTER")),
 			Services: res.ServiceArns,
@@ -172,7 +164,6 @@ func clusterMetrics() (*Metrics, *Metrics, error) {
 		}
 
 		for _, s := range dres.Services {
-			debug("*s.ServiceName = %+v\n", *s.ServiceName)
 
 			for _, d := range s.Deployments {
 				res, err := ECS.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
@@ -201,7 +192,6 @@ func clusterMetrics() (*Metrics, *Metrics, error) {
 						}
 
 						debug("agent = %+v\n", agent)
-						debug("len(cd.PortMappings) = %+v\n", len(cd.PortMappings))
 						debug("*s.DesiredCount = %+v\n", *s.DesiredCount)
 
 						if len(cd.PortMappings) > 0 && !agent {
@@ -267,8 +257,6 @@ func desiredCapacity(largest, total *Metrics) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-
-		debug("ListContainerInstances page: %d\n", len(res.ContainerInstanceArns))
 
 		totalCount += int64(len(res.ContainerInstanceArns))
 		if totalCount < 1 {

--- a/provider/aws/lambda/autoscale/handler.go
+++ b/provider/aws/lambda/autoscale/handler.go
@@ -413,7 +413,7 @@ func main() {
 		&aws.Config{
 			Region:     aws.String(os.Getenv("REGION")),
 			MaxRetries: aws.Int(MAX_RETRY),
-			LogLevel:   aws.LogLevel(aws.LogDebugWithRequestRetries),
+			LogLevel:   aws.LogLevel(aws.LogOff),
 			Retryer: client.DefaultRetryer{
 				NumMaxRetries:    MAX_RETRY,
 				MinRetryDelay:    1 * time.Second,

--- a/provider/aws/workers_spotreplace.go
+++ b/provider/aws/workers_spotreplace.go
@@ -47,7 +47,7 @@ func (p *Provider) spotReplace() error {
 
 	// only modify spot instances when running or converging
 	switch system.Status {
-	case "running", "converging", "rollback":
+	case "running", "converging":
 	default:
 		return nil
 	}
@@ -86,6 +86,9 @@ func (p *Provider) spotReplace() error {
 	log.Logf("instanceCount=%d onDemandMin=%d onDemandCount=%d spotCount=%d spotCountRunning=%d", ic, odmin, odc, spc, spcr)
 
 	spotDesired := ic - odmin
+	if spotDesired <= 0 {
+		return nil
+	}
 
 	if spc != spotDesired {
 		log.Logf("stack=SpotInstances setDesiredCount=%d", spotDesired)


### PR DESCRIPTION
### What is the feature/fix?

- Fix env to support '=' sign to be included in the env value
- Remove sensitive information from autoscale handler
- Fix spot replace when instance is in rollback state
