### PR TITLE
Add support to expose both in internal and external loadbalancer

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -331,6 +331,10 @@ func (m *Manifest) ApplyDefaults() error {
 		if !m.AttributeSet(fmt.Sprintf("services.%s.termination.grace", s.Name)) {
 			m.Services[i].Termination.Grace = 30
 		}
+
+		if s.InternalAndExternal {
+			m.Services[i].Internal = true
+		}
 	}
 
 	return nil

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -10,29 +10,30 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent       ServiceAgent       `yaml:"agent,omitempty"`
-	Build       ServiceBuild       `yaml:"build,omitempty"`
-	Command     ServiceCommand     `yaml:"command,omitempty"`
-	Deployment  ServiceDeployment  `yaml:"deployment,omitempty"`
-	Domains     ServiceDomains     `yaml:"domain,omitempty"`
-	Drain       int                `yaml:"drain,omitempty"`
-	Environment Environment        `yaml:"environment,omitempty"`
-	Health      ServiceHealth      `yaml:"health,omitempty"`
-	Image       string             `yaml:"image,omitempty"`
-	Init        bool               `yaml:"init,omitempty"`
-	Internal    bool               `yaml:"internal,omitempty"`
-	Links       []string           `yaml:"links,omitempty"`
-	Policies    []string           `yaml:"policies,omitempty"`
-	Port        ServicePort        `yaml:"port,omitempty"`
-	Privileged  bool               `yaml:"privileged,omitempty"`
-	Resources   []string           `yaml:"resources,omitempty"`
-	Scale       ServiceScale       `yaml:"scale,omitempty"`
-	Singleton   bool               `yaml:"singleton,omitempty"`
-	Sticky      bool               `yaml:"sticky,omitempty"`
-	Tags        map[string]string  `yaml:"tags,omitempty"`
-	Termination ServiceTermination `yaml:"termination,omitempty"`
-	Test        string             `yaml:"test,omitempty"`
-	Volumes     []string           `yaml:"volumes,omitempty"`
+	Agent               ServiceAgent       `yaml:"agent,omitempty"`
+	Build               ServiceBuild       `yaml:"build,omitempty"`
+	Command             ServiceCommand     `yaml:"command,omitempty"`
+	Deployment          ServiceDeployment  `yaml:"deployment,omitempty"`
+	Domains             ServiceDomains     `yaml:"domain,omitempty"`
+	Drain               int                `yaml:"drain,omitempty"`
+	Environment         Environment        `yaml:"environment,omitempty"`
+	Health              ServiceHealth      `yaml:"health,omitempty"`
+	Image               string             `yaml:"image,omitempty"`
+	Init                bool               `yaml:"init,omitempty"`
+	Internal            bool               `yaml:"internal,omitempty"`
+	InternalAndExternal bool               `yaml:"internalAndExternal,omitempty"`
+	Links               []string           `yaml:"links,omitempty"`
+	Policies            []string           `yaml:"policies,omitempty"`
+	Port                ServicePort        `yaml:"port,omitempty"`
+	Privileged          bool               `yaml:"privileged,omitempty"`
+	Resources           []string           `yaml:"resources,omitempty"`
+	Scale               ServiceScale       `yaml:"scale,omitempty"`
+	Singleton           bool               `yaml:"singleton,omitempty"`
+	Sticky              bool               `yaml:"sticky,omitempty"`
+	Tags                map[string]string  `yaml:"tags,omitempty"`
+	Termination         ServiceTermination `yaml:"termination,omitempty"`
+	Test                string             `yaml:"test,omitempty"`
+	Volumes             []string           `yaml:"volumes,omitempty"`
 }
 
 type Services []Service

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -32,6 +32,17 @@
             {{ if .Domain }} "{{.Domain}}" {{ else }} { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Host" } } ] ] } {{ end }}
           ] }
         },
+        {{ if .InternalAndExternal }}
+        "EndpointExternal": {
+          "Value": { "Fn::If": [ "InternalDomains",
+            { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] },
+            {{ if .Domain }} "{{.Domain}}" {{ else }} { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] } {{ end }}
+          ] }
+        },
+        "TargetGroupExternal": {
+          "Value": { "Ref": "BalancerTargetGroupExternal" }
+        },
+        {{ end }}
         "TargetGroup": {
           "Value": { "Ref": "BalancerTargetGroup{{ if .Internal }}Internal{{ end }}" }
         },
@@ -319,6 +330,7 @@
             "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
           }
         },
+
         "BalancerListenerRule80": {
           "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
           {{ if .Domain }}
@@ -349,6 +361,77 @@
             "Priority": "{{ priority $.App .Name "default" -1 }}"
           }
         },
+        {{ if .InternalAndExternal }}
+        "BalancerTargetGroupExternal": {
+          "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+          "Properties": {
+            "HealthCheckIntervalSeconds": "{{.Health.Interval}}",
+            "HealthCheckTimeoutSeconds": "{{.Health.Timeout}}",
+            "HealthyThresholdCount": "2",
+            "UnhealthyThresholdCount": "2",
+            "HealthCheckPath": "{{.Health.Path}}",
+            "Matcher": {
+              {{ if or (eq .Port.Scheme "grpc") (eq .Port.Scheme "secure-grpc") }}
+              "GrpcCode": { "Ref": "LoadBalancerGrpcSuccessCodes" }
+              {{ else }}
+              "HttpCode": { "Ref": "LoadBalancerSuccessCodes" }
+              {{ end }}
+            },
+            "Port": "{{.Port.Port}}",
+            {{ if eq .Port.Scheme "grpc" }}
+            "Protocol": "HTTP",
+            "ProtocolVersion": "GRPC",
+            {{ else if eq .Port.Scheme "secure-grpc" }}
+            "Protocol": "HTTPS",
+            "ProtocolVersion": "GRPC",
+            {{ else }}
+            "Protocol": "{{ upcase .Port.Scheme }}",
+            {{ end }}
+            "TargetGroupAttributes": [
+              { "Key": "deregistration_delay.timeout_seconds", "Value": "{{.Drain}}" },
+              { "Key": "load_balancing.algorithm.type", "Value": { "Ref": "LoadBalancerAlgorithm" } },
+              { "Key": "slow_start.duration_seconds", "Value": { "Ref": "SlowStartDuration" } },
+              { "Key": "stickiness.enabled", "Value": "{{.Sticky}}" }
+            ],
+            "Tags": [
+              { "Key": "App", "Value": "{{$.App}}" },
+              { "Key": "Service", "Value": "{{.Name}}" }
+            ],
+            "TargetType": { "Fn::If": [ "IsolateServices", "ip", "instance" ] },
+            "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
+          }
+        },
+        "BalancerListenerRule80External": {
+          "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+          {{ if .Domain }}
+            "Condition": "InternalDomainsAndRouteHttp",
+          {{ else }}
+            "Condition": "RouteHttp",
+          {{ end }}
+          "Properties": {
+            "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "BalancerTargetGroupExternal" } } ],
+            "Conditions": [ { "Field": "host-header", "Values": [ { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] } ] } ],
+            "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener80" } },
+            "Priority": "{{ priority $.App .Name "default-external" -1 }}"
+          }
+        },
+        "BalancerListenerRule443External": {
+          "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+          {{ if .Domain }}
+            "Condition": "InternalDomains",
+          {{ end }}
+          "Properties": {
+            "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "BalancerTargetGroupExternal" } } ],
+            "Conditions": [ { "Field": "host-header", "Values": [
+              { "Fn::Join": [ ".", [ "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] } {{- if $.WildcardDomain }},
+              { "Fn::Join": [".", [ "*", "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] }
+              {{ end }}
+              ] } ],
+            "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener443" } },
+            "Priority": "{{ priority $.App .Name "default-external" -1 }}"
+          }
+        },
+        {{ end }}
         {{ if $.WildcardDomain }}
         "WildCardCertificate": {
           "Type": "AWS::CertificateManager::Certificate",
@@ -380,6 +463,38 @@
               "ListenerArn" : { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Listener443" } }
             }
         },
+        {{ if .InternalAndExternal }}
+        "WildCardCertificateExternal": {
+          "Type": "AWS::CertificateManager::Certificate",
+          {{ if .Domain }}
+            "Condition": "InternalDomains",
+          {{ end }}
+          "Properties": {
+            "DomainName": { "Fn::Join": [ ".", [ "*", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] },
+            "DomainValidationOptions": [
+              {
+                "DomainName": { "Fn::Join": [ ".", [ "*", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] },
+                "ValidationDomain": "convox.site"
+              },
+              {
+                "DomainName": { "Fn::Join": [ ".", [ "*", "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] },
+                "ValidationDomain": "convox.site"
+              }
+            ],
+            "SubjectAlternativeNames": [ { "Fn::Join": [ ".", [ "*", "{{$.App}}-{{.Name}}", { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterHost" } } ] ] } ]
+          }
+        },
+        "AddListenerCertificatesExternal": {
+          "Type" : "AWS::ElasticLoadBalancingV2::ListenerCertificate",
+          {{ if .Domain }}
+            "Condition": "InternalDomains",
+          {{ end }}
+          "Properties" : {
+              "Certificates" : [ { "CertificateArn" : { "Ref": "WildCardCertificate" } } ],
+              "ListenerArn" : { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener443" } }
+            }
+        },
+        {{ end }}
         {{ end }}
         "RecordSetInternalDomain": {
           "Type": "AWS::Route53::RecordSet",
@@ -420,6 +535,15 @@
               "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:{{ router .Name $.Manifest }}Listener443" } }
             }
           },
+          {{ if .InternalAndExternal }}
+          "BalancerListenerCertificateExternal": {
+            "Type": "AWS::ElasticLoadBalancingV2::ListenerCertificate",
+            "Properties": {
+              "Certificates": [ { "CertificateArn": { "Ref": "Certificate" } } ],
+              "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener443" } }
+            }
+          },
+          {{ end }}
           {{ range $i, $domain := .Domains }}
             "BalancerListenerRule80Domain{{$i}}": {
               "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
@@ -446,6 +570,33 @@
                 "Priority": "{{ priority $.App $.Service.Name $domain $i }}"
               }
             },
+            {{ if .InternalAndExternal }}
+            "BalancerListenerRule80Domain{{$i}}External": {
+              "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+              "Condition": "RouteHttp",
+              {{ if gt $i 0 }}
+                "DependsOn": "BalancerListenerRule80Domain{{ dec $i }}External",
+              {{ end }}
+              "Properties": {
+              "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "BalancerTargetGroupExternal" } } ],
+                "Conditions": [ { "Field": "host-header", "Values": [ "{{$domain}}" ] } ],
+                "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener80" } },
+                "Priority": "{{ priority $.App $.Service.Name (printf "%s-external" $domain) $i }}"
+              }
+            },
+            "BalancerListenerRule443Domain{{$i}}External": {
+              "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+              {{ if gt $i 0 }}
+                "DependsOn": "BalancerListenerRule443Domain{{ dec $i }}External",
+              {{ end }}
+              "Properties": {
+              "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "BalancerTargetGroupExternal" } } ],
+                "Conditions": [ { "Field": "host-header", "Values": [ "{{$domain}}" ] } ],
+                "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:RouterListener443" } },
+                "Priority": "{{ priority $.App $.Service.Name (printf "%s-external" $domain) $i }}"
+              }
+            },
+            {{ end }}
           {{ end }}
         {{ end }}
       {{ end }}
@@ -616,7 +767,10 @@
           ] },
           {{ if .Port.Port }}
             "HealthCheckGracePeriodSeconds": "{{.Health.Grace}}",
-            "LoadBalancers": [ { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "BalancerTargetGroup{{ if .Internal }}Internal{{ end }}" } } ],
+            "LoadBalancers": [ { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "BalancerTargetGroup{{ if .Internal }}Internal{{ end }}" } } {{ if .InternalAndExternal }},
+            { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "BalancerTargetGroupExternal" } }
+            {{ end }}
+            ],
             "Role": { "Fn::If": [ "IsolateServices", { "Ref": "AWS::NoValue" }, { "Fn::ImportValue": { "Fn::Sub": "${Rack}:ServiceRole" } } ] },
           {{ end }}
           "TaskDefinition": { "Ref": "Tasks" }

--- a/provider/aws/service.go
+++ b/provider/aws/service.go
@@ -57,7 +57,7 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 		endpoint := a.Outputs[fmt.Sprintf("Service%sEndpoint", upperName(ms.Name))]
 		cert := a.Outputs[fmt.Sprintf("Service%sCertificate", upperName(ms.Name))]
 
-		if endpoint == "" {
+		if endpoint == "" || ms.InternalAndExternal {
 			sr, err := p.stackResource(p.rackStack(app), fmt.Sprintf("Service%s", upperName(ms.Name)))
 			if err != nil && !strings.HasPrefix(err.Error(), "resource not found") {
 				return nil, err
@@ -73,6 +73,9 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 
 				cert = outputs["Certificate"]
 				endpoint = outputs["Endpoint"]
+				if ms.InternalAndExternal {
+					endpoint = fmt.Sprintf("%s(internal), %s(external)", outputs["Endpoint"], outputs["EndpointExternal"])
+				}
 			}
 		}
 


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Dual Load Balancer Support for Services**

We've added the ability to expose services through both internal and external load balancers simultaneously. This new feature provides greater flexibility in service accessibility, allowing you to make a service available both within your VPC and to the public internet.

Previously, services could only be exposed through either an internal or external load balancer, but not both. This enhancement enables hybrid access patterns where certain services need to be accessible from both internal resources and external clients.

---

### How to use it?

To enable dual load balancer access for a service, set the `internalAndExternal` attribute to `true` in your `convox.yml`:

```yaml
environment:
  - PORT=3000
services:
  web:
    internalAndExternal: true
    build: .
    port: 3000
```

**Important Prerequisites:**
- Your Rack must have the `Internal` parameter set to `Yes`:
  ```
  $ convox rack params set Internal=Yes
  ```
- This creates both an internal load balancer (accessible only within your VPC) and an external load balancer (accessible from the internet) for the specified service.

This is particularly useful for:
- Services that need to be accessed by both internal microservices and external clients
- API gateways that serve both public and private traffic
- Admin interfaces that require both VPC-internal access and controlled external access

---

### Does it have a breaking change?

There are no breaking changes introduced with this feature. Existing services will continue to work as before. The `internalAndExternal` attribute is optional and defaults to `false` when not specified.

---

### Requirements

To use this feature, you must:
- Be on at least rack version `20250822114342`
- Have the `Internal` rack parameter set to `Yes`

You can check your rack's version with the command `convox rack`.
Update your rack to the latest version with the command `convox rack update`.