### PR TITLE
Nlb rack cf

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -212,6 +212,33 @@ func (m *Manifest) Validate() error {
 		if !nameValidator.MatchString(s.Name) {
 			return fmt.Errorf("service name %s invalid, %s", s.Name, ValidNameDescription)
 		}
+
+		if len(s.NLB) > 0 && s.Agent.Enabled {
+			return fmt.Errorf("service %s: agent mode is incompatible with nlb ports", s.Name)
+		}
+
+		seenPorts := map[int]int{}
+		for _, np := range s.NLB {
+			if np.Port < 1 || np.Port > 65535 {
+				return fmt.Errorf("service %s: nlb port %d out of range", s.Name, np.Port)
+			}
+			if np.ContainerPort < 1 || np.ContainerPort > 65535 {
+				return fmt.Errorf("service %s: nlb containerPort %d out of range", s.Name, np.ContainerPort)
+			}
+			if np.Protocol != "tcp" {
+				return fmt.Errorf("service %s nlb port %d: only tcp protocol is currently supported", s.Name, np.Port)
+			}
+			if np.Scheme != "public" && np.Scheme != "internal" {
+				return fmt.Errorf("service %s nlb port %d: scheme must be public or internal, got %q", s.Name, np.Port, np.Scheme)
+			}
+			if existing, ok := seenPorts[np.Port]; ok {
+				if existing != np.ContainerPort {
+					return fmt.Errorf("service %s: nlb port %d declared with conflicting containerPort values", s.Name, np.Port)
+				}
+				return fmt.Errorf("service %s: duplicate nlb port %d", s.Name, np.Port)
+			}
+			seenPorts[np.Port] = np.ContainerPort
+		}
 	}
 
 	for _, r := range m.Resources {
@@ -334,6 +361,21 @@ func (m *Manifest) ApplyDefaults() error {
 
 		if s.InternalAndExternal {
 			m.Services[i].Internal = true
+		}
+
+		for j := range m.Services[i].NLB {
+			np := &m.Services[i].NLB[j]
+			np.Protocol = strings.ToLower(np.Protocol)
+			if np.Protocol == "" {
+				np.Protocol = "tcp"
+			}
+			np.Scheme = strings.ToLower(np.Scheme)
+			if np.Scheme == "" {
+				np.Scheme = "public"
+			}
+			if np.ContainerPort == 0 {
+				np.ContainerPort = np.Port
+			}
 		}
 	}
 

--- a/pkg/manifest/nlb_test.go
+++ b/pkg/manifest/nlb_test.go
@@ -1,0 +1,206 @@
+package manifest_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/convox/rack/pkg/manifest"
+)
+
+// loadBytes is a test helper that loads a manifest from bytes and returns the manifest and error.
+func loadBytes(t *testing.T, data []byte) (*manifest.Manifest, error) {
+	t.Helper()
+	return manifest.Load(data, nil)
+}
+
+// loadFixture reads a named testdata file and loads it.
+func loadFixture(t *testing.T, name string) (*manifest.Manifest, error) {
+	t.Helper()
+	data, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return manifest.Load(data, nil)
+}
+
+// requireErrContains asserts err is non-nil and its message contains the substring.
+func requireErrContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected error containing %q, got %q", want, err.Error())
+	}
+}
+
+func TestManifestLoadNLB(t *testing.T) {
+	m, err := loadFixture(t, "nlb.yml")
+	if err != nil {
+		t.Fatalf("valid nlb manifest failed to load: %v", err)
+	}
+	s, err := m.Service("api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.NLB) != 2 {
+		t.Fatalf("expected 2 nlb ports, got %d", len(s.NLB))
+	}
+	if s.NLB[0].Port != 8443 || s.NLB[0].Protocol != "tcp" || s.NLB[0].ContainerPort != 8443 || s.NLB[0].Scheme != "public" {
+		t.Errorf("nlb[0] mismatch: %+v", s.NLB[0])
+	}
+	if s.NLB[1].Scheme != "internal" {
+		t.Errorf("nlb[1].Scheme = %q, want internal", s.NLB[1].Scheme)
+	}
+}
+
+func TestManifestLoadNLBDuplicatePort(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-dup-port.yml")
+	requireErrContains(t, err, "duplicate nlb port 8443")
+}
+
+func TestManifestLoadNLBConflictingContainerPort(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-conflicting-container-port.yml")
+	requireErrContains(t, err, "conflicting containerPort")
+}
+
+func TestManifestLoadNLBBadProtocolUDP(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-proto.yml")
+	requireErrContains(t, err, "only tcp protocol is currently supported")
+}
+
+func TestManifestLoadNLBBadProtocolTLS(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-tls.yml")
+	requireErrContains(t, err, "only tcp protocol is currently supported")
+}
+
+func TestManifestLoadNLBBadProtocolTCPUDP(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-tcpudp.yml")
+	requireErrContains(t, err, "only tcp protocol is currently supported")
+}
+
+func TestManifestLoadNLBBadScheme(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-scheme.yml")
+	requireErrContains(t, err, "scheme must be public or internal")
+}
+
+func TestManifestLoadNLBPortZero(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-port-zero.yml")
+	requireErrContains(t, err, "out of range")
+}
+
+func TestManifestLoadNLBPortTooHigh(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-port-too-high.yml")
+	requireErrContains(t, err, "out of range")
+}
+
+func TestManifestLoadNLBAgentConflict(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-agent.yml")
+	requireErrContains(t, err, "agent mode is incompatible with nlb ports")
+}
+
+func TestManifestLoadNLBDefaults(t *testing.T) {
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := m.Service("api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.NLB[0].Protocol != "tcp" {
+		t.Errorf("default protocol = %q, want tcp", s.NLB[0].Protocol)
+	}
+	if s.NLB[0].Scheme != "public" {
+		t.Errorf("default scheme = %q, want public", s.NLB[0].Scheme)
+	}
+	if s.NLB[0].ContainerPort != 8443 {
+		t.Errorf("default containerPort = %d, want 8443", s.NLB[0].ContainerPort)
+	}
+}
+
+func TestManifestLoadNLBCaseInsensitive(t *testing.T) {
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        protocol: TCP
+        scheme: Public
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, _ := m.Service("api")
+	if s.NLB[0].Protocol != "tcp" {
+		t.Errorf("protocol should be normalized: got %q", s.NLB[0].Protocol)
+	}
+	if s.NLB[0].Scheme != "public" {
+		t.Errorf("scheme should be normalized: got %q", s.NLB[0].Scheme)
+	}
+}
+
+func TestManifestLoadNLBDifferentContainerPort(t *testing.T) {
+	m, err := loadFixture(t, "nlb-different-container-port.yml")
+	if err != nil {
+		t.Fatalf("valid manifest failed to load: %v", err)
+	}
+	s, _ := m.Service("api")
+	if s.NLB[0].Port != 8443 || s.NLB[0].ContainerPort != 3000 {
+		t.Errorf("expected port=8443, containerPort=3000, got %+v", s.NLB[0])
+	}
+}
+
+func TestManifestLoadNLBNullAndEmpty(t *testing.T) {
+	// nlb: null
+	m1, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s1, _ := m1.Service("api")
+	if len(s1.NLB) != 0 {
+		t.Errorf("nlb: null should yield empty slice, got %+v", s1.NLB)
+	}
+
+	// nlb: []
+	m2, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb: []
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, _ := m2.Service("api")
+	if len(s2.NLB) != 0 {
+		t.Errorf("nlb: [] should yield empty slice, got %+v", s2.NLB)
+	}
+}
+
+func TestManifestLoadNLBCoexistsWithALBPort(t *testing.T) {
+	// port:3000/http on ALB + NLB listener on 3000 targeting same container port — allowed
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    port: http:3000
+    nlb:
+      - port: 3000
+`))
+	if err != nil {
+		t.Fatalf("expected ALB+NLB on same port to be allowed: %v", err)
+	}
+	s, _ := m.Service("api")
+	if len(s.NLB) != 1 || s.NLB[0].Port != 3000 {
+		t.Errorf("expected 1 NLB port=3000, got %+v", s.NLB)
+	}
+}

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -23,6 +23,7 @@ type Service struct {
 	Internal            bool               `yaml:"internal,omitempty"`
 	InternalAndExternal bool               `yaml:"internalAndExternal,omitempty"`
 	Links               []string           `yaml:"links,omitempty"`
+	NLB                 []ServiceNLBPort   `yaml:"nlb,omitempty"`
 	Policies            []string           `yaml:"policies,omitempty"`
 	Port                ServicePort        `yaml:"port,omitempty"`
 	Privileged          bool               `yaml:"privileged,omitempty"`
@@ -46,6 +47,13 @@ type ServiceAgent struct {
 type ServiceAgentPort struct {
 	Port     int    `yaml:"port,omitempty"`
 	Protocol string `yaml:"protocol,omitempty"`
+}
+
+type ServiceNLBPort struct {
+	Port          int    `yaml:"port"`
+	Protocol      string `yaml:"protocol,omitempty"`
+	ContainerPort int    `yaml:"containerPort,omitempty"`
+	Scheme        string `yaml:"scheme,omitempty"`
 }
 
 type ServiceBuild struct {

--- a/pkg/manifest/testdata/invalid-nlb-agent.yml
+++ b/pkg/manifest/testdata/invalid-nlb-agent.yml
@@ -1,0 +1,7 @@
+services:
+  api:
+    image: example/api
+    agent:
+      enabled: true
+    nlb:
+      - port: 8443

--- a/pkg/manifest/testdata/invalid-nlb-bad-proto.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-proto.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        protocol: udp

--- a/pkg/manifest/testdata/invalid-nlb-bad-scheme.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-scheme.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        scheme: bogus

--- a/pkg/manifest/testdata/invalid-nlb-bad-tcpudp.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-tcpudp.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        protocol: tcp_udp

--- a/pkg/manifest/testdata/invalid-nlb-bad-tls.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-tls.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        protocol: tls

--- a/pkg/manifest/testdata/invalid-nlb-conflicting-container-port.yml
+++ b/pkg/manifest/testdata/invalid-nlb-conflicting-container-port.yml
@@ -1,0 +1,8 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        containerPort: 3000
+      - port: 8443
+        containerPort: 4000

--- a/pkg/manifest/testdata/invalid-nlb-dup-port.yml
+++ b/pkg/manifest/testdata/invalid-nlb-dup-port.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+      - port: 8443

--- a/pkg/manifest/testdata/invalid-nlb-port-too-high.yml
+++ b/pkg/manifest/testdata/invalid-nlb-port-too-high.yml
@@ -1,0 +1,5 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 65536

--- a/pkg/manifest/testdata/invalid-nlb-port-zero.yml
+++ b/pkg/manifest/testdata/invalid-nlb-port-zero.yml
@@ -1,0 +1,5 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 0

--- a/pkg/manifest/testdata/nlb-different-container-port.yml
+++ b/pkg/manifest/testdata/nlb-different-container-port.yml
@@ -1,0 +1,7 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        containerPort: 3000
+        scheme: public

--- a/pkg/manifest/testdata/nlb.yml
+++ b/pkg/manifest/testdata/nlb.yml
@@ -1,0 +1,13 @@
+services:
+  api:
+    image: example/api
+    port: http:3000
+    nlb:
+      - port: 8443
+        protocol: tcp
+        containerPort: 8443
+        scheme: public
+      - port: 50051
+        protocol: tcp
+        containerPort: 50051
+        scheme: internal

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -71,6 +71,8 @@ type Provider struct {
 	ELBLogBucket                      string
 	LogBucket                         string
 	LogDriver                         string
+	NLB                               bool
+	NLBInternal                       bool
 	NotificationTopic                 string
 	OnDemandMinCount                  int
 	Password                          string
@@ -172,6 +174,8 @@ func (p *Provider) loadParams() error {
 	p.LogBucket = labels["rack.LogBucket"]
 	p.LogDriver = labels["rack.LogDriver"]
 	p.MaintainTimerState = labels["rack.MaintainTimerState"] == "Yes"
+	p.NLB = labels["rack.NLB"] == "Yes"
+	p.NLBInternal = labels["rack.NLBInternal"] == "Yes"
 	p.NotificationTopic = labels["rack.NotificationTopic"]
 	p.OnDemandMinCount = intParam(labels["rack.OnDemandMinCount"], 2)
 	p.Private = labels["rack.Private"] == "Yes"

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -12,6 +12,12 @@
       "Fn::And": [ { "Condition": "BlankExistingVpc" }, { "Condition": "ThirdAvailabilityZone" } ]
     },
     "HasEcsContainerStopTimeout": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "EcsContainerStopTimeout" }, "" ] } ] } ,
+    "HasNLB": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "NLB" }, "No" ] } ] },
+    "HasNLBInternal": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "NLBInternal" }, "No" ] } ] },
+    "HasNLBAndThirdAZAndHA": { "Fn::And": [
+      { "Condition": "HasNLB" },
+      { "Condition": "ThirdAvailabilityZoneAndHighAvailability" }
+    ] },
     "BlankInstanceBootCommand": { "Fn::Equals": [ { "Ref": "InstanceBootCommand" }, "" ] },
     "BlankInstancePolicy": { "Fn::Equals": [ { "Ref": "InstancePolicy" }, "" ] },
     "BlankInstanceRunCommand": { "Fn::Equals": [ { "Ref": "InstanceRunCommand" }, "" ] },
@@ -429,6 +435,51 @@
           ""
         ]
       }
+    },
+    "NLBArn": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBArn" } },
+      "Value": { "Ref": "NLBRouter" }
+    },
+    "NLBCanonicalHostedZoneID": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBCanonicalHostedZoneID" } },
+      "Value": { "Fn::GetAtt": [ "NLBRouter", "CanonicalHostedZoneID" ] }
+    },
+    "NLBEIP0": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBEIP0" } },
+      "Value": { "Ref": "NLBAddress0" }
+    },
+    "NLBEIP1": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBEIP1" } },
+      "Value": { "Ref": "NLBAddress1" }
+    },
+    "NLBEIP2": {
+      "Condition": "HasNLBAndThirdAZAndHA",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBEIP2" } },
+      "Value": { "Ref": "NLBAddress2" }
+    },
+    "NLBHost": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBHost" } },
+      "Value": { "Fn::GetAtt": [ "NLBRouter", "DNSName" ] }
+    },
+    "NLBInternalArn": {
+      "Condition": "HasNLBInternal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBInternalArn" } },
+      "Value": { "Ref": "NLBRouterInternal" }
+    },
+    "NLBInternalCanonicalHostedZoneID": {
+      "Condition": "HasNLBInternal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBInternalCanonicalHostedZoneID" } },
+      "Value": { "Fn::GetAtt": [ "NLBRouterInternal", "CanonicalHostedZoneID" ] }
+    },
+    "NLBInternalHost": {
+      "Condition": "HasNLBInternal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBInternalHost" } },
+      "Value": { "Fn::GetAtt": [ "NLBRouterInternal", "DNSName" ] }
     },
     "NotificationTopic": {
       "Value": { "Ref": "NotificationTopic" }
@@ -945,6 +996,18 @@
       "Default": "3",
       "AllowedValues": [ "2", "3" ]
     },
+    "NLB": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ],
+      "Description": "Create a public Network Load Balancer for services that opt in"
+    },
+    "NLBInternal": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ],
+      "Description": "Create an internal Network Load Balancer for services that opt in (requires Internal=Yes)"
+    },
     "NoHAAutoscaleExtra": {
       "Type": "Number",
       "Description": "When HighAvailability is set to false, the autoscale will maintain a certain number of extra capacity instances running on racks that are not configured for high availability",
@@ -1457,6 +1520,30 @@
       "Type": "AWS::EC2::EIP",
       "Properties": {
         "Domain": "vpc"
+      }
+    },
+    "NLBAddress0": {
+      "Type": "AWS::EC2::EIP",
+      "Condition": "HasNLB",
+      "Properties": {
+        "Domain": "vpc",
+        "Tags": [ { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } } ]
+      }
+    },
+    "NLBAddress1": {
+      "Type": "AWS::EC2::EIP",
+      "Condition": "HasNLB",
+      "Properties": {
+        "Domain": "vpc",
+        "Tags": [ { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } } ]
+      }
+    },
+    "NLBAddress2": {
+      "Type": "AWS::EC2::EIP",
+      "Condition": "HasNLBAndThirdAZAndHA",
+      "Properties": {
+        "Domain": "vpc",
+        "Tags": [ { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } } ]
       }
     },
     "SecureEnvironmentRole": {
@@ -3650,6 +3737,54 @@
         ]
       }
     },
+    "NLBRouter": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Condition": "HasNLB",
+      "Properties": {
+        "Type": "network",
+        "Scheme": "internet-facing",
+        "SubnetMappings": [
+          { "SubnetId": { "Ref": "Subnet0" }, "AllocationId": { "Fn::GetAtt": [ "NLBAddress0", "AllocationId" ] } },
+          { "SubnetId": { "Ref": "Subnet1" }, "AllocationId": { "Fn::GetAtt": [ "NLBAddress1", "AllocationId" ] } },
+          { "Fn::If": [ "HasNLBAndThirdAZAndHA",
+            { "SubnetId": { "Ref": "Subnet2" }, "AllocationId": { "Fn::GetAtt": [ "NLBAddress2", "AllocationId" ] } },
+            { "Ref": "AWS::NoValue" }
+          ] }
+        ],
+        "Tags": [
+          { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } }
+        ]
+      }
+    },
+    "NLBRouterInternal": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Condition": "HasNLBInternal",
+      "Properties": {
+        "Type": "network",
+        "Scheme": "internal",
+        "SubnetMappings": { "Fn::If": [ "Private",
+          [
+            { "SubnetId": { "Ref": "SubnetPrivate0" } },
+            { "SubnetId": { "Ref": "SubnetPrivate1" } },
+            { "Fn::If": [ "ThirdAvailabilityZoneAndHighAvailability",
+              { "SubnetId": { "Ref": "SubnetPrivate2" } },
+              { "Ref": "AWS::NoValue" }
+            ] }
+          ],
+          [
+            { "SubnetId": { "Ref": "Subnet0" } },
+            { "SubnetId": { "Ref": "Subnet1" } },
+            { "Fn::If": [ "ThirdAvailabilityZoneAndHighAvailability",
+              { "SubnetId": { "Ref": "Subnet2" } },
+              { "Ref": "AWS::NoValue" }
+            ] }
+          ]
+        ] },
+        "Tags": [
+          { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } }
+        ]
+      }
+    },
     "ApiBalancer": {
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "DependsOn": [ "ApiRole", "LogsPolicy" ],
@@ -4065,6 +4200,8 @@
               "rack.Internal": { "Ref": "Internal" },
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
+              "rack.NLB": { "Ref": "NLB" },
+              "rack.NLBInternal": { "Ref": "NLBInternal" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
@@ -4201,6 +4338,8 @@
               "rack.Internal": { "Ref": "Internal" },
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
+              "rack.NLB": { "Ref": "NLB" },
+              "rack.NLBInternal": { "Ref": "NLBInternal" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
@@ -4329,6 +4468,8 @@
               "rack.Internal": { "Ref": "Internal" },
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
+              "rack.NLB": { "Ref": "NLB" },
+              "rack.NLBInternal": { "Ref": "NLBInternal" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
@@ -4479,6 +4620,8 @@
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
               "rack.MaintainTimerState": { "Ref": "MaintainTimerState" },
+              "rack.NLB": { "Ref": "NLB" },
+              "rack.NLBInternal": { "Ref": "NLBInternal" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },

--- a/provider/aws/system.go
+++ b/provider/aws/system.go
@@ -638,6 +638,10 @@ func (p *Provider) Sync(name string) error {
 }
 
 func (p *Provider) SystemUpdate(opts structs.SystemUpdateOptions) error {
+	if err := p.validateNLBParams(opts); err != nil {
+		return err
+	}
+
 	changes := map[string]string{}
 	hasOtherChange := false
 

--- a/provider/aws/system_nlb.go
+++ b/provider/aws/system_nlb.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/convox/rack/pkg/manifest"
+	"github.com/convox/rack/pkg/structs"
+)
+
+// appsUsingNLBScheme returns the list of gen2 apps on the rack whose current running release
+// declares at least one service with an NLB port of the given scheme ("public" or "internal").
+// Returns entries formatted as "app/service".
+//
+// Fails open on per-app errors (logs a warning and continues) so a single broken release does
+// not block rack-wide operations.
+func (p *Provider) appsUsingNLBScheme(scheme string) ([]string, error) {
+	log := p.logger("appsUsingNLBScheme")
+
+	apps, err := p.AppList()
+	if err != nil {
+		return nil, err
+	}
+
+	var blockers []string
+	for _, a := range apps {
+		if a.Tags["Generation"] != "2" {
+			continue
+		}
+		if a.Release == "" {
+			continue
+		}
+		r, err := p.ReleaseGet(a.Name, a.Release)
+		if err != nil {
+			log.Logf("warning: skipped app=%s err=%v", a.Name, err)
+			continue
+		}
+		if r.Manifest == "" {
+			continue
+		}
+		m, err := manifest.Load([]byte(r.Manifest), nil)
+		if err != nil {
+			log.Logf("warning: skipped app=%s manifest parse failed err=%v", a.Name, err)
+			continue
+		}
+		for _, s := range m.Services {
+			for _, np := range s.NLB {
+				if np.Scheme == scheme {
+					blockers = append(blockers, fmt.Sprintf("%s/%s", a.Name, s.Name))
+					break
+				}
+			}
+		}
+	}
+	return blockers, nil
+}
+
+// validateNLBParams enforces the NLB rack-param rules:
+//   - NLB=Yes incompatible with InternalOnly=Yes
+//   - NLBInternal=Yes requires Internal=Yes (either already set or set in the same call)
+//   - Disabling NLB/NLBInternal requires no dependent gen2 apps
+func (p *Provider) validateNLBParams(opts structs.SystemUpdateOptions) error {
+	want := func(key string) (string, bool) {
+		if opts.Parameters == nil {
+			return "", false
+		}
+		v, ok := opts.Parameters[key]
+		return v, ok
+	}
+
+	yesNo := func(b bool) string {
+		if b {
+			return "Yes"
+		}
+		return "No"
+	}
+
+	currentNLB := yesNo(p.NLB)
+	currentNLBInternal := yesNo(p.NLBInternal)
+	currentInternal := yesNo(p.Internal)
+	currentInternalOnly := yesNo(p.InternalOnly)
+
+	nextNLB, nlbSet := want("NLB")
+	if !nlbSet {
+		nextNLB = currentNLB
+	}
+	nextNLBInternal, nlbiSet := want("NLBInternal")
+	if !nlbiSet {
+		nextNLBInternal = currentNLBInternal
+	}
+	nextInternal, internalSet := want("Internal")
+	if !internalSet {
+		nextInternal = currentInternal
+	}
+	nextInternalOnly, _ := want("InternalOnly")
+	if nextInternalOnly == "" {
+		nextInternalOnly = currentInternalOnly
+	}
+
+	if nextNLB == "Yes" && nextInternalOnly == "Yes" {
+		return fmt.Errorf("cannot enable public NLB on an InternalOnly rack; use NLBInternal instead")
+	}
+
+	if nextNLBInternal == "Yes" && nextInternal != "Yes" {
+		return fmt.Errorf("cannot enable NLBInternal on a rack without Internal=Yes; set Internal=Yes in the same command")
+	}
+
+	if nlbSet && currentNLB == "Yes" && nextNLB == "No" {
+		blockers, err := p.appsUsingNLBScheme("public")
+		if err != nil {
+			return err
+		}
+		if len(blockers) > 0 {
+			sort.Strings(blockers)
+			return fmt.Errorf("cannot disable NLB: apps %s still declare public nlb ports; remove nlb: from their manifests and redeploy first", strings.Join(blockers, ", "))
+		}
+	}
+
+	if nlbiSet && currentNLBInternal == "Yes" && nextNLBInternal == "No" {
+		blockers, err := p.appsUsingNLBScheme("internal")
+		if err != nil {
+			return err
+		}
+		if len(blockers) > 0 {
+			sort.Strings(blockers)
+			return fmt.Errorf("cannot disable NLBInternal: apps %s still declare internal nlb ports; remove nlb: from their manifests and redeploy first", strings.Join(blockers, ", "))
+		}
+	}
+
+	return nil
+}

--- a/provider/aws/system_nlb_test.go
+++ b/provider/aws/system_nlb_test.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/convox/rack/pkg/structs"
+)
+
+func TestValidateNLBParams_InternalOnlyConflict(t *testing.T) {
+	p := &Provider{InternalOnly: true}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{Parameters: map[string]string{"NLB": "Yes"}})
+	if err == nil {
+		t.Fatal("expected error enabling NLB on InternalOnly rack")
+	}
+}
+
+func TestValidateNLBParams_InternalOnlyCompatible(t *testing.T) {
+	p := &Provider{InternalOnly: true, Internal: true}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{Parameters: map[string]string{"NLBInternal": "Yes"}})
+	if err != nil {
+		t.Fatalf("InternalOnly+Internal+NLBInternal should pass: %v", err)
+	}
+}
+
+func TestValidateNLBParams_InternalRequiredForNLBInternal(t *testing.T) {
+	p := &Provider{Internal: false}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{Parameters: map[string]string{"NLBInternal": "Yes"}})
+	if err == nil {
+		t.Fatal("expected error enabling NLBInternal without Internal=Yes")
+	}
+}
+
+func TestValidateNLBParams_InternalAndNLBInternalSameCall(t *testing.T) {
+	p := &Provider{Internal: false}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{
+		Parameters: map[string]string{"Internal": "Yes", "NLBInternal": "Yes"},
+	})
+	if err != nil {
+		t.Fatalf("expected Internal+NLBInternal together to pass: %v", err)
+	}
+}
+
+func TestValidateNLBParams_NoNLBParamChange(t *testing.T) {
+	p := &Provider{}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{Parameters: map[string]string{"Foo": "bar"}})
+	if err != nil {
+		t.Fatalf("non-NLB param change should not error: %v", err)
+	}
+}
+
+func TestValidateNLBParams_NilParameters(t *testing.T) {
+	p := &Provider{}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{})
+	if err != nil {
+		t.Fatalf("nil parameters should not error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds rack-level NLB infrastructure to V2 racks. Introduces two rack parameters (`NLB`, `NLBInternal`, both default `No`), conditional CloudFormation resources for public + internal Network Load Balancers with SubnetMappings and EIPs, stack outputs exporting NLB DNS and EIPs, Docker labels propagating NLB state to the rack API, and Go-side validation for rack parameter transitions. Services do not yet consume the NLBs — that lands in PR 3.

## CloudFormation changes (rack.json)

**New parameters:**
- `NLB` — `String`, default `No`, allowed `Yes/No`. Creates a public Network Load Balancer.
- `NLBInternal` — `String`, default `No`, allowed `Yes/No`. Creates an internal NLB. Requires `Internal=Yes`.

**New conditions:**
- `HasNLB` — true when `NLB != No`
- `HasNLBInternal` — true when `NLBInternal != No`
- `HasNLBAndThirdAZAndHA` — `HasNLB` ∧ existing `ThirdAvailabilityZoneAndHighAvailability`

**New resources:**
- `NLBAddress0/1/2` — `AWS::EC2::EIP`, tagged with rack name. Address2 conditional on HasNLBAndThirdAZAndHA.
- `NLBRouter` — `AWS::ElasticLoadBalancingV2::LoadBalancer` (Type: network, Scheme: internet-facing). Uses `SubnetMappings` with AllocationIds from the EIPs. No `DependsOn`, no `LoadBalancerAttributes` (v1 accepts AWS defaults: cross-zone off, no deletion protection, TCP idle timeout 350s). Phase 2 adds access logs, cross-zone toggle, idle-timeout param.
- `NLBRouterInternal` — internal scheme, `SubnetMappings` branched on `Private` (private subnets when `Private=Yes`, public subnets otherwise), no EIPs.

**New outputs (all with `${Rack}:<name>` exports):**
- Public NLB: `NLBArn`, `NLBHost`, `NLBCanonicalHostedZoneID`, `NLBEIP0`, `NLBEIP1`, `NLBEIP2`
- Internal NLB: `NLBInternalArn`, `NLBInternalHost`, `NLBInternalCanonicalHostedZoneID`

**Docker labels (4 task-def blocks):**
- `rack.NLB` → `{ "Ref": "NLB" }`
- `rack.NLBInternal` → `{ "Ref": "NLBInternal" }`

## Go changes

**`provider/aws/aws.go`:**
- `Provider` struct gains `NLB bool` and `NLBInternal bool` fields
- Docker-label parser reads `rack.NLB` and `rack.NLBInternal`

**`provider/aws/system.go` + new `provider/aws/system_nlb.go`:**
- `SystemUpdate()` now calls `validateNLBParams()` before any AWS operations
- Validation rules:
  - `NLB=Yes` rejected when `InternalOnly=Yes`
  - `NLBInternal=Yes` requires `Internal=Yes` (either pre-existing or set in the same call)
  - Disabling `NLB` or `NLBInternal` with dependent gen2 apps is rejected; error lists the blocking `app/service` pairs
  - Gen1 apps explicitly skipped via `Tags["Generation"] != "2"`
  - Fails open on per-app manifest load errors (logs warning, continues scan)
- Uses package-convention logger (`p.logger("appsUsingNLBScheme").Logf`) and sorts blockers list for stable error output

## Backward compatibility

- All new parameters default to `No`; existing racks create zero new resources on upgrade
- Conditions default false; NLB CF resources are not emitted
- Adding `rack.NLB` / `rack.NLBInternal` Docker labels to the 4 ECS task definitions produces a new task definition revision on first upgrade (rolling restart of rack API containers, no user impact — same pattern as previous label additions)
- Docker labels additive — old rack API pods ignore unknown labels (rolling-update coexistence safe)
- No changes to `pkg/structs/`, no new HTTP routes, no SDK methods
- Gen1 untouched
- Downgrade path: user must set `NLB=No NLBInternal=No` and redeploy any apps using NLB before downgrading to a version lacking these parameters. CF will reject the update cleanly if attempted with non-default values.

## Rollout notes

- User's enabling `NLB=Yes` must first verify EIP quota headroom: 2 EIPs for 2-AZ rack, 3 for HA+3-AZ. Default AWS quota is 5 per region. `Private=Yes` already consumes 2-3 EIPs for NAT gateways, so `Private=Yes + NLB=Yes + 3-AZ HA` needs 6 total.
- NLB provisioning typically takes 5-10 minutes; follow-up PR 3 adds a CLI hint on the `Yes` transition.
- No user action required unless explicitly enabling NLB.

## Files changed

- `provider/aws/formation/rack.json` — params, conditions, EIPs, NLB resources, outputs, Docker labels
- `provider/aws/aws.go` — Provider struct fields, label reads
- `provider/aws/system.go` — validateNLBParams call site
- `provider/aws/system_nlb.go` (new) — validateNLBParams, appsUsingNLBScheme
- `provider/aws/system_nlb_test.go` (new) — 6 unit tests
