### PR TITLE
Enables fully statically linked binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ profile.out
 cmd/convox/pkg
 provider/aws/lambda/autoscale/handler
 provider/aws/lambda/autoscale/lambda.zip
+provider/aws/lambda/autoscale/bootstrap
 .vscode/
 .DS_Store

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -433,7 +433,7 @@
       "Value": { "Ref": "AWS::StackName" }
     },
     "RackDomain": {
-      "Value": { 
+      "Value": {
         "Fn::Join": [ ".", [
           "rack",
           { "Fn::Select": [ 0, { "Fn::Split": [ ".", { "Fn::GetAtt": [ "ApiBalancer", "DNSName" ] } ] } ] },
@@ -2412,7 +2412,7 @@
         "Handler": "handler",
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
-        "Runtime": "provided.al2",
+        "Runtime": "provided.al2023",
         "Timeout": "60",
         "VpcConfig": { "Fn::If": [ "PrivateAndPlaceLambdaInVpc",
           {
@@ -2543,7 +2543,7 @@
         "Handler": "handler",
         "MemorySize": "128",
         "Role": { "Fn::GetAtt": [ "InstancesLifecycleHandlerRole", "Arn" ] },
-        "Runtime": "provided.al2",
+        "Runtime": "provided.al2023",
         "Timeout": "300",
         "VpcConfig": { "Fn::If": [ "PrivateAndPlaceLambdaInVpc",
           {
@@ -3000,7 +3000,7 @@
                 { "Key": "Name", "Value": { "Ref": "AWS::StackName" }},
                 { "Key": "Rack", "Value": { "Ref": "AWS::StackName" }},
                 { "Key": "GatewayAttachment", "Value": { "Fn::If": [ "ExistingVpc", "existing",{ "Ref": "GatewayAttachment"}]}},
-                { "Key": "NatGateways", "Value": { "Fn::If": 
+                { "Key": "NatGateways", "Value": { "Fn::If":
                   [  "PrivateInstances",
                       {
                         "Fn::Join": [
@@ -3262,7 +3262,7 @@
                 { "Key": "Name", "Value": { "Ref": "AWS::StackName" }},
                 { "Key": "Rack", "Value": { "Ref": "AWS::StackName" }},
                 { "Key": "GatewayAttachment", "Value": { "Fn::If": [ "ExistingVpc", "existing",{ "Ref": "GatewayAttachment"}]}},
-                { "Key": "NatGateways", "Value": { "Fn::If": 
+                { "Key": "NatGateways", "Value": { "Fn::If":
                   [  "PrivateInstances",
                       {
                         "Fn::Join": [
@@ -3968,7 +3968,7 @@
         "DeploymentConfiguration": { "MinimumHealthyPercent": { "Fn::If": [ "HighAvailability", "50", "0" ] }, "MaximumPercent": "200" },
         "DesiredCount": { "Fn::If": [ "HighAvailability", { "Ref": "ApiCount" }, 1 ] },
         "LoadBalancers": [ { "ContainerName": "web", "ContainerPort": "5443", "TargetGroupArn": { "Ref": "ApiBalancerTargetGroup" } }],
-        "PlacementConstraints": [ { "Fn::If": ["SpotFleet", { "Type": "memberOf", "Expression": "attribute:asg == primary" }, { "Ref": "AWS::NoValue" }] } ], 
+        "PlacementConstraints": [ { "Fn::If": ["SpotFleet", { "Type": "memberOf", "Expression": "attribute:asg == primary" }, { "Ref": "AWS::NoValue" }] } ],
         "Role": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
         "TaskDefinition": { "Ref": "ApiWebTasks" }
       }
@@ -4515,7 +4515,7 @@
         "VersioningConfiguration": { "Status" : {"Ref": "EnableS3Versioning" } },
         "LifecycleConfiguration": { "Fn::If": [ "BlankLogRetention",
           { "Rules": [ { "NoncurrentVersionExpiration": { "NewerNoncurrentVersions" : 1, "NoncurrentDays" : 365 }, "Status": "Enabled" } ] },
-          { "Rules": [ 
+          { "Rules": [
             { "ExpirationInDays": { "Ref": "LogRetention" }, "Status": "Enabled" },
             { "NoncurrentVersionExpiration": { "NewerNoncurrentVersions" : 1, "NoncurrentDays" : 365 }, "Status": "Enabled" }
             ] }

--- a/provider/aws/lambda/autoscale/Makefile
+++ b/provider/aws/lambda/autoscale/Makefile
@@ -8,7 +8,7 @@ lambda.zip: handler
 	zip -r lambda.zip bootstrap
 
 handler: *.go
-	GOOS=linux GOARCH=amd64 go build -o bootstrap
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-extldflags=-static" -o bootstrap
 
 clean:
 	rm -f lambda.zip bootstrap

--- a/provider/aws/lambda/formation/Makefile
+++ b/provider/aws/lambda/formation/Makefile
@@ -9,7 +9,7 @@ lambda.zip: index.js main
 	zip -r lambda.zip main index.js
 
 main: *.go
-	GOOS=linux GOARCH=amd64 go build -o main
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-extldflags=-static" -o main
 
 release: lambda.zip
 	aws s3 cp lambda.zip s3://convox/release/$(VERSION)/lambda/formation.zip --acl public-read

--- a/provider/aws/lambda/lifecycle/Makefile
+++ b/provider/aws/lambda/lifecycle/Makefile
@@ -18,7 +18,7 @@ upload: lambda.zip
 	bin/upload $(RACK)
 
 handler: *.go
-	GOOS=linux GOARCH=amd64 go build -o bootstrap
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-extldflags=-static"  -o bootstrap
 
 lambda.zip: handler
 	zip -r lambda.zip bootstrap

--- a/provider/aws/lambda/syslog/Makefile
+++ b/provider/aws/lambda/syslog/Makefile
@@ -6,7 +6,7 @@ lambda.zip: handler
 	zip -r lambda.zip bootstrap
 
 handler: *.go
-	GOOS=linux GOARCH=amd64 go build -o bootstrap
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-extldflags=-static" -o bootstrap
 
 clean:
 	rm -f lambda.zip bootstrap

--- a/provider/aws/templates/resource/syslog.tmpl
+++ b/provider/aws/templates/resource/syslog.tmpl
@@ -83,7 +83,7 @@
         },
         "Handler": "handler",
         "Role": { "Fn::GetAtt": [ "Role", "Arn" ] },
-        "Runtime": "provided.al2",
+        "Runtime": "provided.al2023",
         "Timeout": "25",
         "VpcConfig": { "Fn::If": [ "Private",
           { "SecurityGroupIds": [ { "Ref": "SecurityGroup" } ], "SubnetIds": { "Ref": "SubnetsPrivate" } },


### PR DESCRIPTION
### What is the feature/fix?

Ensures a fully self-contained AWS Lambda deployment and reduces runtime dependencies

### Does it has a breaking change?

Change the autoscaler to build a fully statically linked binary