### PR TITLE
align docker CLI to 29.3.1 across all images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -qq update && apt-get -qq -y install curl
 
 ENV DOCKER_BUILDKIT=1
 
-RUN curl -s https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-18.09.9.tgz | \
+RUN curl -s https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-29.3.1.tgz | \
     tar -C /usr/bin --strip-components 1 -xz
 
 RUN curl -Ls https://storage.googleapis.com/kubernetes-release/release/v1.28.15/bin/linux/${KUBECTL_ARCH}/kubectl -o /usr/bin/kubectl && \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -20,7 +20,7 @@ ARG KUBECTL_ARCH=arm64
 
 RUN apt-get -qq update && apt-get -qq -y install curl
 
-RUN curl -s https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-18.03.1-ce.tgz | \
+RUN curl -s https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-29.3.1.tgz | \
     tar -C /usr/bin --strip-components 1 -xz
 
 RUN curl -Ls https://storage.googleapis.com/kubernetes-release/release/v1.28.15/bin/linux/${KUBECTL_ARCH}/kubectl -o /usr/bin/kubectl && \

--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -12,7 +12,7 @@ unzip awscliv2.zip
 sudo ./aws/install
 
 # install docker
-curl -s https://download.docker.com/linux/static/stable/x86_64/docker-18.09.6.tgz | sudo tar -C /usr/bin --strip-components 1 -xz
+curl -s https://download.docker.com/linux/static/stable/x86_64/docker-29.3.1.tgz | sudo tar -C /usr/bin --strip-components 1 -xz
 
 # install kubectl
 curl -Ls https://storage.googleapis.com/kubernetes-release/release/v1.28.15/bin/linux/amd64/kubectl -o /tmp/kubectl && \


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Align Docker CLI to 29.3.1 Across All Images**

The Docker CLI static binary bundled in the rack image has been updated to version 29.3.1 (March 2026) across all architectures. Previously, three different files specified three different Docker CLI versions spanning June 2018 to September 2019 (18.03.1-ce on ARM, 18.09.6 in CI, 18.09.9 in the primary Dockerfile). All are now aligned to Docker 29.3.1, the latest stable release, for both x86_64 and aarch64.

The Docker CLI is used internally by the rack for image operations during builds and releases (pull, push, tag, save, load, login, inspect). It is forward and backward compatible with the Docker daemons running on ECS-optimized AMIs (Docker ~20.10.x on AL2, ~25.x on AL2023).

---

### How to use it?

This update is automatically applied when you update your rack. No additional configuration is required.

```
$ convox rack update
```

---

### Does it have a breaking change?

No breaking changes. The Docker CLI maintains backward compatibility with older Docker daemons. All image operations (build, push, pull, deploy) continue to work identically.

---

### Requirements

To receive this update, you must update to rack version `20260406110041` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
