### PR TITLE
Nlb service cf

### DIFF
--- a/pkg/cli/fixtures_test.go
+++ b/pkg/cli/fixtures_test.go
@@ -327,3 +327,40 @@ func fxSystemInternal() *structs.System {
 		Version:    "20180901000000",
 	}
 }
+
+func fxSystemNLB() *structs.System {
+	return &structs.System{
+		Count:  1,
+		Domain: "domain",
+		Name:   "name",
+		Outputs: map[string]string{
+			"NLBHost": "nlb-host.elb.region.amazonaws.com",
+			"NLBEIP0": "203.0.113.10",
+			"NLBEIP1": "203.0.113.11",
+			"NLBEIP2": "203.0.113.12",
+		},
+		Parameters: map[string]string{"Autoscale": "Yes", "ParamFoo": "value1", "ParamOther": "value2"},
+		Provider:   "provider",
+		Region:     "region",
+		Status:     "running",
+		Type:       "type",
+		Version:    "21000101000000",
+	}
+}
+
+func fxSystemNLBInternal() *structs.System {
+	return &structs.System{
+		Count:  1,
+		Domain: "domain",
+		Name:   "name",
+		Outputs: map[string]string{
+			"NLBInternalHost": "nlb-internal-host.elb.region.amazonaws.com",
+		},
+		Parameters: map[string]string{"Autoscale": "Yes", "ParamFoo": "value1", "ParamOther": "value2"},
+		Provider:   "provider",
+		Region:     "region",
+		Status:     "running",
+		Type:       "type",
+		Version:    "21000101000000",
+	}
+}

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -142,6 +142,23 @@ func Rack(rack sdk.Interface, c *stdcli.Context) error {
 		}
 	}
 
+	if nlb := s.Outputs["NLBHost"]; nlb != "" {
+		var eips []string
+		for _, k := range []string{"NLBEIP0", "NLBEIP1", "NLBEIP2"} {
+			if v := s.Outputs[k]; v != "" {
+				eips = append(eips, v)
+			}
+		}
+		if len(eips) > 0 {
+			i.Add("NLB", fmt.Sprintf("%s (%s)", nlb, strings.Join(eips, ", ")))
+		} else {
+			i.Add("NLB", nlb)
+		}
+	}
+	if nlbi := s.Outputs["NLBInternalHost"]; nlbi != "" {
+		i.Add("NLB Internal", nlbi)
+	}
+
 	i.Add("Status", s.Status)
 	i.Add("Version", s.Version)
 
@@ -349,6 +366,14 @@ func RackParamsSet(rack sdk.Interface, c *stdcli.Context) error {
 	} else {
 		if err := rack.SystemUpdate(opts); err != nil {
 			return err
+		}
+	}
+
+	// If NLB/NLBInternal was just enabled, hint about provisioning time.
+	for _, k := range []string{"NLB", "NLBInternal"} {
+		if next, ok := opts.Parameters[k]; ok && next == "Yes" && s.Parameters[k] != "Yes" {
+			c.Writef("NLB provisioning typically takes 5-10 minutes; check status with 'convox rack'.\n")
+			break
 		}
 	}
 

--- a/pkg/cli/rack_test.go
+++ b/pkg/cli/rack_test.go
@@ -71,6 +71,46 @@ func TestRackInternal(t *testing.T) {
 	})
 }
 
+func TestRackNLB(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystemNLB(), nil)
+
+		res, err := testExecute(e, "rack", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			"Name      name",
+			"Provider  provider",
+			"Region    region",
+			"Router    domain",
+			"NLB       nlb-host.elb.region.amazonaws.com (203.0.113.10, 203.0.113.11, 203.0.113.12)",
+			"Status    running",
+			"Version   21000101000000",
+		})
+	})
+}
+
+func TestRackNLBInternal(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystemNLBInternal(), nil)
+
+		res, err := testExecute(e, "rack", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			"Name          name",
+			"Provider      provider",
+			"Region        region",
+			"Router        domain",
+			"NLB Internal  nlb-internal-host.elb.region.amazonaws.com",
+			"Status        running",
+			"Version       21000101000000",
+		})
+	})
+}
+
 func TestRackInstall(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -212,6 +212,33 @@ func (m *Manifest) Validate() error {
 		if !nameValidator.MatchString(s.Name) {
 			return fmt.Errorf("service name %s invalid, %s", s.Name, ValidNameDescription)
 		}
+
+		if len(s.NLB) > 0 && s.Agent.Enabled {
+			return fmt.Errorf("service %s: agent mode is incompatible with nlb ports", s.Name)
+		}
+
+		seenPorts := map[int]int{}
+		for _, np := range s.NLB {
+			if np.Port < 1 || np.Port > 65535 {
+				return fmt.Errorf("service %s: nlb port %d out of range", s.Name, np.Port)
+			}
+			if np.ContainerPort < 1 || np.ContainerPort > 65535 {
+				return fmt.Errorf("service %s: nlb containerPort %d out of range", s.Name, np.ContainerPort)
+			}
+			if np.Protocol != "tcp" {
+				return fmt.Errorf("service %s nlb port %d: only tcp protocol is currently supported", s.Name, np.Port)
+			}
+			if np.Scheme != "public" && np.Scheme != "internal" {
+				return fmt.Errorf("service %s nlb port %d: scheme must be public or internal, got %q", s.Name, np.Port, np.Scheme)
+			}
+			if existing, ok := seenPorts[np.Port]; ok {
+				if existing != np.ContainerPort {
+					return fmt.Errorf("service %s: nlb port %d declared with conflicting containerPort values", s.Name, np.Port)
+				}
+				return fmt.Errorf("service %s: duplicate nlb port %d", s.Name, np.Port)
+			}
+			seenPorts[np.Port] = np.ContainerPort
+		}
 	}
 
 	for _, r := range m.Resources {
@@ -334,6 +361,21 @@ func (m *Manifest) ApplyDefaults() error {
 
 		if s.InternalAndExternal {
 			m.Services[i].Internal = true
+		}
+
+		for j := range m.Services[i].NLB {
+			np := &m.Services[i].NLB[j]
+			np.Protocol = strings.ToLower(np.Protocol)
+			if np.Protocol == "" {
+				np.Protocol = "tcp"
+			}
+			np.Scheme = strings.ToLower(np.Scheme)
+			if np.Scheme == "" {
+				np.Scheme = "public"
+			}
+			if np.ContainerPort == 0 {
+				np.ContainerPort = np.Port
+			}
 		}
 	}
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -218,6 +218,7 @@ func (m *Manifest) Validate() error {
 		}
 
 		seenPorts := map[int]int{}
+		seenContainerPorts := map[int]bool{}
 		for _, np := range s.NLB {
 			if np.Port < 1 || np.Port > 65535 {
 				return fmt.Errorf("service %s: nlb port %d out of range", s.Name, np.Port)
@@ -237,7 +238,11 @@ func (m *Manifest) Validate() error {
 				}
 				return fmt.Errorf("service %s: duplicate nlb port %d", s.Name, np.Port)
 			}
+			if seenContainerPorts[np.ContainerPort] {
+				return fmt.Errorf("service %s: nlb containerPort %d used by multiple nlb listeners", s.Name, np.ContainerPort)
+			}
 			seenPorts[np.Port] = np.ContainerPort
+			seenContainerPorts[np.ContainerPort] = true
 		}
 	}
 

--- a/pkg/manifest/nlb_test.go
+++ b/pkg/manifest/nlb_test.go
@@ -187,6 +187,21 @@ func TestManifestLoadNLBNullAndEmpty(t *testing.T) {
 	}
 }
 
+func TestManifestLoadNLBDuplicateContainerPort(t *testing.T) {
+	data := []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8080
+        containerPort: 443
+      - port: 9090
+        containerPort: 443
+`)
+	if _, err := manifest.Load(data, nil); err == nil {
+		t.Fatal("expected error for duplicate containerPort across nlb listeners")
+	}
+}
+
 func TestManifestLoadNLBCoexistsWithALBPort(t *testing.T) {
 	// port:3000/http on ALB + NLB listener on 3000 targeting same container port — allowed
 	m, err := loadBytes(t, []byte(`services:

--- a/pkg/manifest/nlb_test.go
+++ b/pkg/manifest/nlb_test.go
@@ -1,0 +1,206 @@
+package manifest_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/convox/rack/pkg/manifest"
+)
+
+// loadBytes is a test helper that loads a manifest from bytes and returns the manifest and error.
+func loadBytes(t *testing.T, data []byte) (*manifest.Manifest, error) {
+	t.Helper()
+	return manifest.Load(data, nil)
+}
+
+// loadFixture reads a named testdata file and loads it.
+func loadFixture(t *testing.T, name string) (*manifest.Manifest, error) {
+	t.Helper()
+	data, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return manifest.Load(data, nil)
+}
+
+// requireErrContains asserts err is non-nil and its message contains the substring.
+func requireErrContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected error containing %q, got %q", want, err.Error())
+	}
+}
+
+func TestManifestLoadNLB(t *testing.T) {
+	m, err := loadFixture(t, "nlb.yml")
+	if err != nil {
+		t.Fatalf("valid nlb manifest failed to load: %v", err)
+	}
+	s, err := m.Service("api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.NLB) != 2 {
+		t.Fatalf("expected 2 nlb ports, got %d", len(s.NLB))
+	}
+	if s.NLB[0].Port != 8443 || s.NLB[0].Protocol != "tcp" || s.NLB[0].ContainerPort != 8443 || s.NLB[0].Scheme != "public" {
+		t.Errorf("nlb[0] mismatch: %+v", s.NLB[0])
+	}
+	if s.NLB[1].Scheme != "internal" {
+		t.Errorf("nlb[1].Scheme = %q, want internal", s.NLB[1].Scheme)
+	}
+}
+
+func TestManifestLoadNLBDuplicatePort(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-dup-port.yml")
+	requireErrContains(t, err, "duplicate nlb port 8443")
+}
+
+func TestManifestLoadNLBConflictingContainerPort(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-conflicting-container-port.yml")
+	requireErrContains(t, err, "conflicting containerPort")
+}
+
+func TestManifestLoadNLBBadProtocolUDP(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-proto.yml")
+	requireErrContains(t, err, "only tcp protocol is currently supported")
+}
+
+func TestManifestLoadNLBBadProtocolTLS(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-tls.yml")
+	requireErrContains(t, err, "only tcp protocol is currently supported")
+}
+
+func TestManifestLoadNLBBadProtocolTCPUDP(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-tcpudp.yml")
+	requireErrContains(t, err, "only tcp protocol is currently supported")
+}
+
+func TestManifestLoadNLBBadScheme(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-bad-scheme.yml")
+	requireErrContains(t, err, "scheme must be public or internal")
+}
+
+func TestManifestLoadNLBPortZero(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-port-zero.yml")
+	requireErrContains(t, err, "out of range")
+}
+
+func TestManifestLoadNLBPortTooHigh(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-port-too-high.yml")
+	requireErrContains(t, err, "out of range")
+}
+
+func TestManifestLoadNLBAgentConflict(t *testing.T) {
+	_, err := loadFixture(t, "invalid-nlb-agent.yml")
+	requireErrContains(t, err, "agent mode is incompatible with nlb ports")
+}
+
+func TestManifestLoadNLBDefaults(t *testing.T) {
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := m.Service("api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.NLB[0].Protocol != "tcp" {
+		t.Errorf("default protocol = %q, want tcp", s.NLB[0].Protocol)
+	}
+	if s.NLB[0].Scheme != "public" {
+		t.Errorf("default scheme = %q, want public", s.NLB[0].Scheme)
+	}
+	if s.NLB[0].ContainerPort != 8443 {
+		t.Errorf("default containerPort = %d, want 8443", s.NLB[0].ContainerPort)
+	}
+}
+
+func TestManifestLoadNLBCaseInsensitive(t *testing.T) {
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        protocol: TCP
+        scheme: Public
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, _ := m.Service("api")
+	if s.NLB[0].Protocol != "tcp" {
+		t.Errorf("protocol should be normalized: got %q", s.NLB[0].Protocol)
+	}
+	if s.NLB[0].Scheme != "public" {
+		t.Errorf("scheme should be normalized: got %q", s.NLB[0].Scheme)
+	}
+}
+
+func TestManifestLoadNLBDifferentContainerPort(t *testing.T) {
+	m, err := loadFixture(t, "nlb-different-container-port.yml")
+	if err != nil {
+		t.Fatalf("valid manifest failed to load: %v", err)
+	}
+	s, _ := m.Service("api")
+	if s.NLB[0].Port != 8443 || s.NLB[0].ContainerPort != 3000 {
+		t.Errorf("expected port=8443, containerPort=3000, got %+v", s.NLB[0])
+	}
+}
+
+func TestManifestLoadNLBNullAndEmpty(t *testing.T) {
+	// nlb: null
+	m1, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s1, _ := m1.Service("api")
+	if len(s1.NLB) != 0 {
+		t.Errorf("nlb: null should yield empty slice, got %+v", s1.NLB)
+	}
+
+	// nlb: []
+	m2, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb: []
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, _ := m2.Service("api")
+	if len(s2.NLB) != 0 {
+		t.Errorf("nlb: [] should yield empty slice, got %+v", s2.NLB)
+	}
+}
+
+func TestManifestLoadNLBCoexistsWithALBPort(t *testing.T) {
+	// port:3000/http on ALB + NLB listener on 3000 targeting same container port — allowed
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    port: http:3000
+    nlb:
+      - port: 3000
+`))
+	if err != nil {
+		t.Fatalf("expected ALB+NLB on same port to be allowed: %v", err)
+	}
+	s, _ := m.Service("api")
+	if len(s.NLB) != 1 || s.NLB[0].Port != 3000 {
+		t.Errorf("expected 1 NLB port=3000, got %+v", s.NLB)
+	}
+}

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -23,6 +23,7 @@ type Service struct {
 	Internal            bool               `yaml:"internal,omitempty"`
 	InternalAndExternal bool               `yaml:"internalAndExternal,omitempty"`
 	Links               []string           `yaml:"links,omitempty"`
+	NLB                 []ServiceNLBPort   `yaml:"nlb,omitempty"`
 	Policies            []string           `yaml:"policies,omitempty"`
 	Port                ServicePort        `yaml:"port,omitempty"`
 	Privileged          bool               `yaml:"privileged,omitempty"`
@@ -46,6 +47,13 @@ type ServiceAgent struct {
 type ServiceAgentPort struct {
 	Port     int    `yaml:"port,omitempty"`
 	Protocol string `yaml:"protocol,omitempty"`
+}
+
+type ServiceNLBPort struct {
+	Port          int    `yaml:"port"`
+	Protocol      string `yaml:"protocol,omitempty"`
+	ContainerPort int    `yaml:"containerPort,omitempty"`
+	Scheme        string `yaml:"scheme,omitempty"`
 }
 
 type ServiceBuild struct {

--- a/pkg/manifest/testdata/invalid-nlb-agent.yml
+++ b/pkg/manifest/testdata/invalid-nlb-agent.yml
@@ -1,0 +1,7 @@
+services:
+  api:
+    image: example/api
+    agent:
+      enabled: true
+    nlb:
+      - port: 8443

--- a/pkg/manifest/testdata/invalid-nlb-bad-proto.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-proto.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        protocol: udp

--- a/pkg/manifest/testdata/invalid-nlb-bad-scheme.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-scheme.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        scheme: bogus

--- a/pkg/manifest/testdata/invalid-nlb-bad-tcpudp.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-tcpudp.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        protocol: tcp_udp

--- a/pkg/manifest/testdata/invalid-nlb-bad-tls.yml
+++ b/pkg/manifest/testdata/invalid-nlb-bad-tls.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        protocol: tls

--- a/pkg/manifest/testdata/invalid-nlb-conflicting-container-port.yml
+++ b/pkg/manifest/testdata/invalid-nlb-conflicting-container-port.yml
@@ -1,0 +1,8 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        containerPort: 3000
+      - port: 8443
+        containerPort: 4000

--- a/pkg/manifest/testdata/invalid-nlb-dup-port.yml
+++ b/pkg/manifest/testdata/invalid-nlb-dup-port.yml
@@ -1,0 +1,6 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+      - port: 8443

--- a/pkg/manifest/testdata/invalid-nlb-port-too-high.yml
+++ b/pkg/manifest/testdata/invalid-nlb-port-too-high.yml
@@ -1,0 +1,5 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 65536

--- a/pkg/manifest/testdata/invalid-nlb-port-zero.yml
+++ b/pkg/manifest/testdata/invalid-nlb-port-zero.yml
@@ -1,0 +1,5 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 0

--- a/pkg/manifest/testdata/nlb-different-container-port.yml
+++ b/pkg/manifest/testdata/nlb-different-container-port.yml
@@ -1,0 +1,7 @@
+services:
+  api:
+    image: example/api
+    nlb:
+      - port: 8443
+        containerPort: 3000
+        scheme: public

--- a/pkg/manifest/testdata/nlb.yml
+++ b/pkg/manifest/testdata/nlb.yml
@@ -1,0 +1,13 @@
+services:
+  api:
+    image: example/api
+    port: http:3000
+    nlb:
+      - port: 8443
+        protocol: tcp
+        containerPort: 8443
+        scheme: public
+      - port: 50051
+        protocol: tcp
+        containerPort: 50051
+        scheme: internal

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -71,6 +71,8 @@ type Provider struct {
 	ELBLogBucket                      string
 	LogBucket                         string
 	LogDriver                         string
+	NLB                               bool
+	NLBInternal                       bool
 	NotificationTopic                 string
 	OnDemandMinCount                  int
 	Password                          string
@@ -172,6 +174,8 @@ func (p *Provider) loadParams() error {
 	p.LogBucket = labels["rack.LogBucket"]
 	p.LogDriver = labels["rack.LogDriver"]
 	p.MaintainTimerState = labels["rack.MaintainTimerState"] == "Yes"
+	p.NLB = labels["rack.NLB"] == "Yes"
+	p.NLBInternal = labels["rack.NLBInternal"] == "Yes"
 	p.NotificationTopic = labels["rack.NotificationTopic"]
 	p.OnDemandMinCount = intParam(labels["rack.OnDemandMinCount"], 2)
 	p.Private = labels["rack.Private"] == "Yes"

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -12,6 +12,12 @@
       "Fn::And": [ { "Condition": "BlankExistingVpc" }, { "Condition": "ThirdAvailabilityZone" } ]
     },
     "HasEcsContainerStopTimeout": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "EcsContainerStopTimeout" }, "" ] } ] } ,
+    "HasNLB": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "NLB" }, "No" ] } ] },
+    "HasNLBInternal": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "NLBInternal" }, "No" ] } ] },
+    "HasNLBAndThirdAZAndHA": { "Fn::And": [
+      { "Condition": "HasNLB" },
+      { "Condition": "ThirdAvailabilityZoneAndHighAvailability" }
+    ] },
     "BlankInstanceBootCommand": { "Fn::Equals": [ { "Ref": "InstanceBootCommand" }, "" ] },
     "BlankInstancePolicy": { "Fn::Equals": [ { "Ref": "InstancePolicy" }, "" ] },
     "BlankInstanceRunCommand": { "Fn::Equals": [ { "Ref": "InstanceRunCommand" }, "" ] },
@@ -429,6 +435,51 @@
           ""
         ]
       }
+    },
+    "NLBArn": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBArn" } },
+      "Value": { "Ref": "NLBRouter" }
+    },
+    "NLBCanonicalHostedZoneID": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBCanonicalHostedZoneID" } },
+      "Value": { "Fn::GetAtt": [ "NLBRouter", "CanonicalHostedZoneID" ] }
+    },
+    "NLBEIP0": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBEIP0" } },
+      "Value": { "Ref": "NLBAddress0" }
+    },
+    "NLBEIP1": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBEIP1" } },
+      "Value": { "Ref": "NLBAddress1" }
+    },
+    "NLBEIP2": {
+      "Condition": "HasNLBAndThirdAZAndHA",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBEIP2" } },
+      "Value": { "Ref": "NLBAddress2" }
+    },
+    "NLBHost": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBHost" } },
+      "Value": { "Fn::GetAtt": [ "NLBRouter", "DNSName" ] }
+    },
+    "NLBInternalArn": {
+      "Condition": "HasNLBInternal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBInternalArn" } },
+      "Value": { "Ref": "NLBRouterInternal" }
+    },
+    "NLBInternalCanonicalHostedZoneID": {
+      "Condition": "HasNLBInternal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBInternalCanonicalHostedZoneID" } },
+      "Value": { "Fn::GetAtt": [ "NLBRouterInternal", "CanonicalHostedZoneID" ] }
+    },
+    "NLBInternalHost": {
+      "Condition": "HasNLBInternal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBInternalHost" } },
+      "Value": { "Fn::GetAtt": [ "NLBRouterInternal", "DNSName" ] }
     },
     "NotificationTopic": {
       "Value": { "Ref": "NotificationTopic" }
@@ -945,6 +996,18 @@
       "Default": "3",
       "AllowedValues": [ "2", "3" ]
     },
+    "NLB": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ],
+      "Description": "Create a public Network Load Balancer for services that opt in"
+    },
+    "NLBInternal": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ],
+      "Description": "Create an internal Network Load Balancer for services that opt in (requires Internal=Yes)"
+    },
     "NoHAAutoscaleExtra": {
       "Type": "Number",
       "Description": "When HighAvailability is set to false, the autoscale will maintain a certain number of extra capacity instances running on racks that are not configured for high availability",
@@ -1457,6 +1520,30 @@
       "Type": "AWS::EC2::EIP",
       "Properties": {
         "Domain": "vpc"
+      }
+    },
+    "NLBAddress0": {
+      "Type": "AWS::EC2::EIP",
+      "Condition": "HasNLB",
+      "Properties": {
+        "Domain": "vpc",
+        "Tags": [ { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } } ]
+      }
+    },
+    "NLBAddress1": {
+      "Type": "AWS::EC2::EIP",
+      "Condition": "HasNLB",
+      "Properties": {
+        "Domain": "vpc",
+        "Tags": [ { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } } ]
+      }
+    },
+    "NLBAddress2": {
+      "Type": "AWS::EC2::EIP",
+      "Condition": "HasNLBAndThirdAZAndHA",
+      "Properties": {
+        "Domain": "vpc",
+        "Tags": [ { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } } ]
       }
     },
     "SecureEnvironmentRole": {
@@ -3650,6 +3737,54 @@
         ]
       }
     },
+    "NLBRouter": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Condition": "HasNLB",
+      "Properties": {
+        "Type": "network",
+        "Scheme": "internet-facing",
+        "SubnetMappings": [
+          { "SubnetId": { "Ref": "Subnet0" }, "AllocationId": { "Fn::GetAtt": [ "NLBAddress0", "AllocationId" ] } },
+          { "SubnetId": { "Ref": "Subnet1" }, "AllocationId": { "Fn::GetAtt": [ "NLBAddress1", "AllocationId" ] } },
+          { "Fn::If": [ "HasNLBAndThirdAZAndHA",
+            { "SubnetId": { "Ref": "Subnet2" }, "AllocationId": { "Fn::GetAtt": [ "NLBAddress2", "AllocationId" ] } },
+            { "Ref": "AWS::NoValue" }
+          ] }
+        ],
+        "Tags": [
+          { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } }
+        ]
+      }
+    },
+    "NLBRouterInternal": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Condition": "HasNLBInternal",
+      "Properties": {
+        "Type": "network",
+        "Scheme": "internal",
+        "SubnetMappings": { "Fn::If": [ "Private",
+          [
+            { "SubnetId": { "Ref": "SubnetPrivate0" } },
+            { "SubnetId": { "Ref": "SubnetPrivate1" } },
+            { "Fn::If": [ "ThirdAvailabilityZoneAndHighAvailability",
+              { "SubnetId": { "Ref": "SubnetPrivate2" } },
+              { "Ref": "AWS::NoValue" }
+            ] }
+          ],
+          [
+            { "SubnetId": { "Ref": "Subnet0" } },
+            { "SubnetId": { "Ref": "Subnet1" } },
+            { "Fn::If": [ "ThirdAvailabilityZoneAndHighAvailability",
+              { "SubnetId": { "Ref": "Subnet2" } },
+              { "Ref": "AWS::NoValue" }
+            ] }
+          ]
+        ] },
+        "Tags": [
+          { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } }
+        ]
+      }
+    },
     "ApiBalancer": {
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "DependsOn": [ "ApiRole", "LogsPolicy" ],
@@ -4065,6 +4200,8 @@
               "rack.Internal": { "Ref": "Internal" },
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
+              "rack.NLB": { "Ref": "NLB" },
+              "rack.NLBInternal": { "Ref": "NLBInternal" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
@@ -4201,6 +4338,8 @@
               "rack.Internal": { "Ref": "Internal" },
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
+              "rack.NLB": { "Ref": "NLB" },
+              "rack.NLBInternal": { "Ref": "NLBInternal" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
@@ -4329,6 +4468,8 @@
               "rack.Internal": { "Ref": "Internal" },
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
+              "rack.NLB": { "Ref": "NLB" },
+              "rack.NLBInternal": { "Ref": "NLBInternal" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
@@ -4479,6 +4620,8 @@
               "rack.InternalOnly": { "Ref": "InternalOnly" },
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
               "rack.MaintainTimerState": { "Ref": "MaintainTimerState" },
+              "rack.NLB": { "Ref": "NLB" },
+              "rack.NLBInternal": { "Ref": "NLBInternal" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -229,6 +229,37 @@
       }
     },
     "Resources": {
+      {{ $drain := .Drain }}
+      {{ $svcName := .Name }}
+      {{ $svcPort := .Port.Port }}
+      {{ range .NLB }}
+      "NLBTargetGroup{{ .Port }}": {
+        "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+        "Properties": {
+          "Port": {{ .Port }},
+          "Protocol": "{{ upcase .Protocol }}",
+          "TargetType": { "Fn::If": [ "IsolateServices", "ip", "instance" ] },
+          "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } },
+          "HealthCheckProtocol": "TCP",
+          "HealthCheckPort": "traffic-port",
+          "TargetGroupAttributes": [
+            { "Key": "deregistration_delay.timeout_seconds", "Value": "{{ $drain }}" },
+            { "Key": "preserve_client_ip.enabled", "Value": "false" }
+          ]
+        }
+      },
+      "NLBListener{{ .Port }}": {
+        "Type": "AWS::ElasticLoadBalancingV2::Listener",
+        "Properties": {
+          "DefaultActions": [
+            { "Type": "forward", "TargetGroupArn": { "Ref": "NLBTargetGroup{{ .Port }}" } }
+          ],
+          "LoadBalancerArn": { "Fn::ImportValue": { "Fn::Sub": "{{ if eq .Scheme "internal" }}${Rack}:NLBInternalArn{{ else }}${Rack}:NLBArn{{ end }}" } },
+          "Port": {{ .Port }},
+          "Protocol": "{{ upcase .Protocol }}"
+        }
+      },
+      {{ end }}
       "MinCount": {
         "Type": "Custom::MathMin",
         "Properties": {
@@ -703,6 +734,9 @@
             {{ if .Port.Port }}
               { "IpProtocol": "tcp", "FromPort": "{{.Port.Port}}", "ToPort": "{{.Port.Port}}", "SourceSecurityGroupId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Router{{ if .Internal }}Internal{{ end }}SecurityGroup" } } }
             {{ end }}
+            {{ range $i, $nlb := .NLB }}{{ if or $svcPort (gt $i 0) }},{{ end }}
+              { "IpProtocol": "tcp", "FromPort": {{ $nlb.ContainerPort }}, "ToPort": {{ $nlb.ContainerPort }}, "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
+            {{ end }}
           ],
           "Tags": [ { "Key": "Name", "Value": { "Fn::Sub": "${AWS::StackName}-service" } } ],
           "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
@@ -771,10 +805,21 @@
           ] },
           {{ if .Port.Port }}
             "HealthCheckGracePeriodSeconds": "{{.Health.Grace}}",
-            "LoadBalancers": [ { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "BalancerTargetGroup{{ if .Internal }}Internal{{ end }}" } } {{ if .InternalAndExternal }},
-            { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "BalancerTargetGroupExternal" } }
-            {{ end }}
+          {{ end }}
+          {{ if or .Port.Port .NLB }}
+            "LoadBalancers": [
+              {{ if .Port.Port }}
+              { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "BalancerTargetGroup{{ if .Internal }}Internal{{ end }}" } }
+              {{ if .InternalAndExternal }},
+              { "ContainerName": "{{.Name}}", "ContainerPort": "{{.Port.Port}}", "TargetGroupArn": { "Ref": "BalancerTargetGroupExternal" } }
+              {{ end }}
+              {{ end }}
+              {{ range $i, $nlb := .NLB }}{{ if or $svcPort (gt $i 0) }},{{ end }}
+              { "ContainerName": "{{ $svcName }}", "ContainerPort": {{ $nlb.ContainerPort }}, "TargetGroupArn": { "Ref": "NLBTargetGroup{{ $nlb.Port }}" } }
+              {{ end }}
             ],
+          {{ end }}
+          {{ if .Port.Port }}
             {{ if not .InternalAndExternal }}
             "Role": { "Fn::If": [ "IsolateServices", { "Ref": "AWS::NoValue" }, { "Fn::ImportValue": { "Fn::Sub": "${Rack}:ServiceRole" } } ] },
             {{ end }}
@@ -927,6 +972,12 @@
                     "Protocol": "{{.Protocol}}"
                   },
                 {{ end }}
+                {{ range .NLB }}{{ if ne .ContainerPort $svcPort }}
+                  {
+                    "ContainerPort": "{{.ContainerPort}}",
+                    "Protocol": "tcp"
+                  },
+                {{ end }}{{ end }}
                 { "Ref": "AWS::NoValue" }
               ],
               "StopTimeout": "{{.Termination.Grace}}",

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -228,6 +228,10 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		}
 	}
 
+	if err := p.validateNLBSchemeMatch(m); err != nil {
+		return err
+	}
+
 	cs, err := p.CertificateList()
 	if err != nil {
 		return err
@@ -1072,4 +1076,25 @@ func (p *Provider) getResourceDBIdentifier(app, resourceName string) (string, er
 	}
 
 	return "", fmt.Errorf("db instance not found")
+}
+
+// validateNLBSchemeMatch rejects releases whose manifest declares NLB ports whose
+// scheme (public/internal) does not have the corresponding rack NLB enabled.
+// Called early in release promote, before any CF or DynamoDB writes.
+func (p *Provider) validateNLBSchemeMatch(m *manifest.Manifest) error {
+	for _, s := range m.Services {
+		for _, np := range s.NLB {
+			switch np.Scheme {
+			case "public":
+				if !p.NLB {
+					return fmt.Errorf("service %s declares public nlb port %d but rack does not have NLB enabled; run 'convox rack params set NLB=Yes' first", s.Name, np.Port)
+				}
+			case "internal":
+				if !p.NLBInternal {
+					return fmt.Errorf("service %s declares internal nlb port %d but rack does not have NLBInternal enabled; run 'convox rack params set Internal=Yes NLBInternal=Yes' first", s.Name, np.Port)
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/provider/aws/releases_nlb_test.go
+++ b/provider/aws/releases_nlb_test.go
@@ -1,0 +1,51 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/convox/rack/pkg/manifest"
+)
+
+func TestValidateNLBSchemeMatch_PublicDisabled(t *testing.T) {
+	p := &Provider{NLB: false}
+	m := &manifest.Manifest{Services: []manifest.Service{{
+		Name: "api",
+		NLB:  []manifest.ServiceNLBPort{{Port: 8443, Scheme: "public"}},
+	}}}
+	if err := p.validateNLBSchemeMatch(m); err == nil {
+		t.Fatal("expected error when declaring public nlb on rack with NLB=No")
+	}
+}
+
+func TestValidateNLBSchemeMatch_InternalDisabled(t *testing.T) {
+	p := &Provider{NLBInternal: false}
+	m := &manifest.Manifest{Services: []manifest.Service{{
+		Name: "api",
+		NLB:  []manifest.ServiceNLBPort{{Port: 8443, Scheme: "internal"}},
+	}}}
+	if err := p.validateNLBSchemeMatch(m); err == nil {
+		t.Fatal("expected error when declaring internal nlb on rack with NLBInternal=No")
+	}
+}
+
+func TestValidateNLBSchemeMatch_BothEnabled(t *testing.T) {
+	p := &Provider{NLB: true, NLBInternal: true}
+	m := &manifest.Manifest{Services: []manifest.Service{{
+		Name: "api",
+		NLB: []manifest.ServiceNLBPort{
+			{Port: 8443, Scheme: "public"},
+			{Port: 50051, Scheme: "internal"},
+		},
+	}}}
+	if err := p.validateNLBSchemeMatch(m); err != nil {
+		t.Fatalf("expected no error when both NLBs enabled: %v", err)
+	}
+}
+
+func TestValidateNLBSchemeMatch_NoNLBPorts(t *testing.T) {
+	p := &Provider{}
+	m := &manifest.Manifest{Services: []manifest.Service{{Name: "api"}}}
+	if err := p.validateNLBSchemeMatch(m); err != nil {
+		t.Fatalf("service without nlb should not error: %v", err)
+	}
+}

--- a/provider/aws/system.go
+++ b/provider/aws/system.go
@@ -638,6 +638,10 @@ func (p *Provider) Sync(name string) error {
 }
 
 func (p *Provider) SystemUpdate(opts structs.SystemUpdateOptions) error {
+	if err := p.validateNLBParams(opts); err != nil {
+		return err
+	}
+
 	changes := map[string]string{}
 	hasOtherChange := false
 

--- a/provider/aws/system_nlb.go
+++ b/provider/aws/system_nlb.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/convox/rack/pkg/manifest"
+	"github.com/convox/rack/pkg/structs"
+)
+
+// appsUsingNLBScheme returns the list of gen2 apps on the rack whose current running release
+// declares at least one service with an NLB port of the given scheme ("public" or "internal").
+// Returns entries formatted as "app/service".
+//
+// Fails open on per-app errors (logs a warning and continues) so a single broken release does
+// not block rack-wide operations.
+func (p *Provider) appsUsingNLBScheme(scheme string) ([]string, error) {
+	log := p.logger("appsUsingNLBScheme")
+
+	apps, err := p.AppList()
+	if err != nil {
+		return nil, err
+	}
+
+	var blockers []string
+	for _, a := range apps {
+		if a.Tags["Generation"] != "2" {
+			continue
+		}
+		if a.Release == "" {
+			continue
+		}
+		r, err := p.ReleaseGet(a.Name, a.Release)
+		if err != nil {
+			log.Logf("warning: skipped app=%s err=%v", a.Name, err)
+			continue
+		}
+		if r.Manifest == "" {
+			continue
+		}
+		m, err := manifest.Load([]byte(r.Manifest), nil)
+		if err != nil {
+			log.Logf("warning: skipped app=%s manifest parse failed err=%v", a.Name, err)
+			continue
+		}
+		for _, s := range m.Services {
+			for _, np := range s.NLB {
+				if np.Scheme == scheme {
+					blockers = append(blockers, fmt.Sprintf("%s/%s", a.Name, s.Name))
+					break
+				}
+			}
+		}
+	}
+	return blockers, nil
+}
+
+// validateNLBParams enforces the NLB rack-param rules:
+//   - NLB=Yes incompatible with InternalOnly=Yes
+//   - NLBInternal=Yes requires Internal=Yes (either already set or set in the same call)
+//   - Disabling NLB/NLBInternal requires no dependent gen2 apps
+func (p *Provider) validateNLBParams(opts structs.SystemUpdateOptions) error {
+	want := func(key string) (string, bool) {
+		if opts.Parameters == nil {
+			return "", false
+		}
+		v, ok := opts.Parameters[key]
+		return v, ok
+	}
+
+	yesNo := func(b bool) string {
+		if b {
+			return "Yes"
+		}
+		return "No"
+	}
+
+	currentNLB := yesNo(p.NLB)
+	currentNLBInternal := yesNo(p.NLBInternal)
+	currentInternal := yesNo(p.Internal)
+	currentInternalOnly := yesNo(p.InternalOnly)
+
+	nextNLB, nlbSet := want("NLB")
+	if !nlbSet {
+		nextNLB = currentNLB
+	}
+	nextNLBInternal, nlbiSet := want("NLBInternal")
+	if !nlbiSet {
+		nextNLBInternal = currentNLBInternal
+	}
+	nextInternal, internalSet := want("Internal")
+	if !internalSet {
+		nextInternal = currentInternal
+	}
+	nextInternalOnly, _ := want("InternalOnly")
+	if nextInternalOnly == "" {
+		nextInternalOnly = currentInternalOnly
+	}
+
+	if nextNLB == "Yes" && nextInternalOnly == "Yes" {
+		return fmt.Errorf("cannot enable public NLB on an InternalOnly rack; use NLBInternal instead")
+	}
+
+	if nextNLBInternal == "Yes" && nextInternal != "Yes" {
+		return fmt.Errorf("cannot enable NLBInternal on a rack without Internal=Yes; set Internal=Yes in the same command")
+	}
+
+	if nlbSet && currentNLB == "Yes" && nextNLB == "No" {
+		blockers, err := p.appsUsingNLBScheme("public")
+		if err != nil {
+			return err
+		}
+		if len(blockers) > 0 {
+			sort.Strings(blockers)
+			return fmt.Errorf("cannot disable NLB: apps %s still declare public nlb ports; remove nlb: from their manifests and redeploy first", strings.Join(blockers, ", "))
+		}
+	}
+
+	if nlbiSet && currentNLBInternal == "Yes" && nextNLBInternal == "No" {
+		blockers, err := p.appsUsingNLBScheme("internal")
+		if err != nil {
+			return err
+		}
+		if len(blockers) > 0 {
+			sort.Strings(blockers)
+			return fmt.Errorf("cannot disable NLBInternal: apps %s still declare internal nlb ports; remove nlb: from their manifests and redeploy first", strings.Join(blockers, ", "))
+		}
+	}
+
+	return nil
+}

--- a/provider/aws/system_nlb_test.go
+++ b/provider/aws/system_nlb_test.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/convox/rack/pkg/structs"
+)
+
+func TestValidateNLBParams_InternalOnlyConflict(t *testing.T) {
+	p := &Provider{InternalOnly: true}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{Parameters: map[string]string{"NLB": "Yes"}})
+	if err == nil {
+		t.Fatal("expected error enabling NLB on InternalOnly rack")
+	}
+}
+
+func TestValidateNLBParams_InternalOnlyCompatible(t *testing.T) {
+	p := &Provider{InternalOnly: true, Internal: true}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{Parameters: map[string]string{"NLBInternal": "Yes"}})
+	if err != nil {
+		t.Fatalf("InternalOnly+Internal+NLBInternal should pass: %v", err)
+	}
+}
+
+func TestValidateNLBParams_InternalRequiredForNLBInternal(t *testing.T) {
+	p := &Provider{Internal: false}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{Parameters: map[string]string{"NLBInternal": "Yes"}})
+	if err == nil {
+		t.Fatal("expected error enabling NLBInternal without Internal=Yes")
+	}
+}
+
+func TestValidateNLBParams_InternalAndNLBInternalSameCall(t *testing.T) {
+	p := &Provider{Internal: false}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{
+		Parameters: map[string]string{"Internal": "Yes", "NLBInternal": "Yes"},
+	})
+	if err != nil {
+		t.Fatalf("expected Internal+NLBInternal together to pass: %v", err)
+	}
+}
+
+func TestValidateNLBParams_NoNLBParamChange(t *testing.T) {
+	p := &Provider{}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{Parameters: map[string]string{"Foo": "bar"}})
+	if err != nil {
+		t.Fatalf("non-NLB param change should not error: %v", err)
+	}
+}
+
+func TestValidateNLBParams_NilParameters(t *testing.T) {
+	p := &Provider{}
+	err := p.validateNLBParams(structs.SystemUpdateOptions{})
+	if err != nil {
+		t.Fatalf("nil parameters should not error: %v", err)
+	}
+}

--- a/provider/aws/template_test.go
+++ b/provider/aws/template_test.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	"html/template"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServiceTemplateParses verifies service.json.tmpl parses cleanly with the
+// helper funcs registered in formationHelpers(). This catches template-syntax
+// regressions (missing {{ end }}, unknown function names, malformed actions)
+// without requiring a full render fixture.
+//
+// End-to-end rendering is exercised in integration tests.
+func TestServiceTemplateParses(t *testing.T) {
+	path := filepath.Join("formation", "service.json.tmpl")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	if _, err := template.New(filepath.Base(path)).Funcs(formationHelpers()).Parse(string(data)); err != nil {
+		t.Fatalf("service.json.tmpl failed to parse: %v", err)
+	}
+}
+
+// TestAppTemplateParses is a companion parse check for app.json.tmpl so future
+// refactors to formationHelpers or template syntax are caught in both places.
+func TestAppTemplateParses(t *testing.T) {
+	path := filepath.Join("formation", "app.json.tmpl")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	if _, err := template.New(filepath.Base(path)).Funcs(formationHelpers()).Parse(string(data)); err != nil {
+		t.Fatalf("app.json.tmpl failed to parse: %v", err)
+	}
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Network Load Balancer Support for V2 Racks**

We've added Network Load Balancer (NLB) support to V2 racks. Until now, every app and service on a V2 rack terminated traffic at the shared Application Load Balancer, which is HTTP/HTTPS only. With this release you can opt a rack into a Layer 4 path — public, internal, or both — and expose selected services through per-port NLB listeners declared directly in `convox.yml`. TLS termination, per-NLB security groups with a CIDR allowlist, cross-zone load balancing, preserve-client-IP, and deletion protection are all supported as rack-wide defaults, with per-port overrides available on individual services.

The feature ships in two layers: rack-level infrastructure you opt into with `convox rack params set`, and per-service listeners you declare in each app's `convox.yml`.

**Rack parameters** (all default `No` / `0.0.0.0/0`; existing racks unaffected until opted in):

| Parameter                       | Default       | Purpose                                                                 |
|---------------------------------|---------------|-------------------------------------------------------------------------|
| `NLB`                           | `No`          | Provisions a public NLB with per-AZ Elastic IPs                         |
| `NLBInternal`                   | `No`          | Provisions an internal NLB (requires `Internal=Yes`)                    |
| `NLBAllowCIDR`                  | `0.0.0.0/0`   | CIDR allowlist for the public NLB SG (up to 5, comma-separated)         |
| `NLBInternalAllowCIDR`          | (VPC CIDR)    | CIDR allowlist for the internal NLB SG (up to 5, comma-separated)       |
| `NLBCrossZone`                  | `No`          | Enables cross-zone load balancing on the public NLB                     |
| `NLBInternalCrossZone`          | `No`          | Enables cross-zone load balancing on the internal NLB                   |
| `NLBPreserveClientIP`           | `No`          | Forwards real client IP to public NLB target tasks                      |
| `NLBInternalPreserveClientIP`   | `No`          | Forwards real client IP to internal NLB target tasks                    |
| `NLBDeletionProtection`         | `No`          | Prevents accidental deletion of the public NLB                          |
| `NLBInternalDeletionProtection` | `No`          | Prevents accidental deletion of the internal NLB                        |

**Per-service fields** on `services[*].nlb[*]` in `convox.yml`:

| Field                | Type              | Required                  | Notes                                                                 |
|----------------------|-------------------|---------------------------|-----------------------------------------------------------------------|
| `port`               | int (1-65535)     | yes                       | The port exposed on the NLB                                           |
| `protocol`           | `tcp` \| `tls`    | no (default `tcp`)        | TLS terminates at the NLB; target group stays TCP                     |
| `containerPort`      | int (1-65535)     | no (default = `port`)     | The container port the NLB forwards to                                |
| `scheme`             | `public` \| `internal` | no (default `public`) | Selects which rack NLB the listener attaches to                       |
| `certificate`        | ACM or IAM ARN    | required when `tls`       | Pre-flight-checked at release promote; must be in the rack's region   |
| `cross_zone`         | bool              | no (inherits rack)        | Per-listener override of `NLBCrossZone` / `NLBInternalCrossZone`      |
| `allow_cidr`         | list of CIDRs     | no (inherits rack)        | Per-listener ingress, layered on top of the rack allowlist            |
| `preserve_client_ip` | bool              | no (inherits rack)        | Per-listener override of `NLBPreserveClientIP` / internal equivalent  |

**TLS listener details.** A `tls` listener uses the `ELBSecurityPolicy-TLS13-1-2-2021-06` policy (TLS 1.2 and 1.3, ECDHE cipher suites). The NLB terminates TLS and forwards plaintext to your container; the target group stays on TCP. Certificate validity is checked at `convox deploy` — missing, non-`ISSUED`, cross-region, or cross-account certificates fail within seconds instead of as a stuck CloudFormation update.

**Safety interlocks** (all errors surface at `convox rack params set` or `convox deploy`, before any AWS change):

| Scenario                                                              | Outcome                                                           |
|-----------------------------------------------------------------------|-------------------------------------------------------------------|
| `NLB=Yes` with `InternalOnly=Yes`                                     | Rejected                                                          |
| `NLBInternal=Yes` without `Internal=Yes`                              | Rejected                                                          |
| Disabling `NLB` / `NLBInternal` while apps still declare `nlb:` ports | Rejected; error lists the blocking `app/service` pairs            |
| `NLBDeletionProtection=Yes` combined with `NLB=No` (same call)        | Rejected; must disable deletion protection first                  |
| `convox rack uninstall` while either deletion protection is enabled   | Rejected; must disable deletion protection first                  |
| `NLBPreserveClientIP=Yes` with a user-managed `InstanceSecurityGroup` | Rejected in both directions (silent SG breakage prevented)        |
| `allow_cidr` entry that is non-canonical, IPv6, duplicate, or >5      | Rejected                                                          |
| Service declares `scheme: public` on a rack without `NLB=Yes`         | `convox deploy` fails with remediation command in the error       |

**CLI changes.** `convox rack` gains NLB / NLB Internal rows (hostname + EIPs for the public NLB). `convox services` gains an `NLB PORTS` column showing the declared listener ports, scheme, and a bracketed suffix (`cz=...`, `allow=N`, `pcip=...`) when per-port overrides are present. Enabling `NLB=Yes` or `NLBInternal=Yes` via `convox rack params set` prints a one-line hint that provisioning typically takes 5–10 minutes.


---

### How to use it?

Update your rack:

```
$ convox rack update
```

Then enable NLB at the rack level. Parameters batch into a single call; never run them as sequential commands.

For just the public NLB:

```
$ convox rack params set NLB=Yes
```

For the internal NLB (requires `Internal=Yes`):

```
$ convox rack params set Internal=Yes NLBInternal=Yes
```

Both at once, with cross-zone on, a production CIDR allowlist, and deletion protection:

```
$ convox rack params set NLB=Yes NLBInternal=Yes Internal=Yes \
    NLBAllowCIDR="198.51.100.0/24,203.0.113.0/24" \
    NLBCrossZone=Yes NLBInternalCrossZone=Yes \
    NLBDeletionProtection=Yes NLBInternalDeletionProtection=Yes
```

After provisioning, `convox rack` shows the NLB hostname and associated EIPs:

```
$ convox rack
Name      my-rack
Provider  aws
Region    us-east-1
Router    my-rack-router-...elb.amazonaws.com
NLB       my-rack-nlb-...elb.us-east-1.amazonaws.com (203.0.113.10, 203.0.113.11, 203.0.113.12)
Status    running
Version   20260421192651
```

Next, declare `nlb:` entries on any service in your `convox.yml` and deploy:

```yaml
services:
  api:
    image: example/api
    port: http:3000
    nlb:
      - port: 8443
        protocol: tls
        containerPort: 8443
        scheme: public
        certificate: arn:aws:acm:us-east-1:123456789012:certificate/abc12345-6789-def0-1234-567890abcdef
        cross_zone: true
        allow_cidr:
          - 10.0.0.0/24
          - 10.1.0.0/24
        preserve_client_ip: false
      - port: 50051
        protocol: tcp
        containerPort: 50051
        scheme: internal
```

```
$ convox deploy -a myapp
```

Point a Route 53 `A` (alias) record at the rack's public NLB DNS name — visible in `convox rack` — for the hostname you want to serve. `convox services` summarizes the NLB listeners alongside ALB listeners:

```
$ convox services -a myapp
SERVICE  DOMAIN                 PORTS             NLB PORTS
api      myapp-api.example.com  80:3000 443:3000  8443:8443(public)[cz=true allow=2 pcip=false] 50051:50051(internal)
```

A few common patterns:

- **gRPC over TLS** — `protocol: tls` with a TCP target. Clients get TLS all the way to the NLB; your application process does not manage certificates. For plaintext gRPC between services on the same rack, use `protocol: tcp, scheme: internal`.
- **NLB-only service** — omit `port:` entirely if the service does not need an ALB listener at all. The service runs behind the NLB with no HTTP route.
- **ALB + NLB coexisting on the same port** — declare both `port: http:3000` and an `nlb:` entry on the same container port. The rack deduplicates the ECS port mappings so both listeners route correctly.
- **Switching TCP to TLS** — change `protocol: tcp` to `protocol: tls` and add a `certificate:` on the next deploy. AWS documents this as an in-place `ModifyListener` update; clients see a brief protocol-boundary disruption at switchover.
- **Per-service CIDR allowlist** — set `allow_cidr` on a single NLB port to restrict access to one listener without changing the rack-wide `NLBAllowCIDR`. Up to 5 CIDRs per rack param (5 public + 5 internal), plus additional per-port CIDRs layered on top.
- **Per-service preserve-client-IP** — set `preserve_client_ip: true` on a single listener so your application sees real client IPs. Applies to `ip`-type target groups (Fargate and `isolate: true` services) as well as `instance`-type target groups (standard gen2 services).

If you run `convox deploy` against a rack without the matching rack parameter set, or against a rack where a per-port policy conflicts with a rack-level guard, the deploy fails early with a message pointing at the exact remediation:

```
service api nlb port 8443: rack NLB is not enabled; run 'convox rack params set NLB=Yes' first
```

To disable NLB again, first remove every `nlb:` block from every app's `convox.yml` and redeploy, then disable deletion protection (if set) and flip the rack parameter:

```
$ convox rack params set NLBDeletionProtection=No NLB=No
```

To uninstall a rack entirely, deletion protection must be disabled on both NLBs first; the CLI will refuse `convox rack uninstall` with an actionable error otherwise.

**Operational notes:**

- **EIP quota.** The public NLB allocates one EIP per Availability Zone (2 for a 2-AZ rack, 3 for a 3-AZ rack with `HighAvailability=Yes`). The default AWS EIP quota is 5 per region. If your rack already uses `Private=Yes`, NAT gateways consume 2-3 EIPs on top. Check current usage and request a quota increase before enabling on a `Private=Yes + 3-AZ HA` rack.
- **Provisioning time.** NLB creation typically takes 5-10 minutes after `convox rack params set` returns; the CLI prints a hint reminding you of this on the `Yes` transition.
- **Listener quota.** AWS imposes a limit of 50 listeners per NLB. The rack's shared NLB carries listeners for every app that opts in. Environments approaching 50 public listeners or 50 internal listeners across all apps should request a quota increase before broader adoption.
- **CIDR allowlist capacity.** Rack parameters `NLBAllowCIDR` and `NLBInternalAllowCIDR` each accept up to 5 CIDRs (comma-separated). For fine-grained per-service allowlists beyond the rack default, use the per-port `allow_cidr:` field on individual `nlb:` entries.
- **TLS policy.** The listener uses `ELBSecurityPolicy-TLS13-1-2-2021-06` (TLS 1.2 and 1.3, ECDHE). A configurable policy will ship in a follow-up release if demand is there.
- **Certificate region.** ACM certificates used on NLB listeners must be in the same AWS region as the rack. The pre-flight check surfaces a clear error if you pass a cross-region ARN.
- **User-managed instance SG.** If you have set the rack-level `InstanceSecurityGroup` parameter to a SG you manage yourself, `NLBPreserveClientIP=Yes` is blocked — the NLB would forward real client IPs into an SG whose ingress rules you control, and we will not silently modify that posture. Disable preserve-client-IP in the same `rack params set` call if you need to change both.

---

### Does it have a breaking change?

No breaking changes. All ten new rack parameters default to `No` / `0.0.0.0/0` / blank, so existing racks create zero new NLB resources on upgrade and behave identically until you opt in. Services without `nlb:` produce byte-identical CloudFormation output, and TCP-only NLB listeners without per-port overrides render identically to their earlier form. The `convox rack` output adds the NLB rows only when the rack has NLB enabled and exposes the corresponding stack outputs; the `convox services` output's new `NLB PORTS` column is suppressed entirely when no service in the app has NLB ports declared.

The new Docker labels added to the rack API task definitions produce a single task definition revision on first update, resulting in a normal rolling restart of the rack API containers — the same pattern used for every previous rack parameter addition. Gen1 apps are unaffected; NLB is gen2-only.

Downgrading to a rack version that predates these parameters requires setting `NLB=No` and `NLBInternal=No` first, disabling deletion protection if set, and removing `nlb:` blocks from any active services. CloudFormation will reject the downgrade cleanly if attempted with non-default values.

---

### Requirements

To use this feature, you must update to rack version `20260421192651` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
