### PR TITLE
fix TestAppLogs flake with deterministic time mock

### DIFF
--- a/provider/aws/apps_test.go
+++ b/provider/aws/apps_test.go
@@ -86,6 +86,14 @@ func TestAppGet(t *testing.T) {
 }
 
 func TestAppLogs(t *testing.T) {
+	oldNow := helpers.TimeNow
+	helpers.TimeNow = func() time.Time {
+		return time.Date(2025, 4, 9, 22, 0, 0, 0, time.UTC)
+	}
+	defer func() { helpers.TimeNow = oldNow }()
+
+	mockedNow := helpers.TimeNow()
+
 	provider := StubAwsProvider(
 		cycleListAppStackResources,
 		cycleLogFilterLogEvents1,
@@ -99,7 +107,7 @@ func TestAppLogs(t *testing.T) {
 		Follow: options.Bool(false),
 		Filter: options.String("test"),
 		Prefix: options.Bool(true),
-		Since:  options.Duration(time.Since(time.Date(2011, 1, 1, 0, 0, 0, 0, time.UTC))),
+		Since:  options.Duration(mockedNow.Sub(time.Date(2011, 1, 1, 0, 0, 0, 0, time.UTC))),
 	})
 
 	io.Copy(buf, r)


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Resolve Flaky TestAppLogs Test**

Fixed an intermittent test failure in `TestAppLogs` caused by a timing-sensitive duration calculation. The test now mocks the system clock for deterministic behavior, matching the pattern already used by the adjacent `TestAppLogsSince` test.

This is an internal change to the test suite only. It does not affect any rack behavior, infrastructure, or user-facing functionality.

---

### How to use it?

This fix is internal to the test suite and requires no user action. It is automatically included when you update your rack.

```
$ convox rack update
```

---

### Does it have a breaking change?

No breaking changes. This is a test-only fix with no impact on rack behavior or deployed infrastructure.

---

### Requirements

To receive this fix, you must update to rack version `20260406110041` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
