### PR TITLE
Adds resource tagging

### DIFF
--- a/pkg/manifest/resource.go
+++ b/pkg/manifest/resource.go
@@ -4,6 +4,7 @@ type Resource struct {
 	Name    string            `yaml:"-"`
 	Type    string            `yaml:"type"`
 	Options map[string]string `yaml:"options"`
+	Tags    map[string]string `yaml:"tags"`
 }
 
 type Resources []Resource

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -29,6 +29,7 @@ type Service struct {
 	Scale       ServiceScale       `yaml:"scale,omitempty"`
 	Singleton   bool               `yaml:"singleton,omitempty"`
 	Sticky      bool               `yaml:"sticky,omitempty"`
+	Tags        map[string]string  `yaml:"tags,omitempty"`
 	Termination ServiceTermination `yaml:"termination,omitempty"`
 	Test        string             `yaml:"test,omitempty"`
 	Volumes     []string           `yaml:"volumes,omitempty"`

--- a/provider/aws/formation/resource/efs.json.tmpl
+++ b/provider/aws/formation/resource/efs.json.tmpl
@@ -81,7 +81,13 @@
           "Path": {
             "Ref": "Path"
           }
-        }
+        },
+        "AccessPointTags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     },
     "EncryptionKey": {
@@ -109,7 +115,13 @@
             }
           ]
         },
-        "PendingWindowInDays": "7"
+        "PendingWindowInDays": "7",
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     },
     "FileSystem": {
@@ -136,7 +148,13 @@
               "Ref": "AWS::NoValue"
             }
           ]
-        }
+        },
+        "FileSystemTags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     },
     "MountTargetSecurityGroup": {
@@ -161,6 +179,12 @@
               }
             }
           }
+        ],
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
         ]
       }
     },

--- a/provider/aws/formation/resource/mariadb.json.tmpl
+++ b/provider/aws/formation/resource/mariadb.json.tmpl
@@ -24,7 +24,7 @@
     },
     "Class": {
       "Type": "String",
-      "Default": "db.t2.micro"
+      "Default": "db.t3.micro"
     },
     "DeletionProtection": {
       "Type": "String",
@@ -99,7 +99,13 @@
         "SecurityGroupIngress": [
           { "IpProtocol": "tcp", "FromPort": "3306", "ToPort": "3306", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
         ],
-        "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
+        "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } },
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     },
     "SubnetGroup": {
@@ -109,6 +115,12 @@
         "SubnetIds": [
           { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet0" } },
           { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet1" } }
+        ],
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
         ]
       }
     },
@@ -145,7 +157,13 @@
         "StorageEncrypted": { "Fn::If": [ "NotBlankSnapshot", { "Ref": "AWS::NoValue" }, { "Ref": "Encrypted" } ] },
         "StorageType": { "Fn::If": [ "BlankIops", "gp2", "io2" ] },
         "SourceDBInstanceIdentifier": { "Fn::If": [ "IsReadReplica", { "Ref": "ReadSourceDB" }, { "Ref": "AWS::NoValue" } ] },
-        "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ]
+        "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ],
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     }
   }

--- a/provider/aws/formation/resource/memcached.json.tmpl
+++ b/provider/aws/formation/resource/memcached.json.tmpl
@@ -48,7 +48,13 @@
         "SecurityGroupIngress": [
           { "IpProtocol": "tcp", "FromPort": "11211", "ToPort": "11211", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
         ],
-        "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
+        "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } },
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     },
     "SubnetGroup": {
@@ -58,6 +64,12 @@
         "SubnetIds": [
           { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet0" } },
           { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet1" } }
+        ],
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
         ]
       }
     },
@@ -71,7 +83,13 @@
         "EngineVersion": { "Ref": "Version" },
         "NumCacheNodes": { "Ref": "Nodes" },
         "Port": "11211",
-        "VpcSecurityGroupIds": [ { "Ref": "SecurityGroup" } ]
+        "VpcSecurityGroupIds": [ { "Ref": "SecurityGroup" } ],
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     }
   }

--- a/provider/aws/formation/resource/mysql.json.tmpl
+++ b/provider/aws/formation/resource/mysql.json.tmpl
@@ -24,7 +24,7 @@
     },
     "Class": {
       "Type": "String",
-      "Default": "db.t2.micro"
+      "Default": "db.t3.micro"
     },
     "DeletionProtection": {
       "Type": "String",
@@ -99,7 +99,13 @@
         "SecurityGroupIngress": [
           { "IpProtocol": "tcp", "FromPort": "3306", "ToPort": "3306", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
         ],
-        "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
+        "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } },
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     },
     "SubnetGroup": {
@@ -109,6 +115,12 @@
         "SubnetIds": [
           { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet0" } },
           { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet1" } }
+        ],
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
         ]
       }
     },
@@ -145,7 +157,13 @@
         "StorageEncrypted": { "Fn::If": [ "NotBlankSnapshot", { "Ref": "AWS::NoValue" }, { "Ref": "Encrypted" } ] },
         "StorageType": { "Fn::If": [ "BlankIops", "gp2", "io2" ] },
         "SourceDBInstanceIdentifier": { "Fn::If": [ "IsReadReplica", { "Ref": "ReadSourceDB" }, { "Ref": "AWS::NoValue" } ] },
-        "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ]
+        "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ],
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     }
   }

--- a/provider/aws/formation/resource/postgres.json.tmpl
+++ b/provider/aws/formation/resource/postgres.json.tmpl
@@ -25,7 +25,7 @@
     },
     "Class": {
       "Type": "String",
-      "Default": "db.t2.micro"
+      "Default": "db.t3.micro"
     },
     "DeletionProtection": {
       "Type": "String",
@@ -100,6 +100,12 @@
         "SecurityGroupIngress": [
           { "IpProtocol": "tcp", "FromPort": "5432", "ToPort": "5432", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
         ],
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ],
         "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
       }
     },
@@ -110,6 +116,12 @@
         "SubnetIds": [
           { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet0" } },
           { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet1" } }
+        ],
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
         ]
       }
     },
@@ -151,6 +163,12 @@
         "StorageEncrypted": { "Fn::If": [ "NotBlankSnapshot", { "Ref": "AWS::NoValue" }, { "Ref": "Encrypted" } ] },
         "StorageType": { "Fn::If": [ "BlankIops", "gp2", "io2" ] },
         "SourceDBInstanceIdentifier": { "Fn::If": [ "IsReadReplica", { "Ref": "ReadSourceDB" }, { "Ref": "AWS::NoValue" } ] },
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ],
         "VPCSecurityGroups": [ { "Ref": "SecurityGroup" } ]
       }
     }

--- a/provider/aws/formation/resource/redis.json.tmpl
+++ b/provider/aws/formation/resource/redis.json.tmpl
@@ -38,7 +38,7 @@
     },
     "Version": {
       "Type": "String",
-      "Default": "3.2.6"
+      "Default": "7.0",
     }
   },
   "Outputs": {
@@ -71,7 +71,13 @@
         "SecurityGroupIngress": [
           { "IpProtocol": "tcp", "FromPort": "6379", "ToPort": "6379", "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
         ],
-        "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
+        "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } },
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     },
     "SubnetGroup": {
@@ -81,6 +87,12 @@
         "SubnetIds": [
           { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet0" } },
           { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet1" } }
+        ],
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
         ]
       }
     },
@@ -105,7 +117,13 @@
         "Port": "6379",
         "ReplicationGroupDescription": { "Ref": "AWS::StackName" },
         "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ],
-        "TransitEncryptionEnabled": { "Ref": "Encrypted" }
+        "TransitEncryptionEnabled": { "Ref": "Encrypted" },
+        "Tags": [
+          {{ range $key, $value := .Tags }}
+          { "Key": "{{ $key }}", "Value": "{{ $value }}" },
+          {{ end }}
+          { "Key": "Name", "Value": "{{.Name}}" }
+        ]
       }
     }
   }

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -270,7 +270,9 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		}
 
 		rtp := map[string]interface{}{
+			"Name":                  r.Name,
 			"ThirdAvailabilityZone": hasThirdAZ,
+			"Tags":                  r.Tags,
 		}
 
 		var data []byte
@@ -371,6 +373,7 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 			"Password":       p.Password,
 			"Release":        tp["Release"],
 			"Service":        s,
+			"Tags":           s.Tags,
 			"WildcardDomain": tp["WildcardDomain"],
 		}
 

--- a/provider/aws/templates/resource/mysql.tmpl
+++ b/provider/aws/templates/resource/mysql.tmpl
@@ -29,7 +29,7 @@
       },
       "InstanceType": {
         "Type" : "String",
-        "Default" : "db.t2.micro",
+        "Default" : "db.t3.micro",
         "Description" : "Instance class for database nodes"
       },
       "MultiAZ": {

--- a/provider/aws/templates/resource/postgres.tmpl
+++ b/provider/aws/templates/resource/postgres.tmpl
@@ -30,7 +30,7 @@
       },
       "InstanceType": {
         "Type": "String",
-        "Default": "db.t2.micro",
+        "Default": "db.t3.micro",
         "Description": "Instance class for database nodes"
       },
       "DatabaseSnapshotIdentifier": {

--- a/provider/aws/templates/resource/redis.tmpl
+++ b/provider/aws/templates/resource/redis.tmpl
@@ -24,7 +24,7 @@
       },
       "EngineVersion": {
         "Type": "String",
-        "Default": "3.2.6"
+        "Default": "7.0",
       },
       "InstanceType": {
         "Type": "String",

--- a/provider/kaws/template/resource/mysql.yml.tmpl
+++ b/provider/kaws/template/resource/mysql.yml.tmpl
@@ -37,7 +37,7 @@ spec:
     Parameters:
       Class:
         Type: String
-        Default: db.t2.micro
+        Default: db.t3.micro
       Durable:
         Type: String
         Default: "false"

--- a/provider/kaws/template/resource/postgres.yml.tmpl
+++ b/provider/kaws/template/resource/postgres.yml.tmpl
@@ -38,7 +38,7 @@ spec:
     Parameters:
       Class:
         Type: String
-        Default: db.t2.micro
+        Default: db.t3.micro
       Durable:
         Type: String
         Default: "false"


### PR DESCRIPTION
### What is the feature/fix?

Introduces optional tags fields to unify resource metadata Enables consistent tagging for improved environment management

### Does it has a breaking change?

New feature.
 
### How to use/test it?

Add tags in the convox.yml to the resource you want to add:

```yml
resources:
  mydb:
    type: postgres
    options:
      storage: 100
    tags:
      myresourcetag1: resourcetag1
      myresourcetag2: resourcetag2
```

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
