### PR TITLE
remove dead EC2NatGateway and EC2Route handlers

### DIFF
--- a/provider/aws/lambda/formation/handler/ec2.go
+++ b/provider/aws/lambda/formation/handler/ec2.go
@@ -5,10 +5,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
@@ -28,42 +26,6 @@ func HandleEC2AvailabilityZones(req Request) (string, map[string]string, error) 
 		fmt.Println("DELETING AVAILABILITYZONES")
 		fmt.Printf("req %+v\n", req)
 		return EC2AvailabilityZonesDelete(req)
-	}
-
-	return "", nil, fmt.Errorf("unknown RequestType: %s", req.RequestType)
-}
-
-// HandleEC2NatGateway handles the lifecycle of a Custom::EC2NatGateway
-func HandleEC2NatGateway(req Request) (string, map[string]string, error) {
-	defer recoverFailure(req)
-
-	switch req.RequestType {
-	case "Create":
-		return "invalid", nil, fmt.Errorf("Custom::EC2NatGateway is no longer available")
-	case "Update":
-		return "invalid", nil, fmt.Errorf("Custom::EC2NatGateway is no longer available")
-	case "Delete":
-		fmt.Println("DELETING NATGATEWAY")
-		fmt.Printf("req %+v\n", req)
-		return EC2NatGatewayDelete(req)
-	}
-
-	return "", nil, fmt.Errorf("unknown RequestType: %s", req.RequestType)
-}
-
-// HandleEC2Route handles the lifecycle of a Custom::EC2Route
-func HandleEC2Route(req Request) (string, map[string]string, error) {
-	defer recoverFailure(req)
-
-	switch req.RequestType {
-	case "Create":
-		return "invalid", nil, fmt.Errorf("Custom::EC2Route is no longer available")
-	case "Update":
-		return "invalid", nil, fmt.Errorf("Custom::EC2Route is no longer available")
-	case "Delete":
-		fmt.Println("DELETING ROUTE")
-		fmt.Printf("req %+v\n", req)
-		return EC2RouteDelete(req)
 	}
 
 	return "", nil, fmt.Errorf("unknown RequestType: %s", req.RequestType)
@@ -109,66 +71,4 @@ func EC2AvailabilityZonesUpdate(req Request) (string, map[string]string, error) 
 func EC2AvailabilityZonesDelete(req Request) (string, map[string]string, error) {
 	// nop
 	return req.PhysicalResourceId, nil, nil
-}
-
-// EC2NatGatewayDelete  deletes a Custom::EC2route
-// TODO: delete
-func EC2NatGatewayDelete(req Request) (string, map[string]string, error) {
-	_, err := EC2(req).DeleteNatGateway(&ec2.DeleteNatGatewayInput{
-		NatGatewayId: aws.String(req.PhysicalResourceId),
-	})
-
-	// block for 2 minutes until it's deleted
-	// Fixes subsequent CF error on deleting Elastic IP:
-	//   API: ec2:disassociateAddress You do not have permission to access the specified resource.
-	for i := 0; i < 12; i++ {
-		resp, derr := EC2(req).DescribeNatGateways(&ec2.DescribeNatGatewaysInput{
-			NatGatewayIds: []*string{aws.String(req.PhysicalResourceId)},
-		})
-
-		if derr != nil {
-			fmt.Printf("EC2NatGatewayDelete error: %s\n", derr)
-
-			// if nat gateway not found, break
-			if ae, ok := derr.(awserr.Error); ok {
-				if ae.Code() == "InvalidParameterException" {
-					break
-				}
-			}
-		}
-
-		// if NAT gateway is deleted, break
-		if len(resp.NatGateways) == 1 {
-			n := resp.NatGateways[0]
-
-			if *n.State == "deleted" {
-				break
-			}
-		}
-
-		// sleep and retry
-		time.Sleep(10 * time.Second)
-	}
-
-	// return original DeleteNatGateway success / failure
-	return req.PhysicalResourceId, nil, err
-}
-
-// EC2RouteDelete deletes a Custom::EC2route
-// TODO: delete
-func EC2RouteDelete(req Request) (string, map[string]string, error) {
-	parts := strings.SplitN(req.PhysicalResourceId, "/", 2)
-
-	_, err := EC2(req).DeleteRoute(&ec2.DeleteRouteInput{
-		DestinationCidrBlock: aws.String(parts[1]),
-		RouteTableId:         aws.String(parts[0]),
-	})
-
-	if ae, ok := err.(awserr.Error); ok {
-		if ae.Code() == "InvalidRoute.NotFound" {
-			return req.PhysicalResourceId, nil, nil
-		}
-	}
-
-	return req.PhysicalResourceId, nil, err
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Remove Dead EC2NatGateway and EC2Route Handlers**

Removed four unreachable functions from the CloudFormation custom resource handler: `HandleEC2NatGateway`, `HandleEC2Route`, and their associated delete helpers. These handlers were previously deprecated (Create/Update already returned "no longer available" errors) and were never dispatched — the formation handler switch table does not route `Custom::EC2NatGateway` or `Custom::EC2Route` events. No CloudFormation templates reference these custom resource types.

This is a code cleanup with no impact on rack behavior or deployed infrastructure. The actively used `HandleEC2AvailabilityZones` handler is unchanged.

---

### How to use it?

This cleanup is automatically included when you update your rack. No additional configuration is required.

```
$ convox rack update
```

---

### Does it have a breaking change?

No breaking changes. The removed code was already unreachable and had no effect on rack operations.

---

### Requirements

To receive this update, you must update to rack version `20260406110041` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
