### PR TITLE
add nlb port schema and validation

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -212,6 +212,33 @@ func (m *Manifest) Validate() error {
 		if !nameValidator.MatchString(s.Name) {
 			return fmt.Errorf("service name %s invalid, %s", s.Name, ValidNameDescription)
 		}
+
+		if len(s.NLB) > 0 && s.Agent.Enabled {
+			return fmt.Errorf("service %s: agent mode is incompatible with nlb ports", s.Name)
+		}
+
+		seenPorts := map[int]int{}
+		for _, np := range s.NLB {
+			if np.Port < 1 || np.Port > 65535 {
+				return fmt.Errorf("service %s: nlb port %d out of range", s.Name, np.Port)
+			}
+			if np.ContainerPort < 1 || np.ContainerPort > 65535 {
+				return fmt.Errorf("service %s: nlb containerPort %d out of range", s.Name, np.ContainerPort)
+			}
+			if np.Protocol != "tcp" {
+				return fmt.Errorf("service %s nlb port %d: only tcp protocol is currently supported", s.Name, np.Port)
+			}
+			if np.Scheme != "public" && np.Scheme != "internal" {
+				return fmt.Errorf("service %s nlb port %d: scheme must be public or internal, got %q", s.Name, np.Port, np.Scheme)
+			}
+			if existing, ok := seenPorts[np.Port]; ok {
+				if existing != np.ContainerPort {
+					return fmt.Errorf("service %s: nlb port %d declared with conflicting containerPort values", s.Name, np.Port)
+				}
+				return fmt.Errorf("service %s: duplicate nlb port %d", s.Name, np.Port)
+			}
+			seenPorts[np.Port] = np.ContainerPort
+		}
 	}
 
 	for _, r := range m.Resources {
@@ -334,6 +361,21 @@ func (m *Manifest) ApplyDefaults() error {
 
 		if s.InternalAndExternal {
 			m.Services[i].Internal = true
+		}
+
+		for j := range m.Services[i].NLB {
+			np := &m.Services[i].NLB[j]
+			np.Protocol = strings.ToLower(np.Protocol)
+			if np.Protocol == "" {
+				np.Protocol = "tcp"
+			}
+			np.Scheme = strings.ToLower(np.Scheme)
+			if np.Scheme == "" {
+				np.Scheme = "public"
+			}
+			if np.ContainerPort == 0 {
+				np.ContainerPort = np.Port
+			}
 		}
 	}
 

--- a/pkg/manifest/nlb_test.go
+++ b/pkg/manifest/nlb_test.go
@@ -1,0 +1,206 @@
+package manifest_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/convox/rack/pkg/manifest"
+)
+
+// loadBytes is a test helper that loads a manifest from bytes and returns the manifest and error.
+func loadBytes(t *testing.T, data []byte) (*manifest.Manifest, error) {
+	t.Helper()
+	return manifest.Load(data, nil)
+}
+
+// loadFixture reads a named testdata file and loads it.
+func loadFixture(t *testing.T, name string) (*manifest.Manifest, error) {
+	t.Helper()
+	data, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return manifest.Load(data, nil)
+}
+
+// requireErrContains asserts err is non-nil and its message contains the substring.
+func requireErrContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected error containing %q, got %q", want, err.Error())
+	}
+}
+
+func TestManifestLoadNLB(t *testing.T) {
+	m, err := loadFixture(t, "nlb.yml")
+	if err != nil {
+		t.Fatalf("valid nlb manifest failed to load: %v", err)
+	}
+	s, err := m.Service("api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.NLB) != 2 {
+		t.Fatalf("expected 2 nlb ports, got %d", len(s.NLB))
+	}
+	if s.NLB[0].Port != 8443 || s.NLB[0].Protocol != "tcp" || s.NLB[0].ContainerPort != 8443 || s.NLB[0].Scheme != "public" {
+		t.Errorf("nlb[0] mismatch: %+v", s.NLB[0])
+	}
+	if s.NLB[1].Scheme != "internal" {
+		t.Errorf("nlb[1].Scheme = %q, want internal", s.NLB[1].Scheme)
+	}
+}
+
+func TestManifestLoadNLBDuplicatePort(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-dup-port.yml")
+	requireErrContains(t, err, "duplicate nlb port 8443")
+}
+
+func TestManifestLoadNLBConflictingContainerPort(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-conflicting-container-port.yml")
+	requireErrContains(t, err, "conflicting containerPort")
+}
+
+func TestManifestLoadNLBBadProtocolUDP(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-proto.yml")
+	requireErrContains(t, err, "only tcp protocol is currently supported")
+}
+
+func TestManifestLoadNLBBadProtocolTLS(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-tls.yml")
+	requireErrContains(t, err, "only tcp protocol is currently supported")
+}
+
+func TestManifestLoadNLBBadProtocolTCPUDP(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-tcpudp.yml")
+	requireErrContains(t, err, "only tcp protocol is currently supported")
+}
+
+func TestManifestLoadNLBBadScheme(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-scheme.yml")
+	requireErrContains(t, err, "scheme must be public or internal")
+}
+
+func TestManifestLoadNLBPortZero(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-port-zero.yml")
+	requireErrContains(t, err, "out of range")
+}
+
+func TestManifestLoadNLBPortTooHigh(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-port-too-high.yml")
+	requireErrContains(t, err, "out of range")
+}
+
+func TestManifestLoadNLBAgentConflict(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-agent.yml")
+	requireErrContains(t, err, "agent mode is incompatible with nlb ports")
+}
+
+func TestManifestLoadNLBDefaults(t *testing.T) {
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := m.Service("api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.NLB[0].Protocol != "tcp" {
+		t.Errorf("default protocol = %q, want tcp", s.NLB[0].Protocol)
+	}
+	if s.NLB[0].Scheme != "public" {
+		t.Errorf("default scheme = %q, want public", s.NLB[0].Scheme)
+	}
+	if s.NLB[0].ContainerPort != 8443 {
+		t.Errorf("default containerPort = %d, want 8443", s.NLB[0].ContainerPort)
+	}
+}
+
+func TestManifestLoadNLBCaseInsensitive(t *testing.T) {
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        protocol: TCP
+        scheme: Public
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, _ := m.Service("api")
+	if s.NLB[0].Protocol != "tcp" {
+		t.Errorf("protocol should be normalized: got %q", s.NLB[0].Protocol)
+	}
+	if s.NLB[0].Scheme != "public" {
+		t.Errorf("scheme should be normalized: got %q", s.NLB[0].Scheme)
+	}
+}
+
+func TestManifestLoadNLBDifferentContainerPort(t *testing.T) {
+	m, err := loadFixture(t, "nlb-different-container-port.yml")
+	if err != nil {
+		t.Fatalf("valid manifest failed to load: %v", err)
+	}
+	s, _ := m.Service("api")
+	if s.NLB[0].Port != 8443 || s.NLB[0].ContainerPort != 3000 {
+		t.Errorf("expected port=8443, containerPort=3000, got %+v", s.NLB[0])
+	}
+}
+
+func TestManifestLoadNLBNullAndEmpty(t *testing.T) {
+	// nlb: null
+	m1, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s1, _ := m1.Service("api")
+	if len(s1.NLB) != 0 {
+		t.Errorf("nlb: null should yield empty slice, got %+v", s1.NLB)
+	}
+
+	// nlb: []
+	m2, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb: []
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, _ := m2.Service("api")
+	if len(s2.NLB) != 0 {
+		t.Errorf("nlb: [] should yield empty slice, got %+v", s2.NLB)
+	}
+}
+
+func TestManifestLoadNLBCoexistsWithALBPort(t *testing.T) {
+	// port:3000/http on ALB + NLB listener on 3000 targeting same container port — allowed
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    port: http:3000
+    nlb:
+      - port: 3000
+`))
+	if err != nil {
+		t.Fatalf("expected ALB+NLB on same port to be allowed: %v", err)
+	}
+	s, _ := m.Service("api")
+	if len(s.NLB) != 1 || s.NLB[0].Port != 3000 {
+		t.Errorf("expected 1 NLB port=3000, got %+v", s.NLB)
+	}
+}

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -23,6 +23,7 @@ type Service struct {
 	Internal            bool               `yaml:"internal,omitempty"`
 	InternalAndExternal bool               `yaml:"internalAndExternal,omitempty"`
 	Links               []string           `yaml:"links,omitempty"`
+	NLB                 []ServiceNLBPort   `yaml:"nlb,omitempty"`
 	Policies            []string           `yaml:"policies,omitempty"`
 	Port                ServicePort        `yaml:"port,omitempty"`
 	Privileged          bool               `yaml:"privileged,omitempty"`
@@ -46,6 +47,13 @@ type ServiceAgent struct {
 type ServiceAgentPort struct {
 	Port     int    `yaml:"port,omitempty"`
 	Protocol string `yaml:"protocol,omitempty"`
+}
+
+type ServiceNLBPort struct {
+	Port          int    `yaml:"port"`
+	Protocol      string `yaml:"protocol,omitempty"`
+	ContainerPort int    `yaml:"containerPort,omitempty"`
+	Scheme        string `yaml:"scheme,omitempty"`
 }
 
 type ServiceBuild struct {

--- a/pkg/manifest/testdata/invalid-nlb-agent.yml
+++ b/pkg/manifest/testdata/invalid-nlb-agent.yml
@@ -1,0 +1,7 @@
+services:
+  api:
+    image: example/api
+    agent:
+      enabled: true
+    nlb:
+      - port: 8443

--- a/pkg/manifest/testdata/invalid-nlb-bad-proto.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-proto.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        protocol: udp

--- a/pkg/manifest/testdata/invalid-nlb-bad-scheme.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-scheme.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        scheme: bogus

--- a/pkg/manifest/testdata/invalid-nlb-bad-tcpudp.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-tcpudp.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        protocol: tcp_udp

--- a/pkg/manifest/testdata/invalid-nlb-bad-tls.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-tls.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        protocol: tls

--- a/pkg/manifest/testdata/invalid-nlb-conflicting-container-port.yml
+++ b/pkg/manifest/testdata/invalid-nlb-conflicting-container-port.yml
@@ -1,0 +1,8 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        containerPort: 3000
+      - port: 8443
+        containerPort: 4000

--- a/pkg/manifest/testdata/invalid-nlb-dup-port.yml
+++ b/pkg/manifest/testdata/invalid-nlb-dup-port.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+      - port: 8443

--- a/pkg/manifest/testdata/invalid-nlb-port-too-high.yml
+++ b/pkg/manifest/testdata/invalid-nlb-port-too-high.yml
@@ -1,0 +1,5 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 65536

--- a/pkg/manifest/testdata/invalid-nlb-port-zero.yml
+++ b/pkg/manifest/testdata/invalid-nlb-port-zero.yml
@@ -1,0 +1,5 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 0

--- a/pkg/manifest/testdata/nlb-different-container-port.yml
+++ b/pkg/manifest/testdata/nlb-different-container-port.yml
@@ -1,0 +1,7 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        containerPort: 3000
+        scheme: public

--- a/pkg/manifest/testdata/nlb.yml
+++ b/pkg/manifest/testdata/nlb.yml
@@ -1,0 +1,13 @@
+services:
+  api:
+    image: example/api
+    port: http:3000
+    nlb:
+      - port: 8443
+        protocol: tcp
+        containerPort: 8443
+        scheme: public
+      - port: 50051
+        protocol: tcp
+        containerPort: 50051
+        scheme: internal


### PR DESCRIPTION
## Summary

Adds the convox.yml `nlb:` schema (TCP-only in v1) and validation for services. This is the first of four PRs introducing rack-level NLB support; on its own it is behaviorally inert — the new field is stored on the manifest but no CloudFormation resources reference it yet.

## Scope

- New `ServiceNLBPort` type with fields `port`, `protocol`, `containerPort`, `scheme`
- New `NLB []ServiceNLBPort` field on `Service` (YAML tag `nlb,omitempty`)
- `ApplyDefaults()` normalizes `protocol`/`scheme` to lowercase, defaults `protocol=tcp`, `scheme=public`, `containerPort=port`
- `Validate()` enforces: port range 1..65535, `tcp`-only protocol, `public`/`internal` scheme, no duplicate ports within a service, no agent+nlb combination
- Unit tests with 5 testdata fixtures plus inline-YAML cases for defaults and case normalization

## Example convox.yml

```yaml
services:
  api:
    image: example/api
    port: http:3000
    nlb:
      - port: 8443
        protocol: tcp
        containerPort: 8443
        scheme: public
      - port: 50051
        protocol: tcp
        containerPort: 50051
        scheme: internal
```

## Backward compatibility

- Strictly additive: `NLB` field is a nil slice when absent; YAML tag has `omitempty` so marshal output is unchanged for services that don't use NLB
- Gen1 manifest package (`pkg/manifest1/`) is not modified
- No CloudFormation, provider, or runtime behavior change in this PR
- Older rack versions reading a convox.yml with `nlb:` silently drop the unknown field (`yaml.v2.Unmarshal` non-strict)
