### PR TITLE
fix rack uninstall autoscaler update loop

### DIFF
--- a/provider/aws/disable_autoscaler_test.go
+++ b/provider/aws/disable_autoscaler_test.go
@@ -1,0 +1,193 @@
+package aws
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/eventbridge"
+	"github.com/convox/rack/pkg/test/awsutil"
+)
+
+func stubAutoscalerClients(t *testing.T, cycles ...awsutil.Cycle) (*cloudformation.CloudFormation, *eventbridge.EventBridge, *httptest.Server) {
+	t.Helper()
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+	t.Setenv("AWS_REGION", "us-test-1")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+
+	handler := awsutil.NewHandler(cycles)
+	srv := httptest.NewServer(handler)
+
+	s, err := session.NewSession(&awssdk.Config{
+		Region:                        awssdk.String("us-test-1"),
+		Endpoint:                      awssdk.String(srv.URL),
+		DisableSSL:                    awssdk.Bool(true),
+		CredentialsChainVerboseErrors: awssdk.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %s", err)
+	}
+	return cloudformation.New(s), eventbridge.New(s), srv
+}
+
+// Regex body match on the CloudFormation cycles pins the exact action
+// (Action=DescribeStackResource) and logical resource ID. This prevents
+// an impl that mistakenly calls DescribeStacks or DescribeStackResources
+// (plural) from matching these cycles. CF uses the query protocol
+// (form-encoded POST bodies), not the JSON protocol, so Operation is empty.
+
+var cycleDescribeAutoscalerEventResourceFound = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Operation:  "",
+		Body:       `/Action=DescribeStackResource&.*LogicalResourceId=InstancesAutoscalerEvent/`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `<DescribeStackResourceResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+<DescribeStackResourceResult>
+<StackResourceDetail>
+<StackName>test-rack</StackName>
+<LogicalResourceId>InstancesAutoscalerEvent</LogicalResourceId>
+<PhysicalResourceId>test-rack-InstancesAutoscalerEvent-ABC123</PhysicalResourceId>
+<ResourceType>AWS::Events::Rule</ResourceType>
+<ResourceStatus>CREATE_COMPLETE</ResourceStatus>
+</StackResourceDetail>
+</DescribeStackResourceResult>
+</DescribeStackResourceResponse>`,
+	},
+}
+
+var cycleDescribeAutoscalerEventResourceMissing = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Operation:  "",
+		Body:       `/Action=DescribeStackResource&.*LogicalResourceId=InstancesAutoscalerEvent/`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 400,
+		Body: `<ErrorResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+<Error>
+<Type>Sender</Type>
+<Code>ValidationError</Code>
+<Message>Resource InstancesAutoscalerEvent does not exist for stack test-rack</Message>
+</Error>
+</ErrorResponse>`,
+	},
+}
+
+var cycleDescribeAutoscalerEventResource5xx = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Operation:  "",
+		Body:       `/Action=DescribeStackResource&.*LogicalResourceId=InstancesAutoscalerEvent/`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 500,
+		Body:       `<ErrorResponse><Error><Code>InternalFailure</Code><Message>boom</Message></Error></ErrorResponse>`,
+	},
+}
+
+// Regex body match on the DisableRule cycles pins the rule name extracted
+// from the DescribeStackResource response. If the helper passes the wrong
+// value (e.g., StackName or empty), the cycle won't match, awsutil returns
+// 404, DisableRule errors, and the helper logs "skip autoscaler disable"
+// instead of "disabled autoscaler rule" — failing the happy-path test.
+var cycleDisableRuleSuccess = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Operation:  "AWSEvents.DisableRule",
+		Body:       `/"Name":"test-rack-InstancesAutoscalerEvent-ABC123"/`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body:       `{}`,
+	},
+}
+
+var cycleDisableRuleNotFound = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Operation:  "AWSEvents.DisableRule",
+		Body:       `/"Name":"test-rack-InstancesAutoscalerEvent-ABC123"/`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 404,
+		Body:       `{"__type":"ResourceNotFoundException","message":"Rule not found"}`,
+	},
+}
+
+func TestDisableAutoscalerRuleHappy(t *testing.T) {
+	cf, ev, srv := stubAutoscalerClients(t,
+		cycleDescribeAutoscalerEventResourceFound,
+		cycleDisableRuleSuccess,
+	)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	disableAutoscalerRule(cf, ev, "test-rack", &buf)
+
+	out := buf.String()
+	if !strings.Contains(out, "disabled autoscaler rule: test-rack-InstancesAutoscalerEvent-ABC123") {
+		t.Errorf("expected success log, got: %q", out)
+	}
+	if strings.Contains(out, "skip autoscaler disable") {
+		t.Errorf("unexpected skip log on happy path: %q", out)
+	}
+}
+
+func TestDisableAutoscalerRuleResourceMissing(t *testing.T) {
+	cf, ev, srv := stubAutoscalerClients(t,
+		cycleDescribeAutoscalerEventResourceMissing,
+	)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	disableAutoscalerRule(cf, ev, "test-rack", &buf)
+
+	out := buf.String()
+	if !strings.Contains(out, "skip autoscaler disable") {
+		t.Errorf("expected skip log for missing resource, got: %q", out)
+	}
+}
+
+func TestDisableAutoscalerRuleDisableRuleFails(t *testing.T) {
+	cf, ev, srv := stubAutoscalerClients(t,
+		cycleDescribeAutoscalerEventResourceFound,
+		cycleDisableRuleNotFound,
+	)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	disableAutoscalerRule(cf, ev, "test-rack", &buf)
+
+	out := buf.String()
+	if !strings.Contains(out, "skip autoscaler disable") {
+		t.Errorf("expected skip log when DisableRule fails, got: %q", out)
+	}
+}
+
+func TestDisableAutoscalerRuleDescribeReturns5xx(t *testing.T) {
+	cf, ev, srv := stubAutoscalerClients(t,
+		cycleDescribeAutoscalerEventResource5xx,
+	)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	disableAutoscalerRule(cf, ev, "test-rack", &buf)
+
+	out := buf.String()
+	if !strings.Contains(out, "skip autoscaler disable") {
+		t.Errorf("expected skip log on 5xx, got: %q", out)
+	}
+}

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -2471,6 +2471,7 @@
       "Condition": "Autoscale",
       "Properties": {
         "ScheduleExpression": "cron(*/1 * * * ? *)",
+        "State": "ENABLED",
         "Targets": [ { "Id": "InstancesAutoscaler", "Arn": { "Fn::GetAtt": [ "InstancesAutoscaler", "Arn" ] } } ]
       }
     },

--- a/provider/aws/lambda/autoscale/handler.go
+++ b/provider/aws/lambda/autoscale/handler.go
@@ -28,6 +28,19 @@ const (
 	SCHEDULE_RACK_SCALE_UP_PARAM   = "ScheduleRackScaleUp"
 )
 
+// shouldAutoscale returns true only for CloudFormation stack states where it is
+// safe and meaningful to call UpdateStack. Any in-progress, failed, or
+// rollback state returns false — including UPDATE_ROLLBACK_COMPLETE, which is
+// technically stable but indicates an unresolved prior failure.
+func shouldAutoscale(status string) bool {
+	switch status {
+	case cloudformation.StackStatusCreateComplete, cloudformation.StackStatusUpdateComplete:
+		return true
+	default:
+		return false
+	}
+}
+
 var (
 	CloudFormation *cloudformation.CloudFormation
 	ECS            *ecs.ECS
@@ -83,6 +96,12 @@ func autoscale(desired int64) error {
 
 	if len(res.Stacks) < 1 {
 		return fmt.Errorf("could not find stack: %s", stack)
+	}
+
+	stackStatus := aws.StringValue(res.Stacks[0].StackStatus)
+	if !shouldAutoscale(stackStatus) {
+		fmt.Printf("skipping autoscale: stack %s is %s\n", stack, stackStatus)
+		return nil
 	}
 
 	// check if rack schedule down period

--- a/provider/aws/lambda/autoscale/handler_test.go
+++ b/provider/aws/lambda/autoscale/handler_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+func TestShouldAutoscale(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{cloudformation.StackStatusCreateComplete, true},
+		{cloudformation.StackStatusUpdateComplete, true},
+		{cloudformation.StackStatusCreateInProgress, false},
+		{cloudformation.StackStatusCreateFailed, false},
+		{cloudformation.StackStatusRollbackInProgress, false},
+		{cloudformation.StackStatusRollbackFailed, false},
+		{cloudformation.StackStatusRollbackComplete, false},
+		{cloudformation.StackStatusDeleteInProgress, false},
+		{cloudformation.StackStatusDeleteFailed, false},
+		{cloudformation.StackStatusDeleteComplete, false},
+		{cloudformation.StackStatusUpdateInProgress, false},
+		{cloudformation.StackStatusUpdateFailed, false},
+		{cloudformation.StackStatusUpdateCompleteCleanupInProgress, false},
+		{cloudformation.StackStatusUpdateRollbackInProgress, false},
+		{cloudformation.StackStatusUpdateRollbackFailed, false},
+		{cloudformation.StackStatusUpdateRollbackCompleteCleanupInProgress, false},
+		{cloudformation.StackStatusUpdateRollbackComplete, false},
+		{cloudformation.StackStatusReviewInProgress, false},
+		{cloudformation.StackStatusImportInProgress, false},
+		{cloudformation.StackStatusImportComplete, false},
+		{cloudformation.StackStatusImportRollbackInProgress, false},
+		{cloudformation.StackStatusImportRollbackFailed, false},
+		{cloudformation.StackStatusImportRollbackComplete, false},
+		{"", false},
+		{"UNKNOWN_STATUS", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.status, func(t *testing.T) {
+			got := shouldAutoscale(tc.status)
+			if got != tc.want {
+				t.Errorf("shouldAutoscale(%q) = %v; want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}

--- a/provider/aws/system.go
+++ b/provider/aws/system.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/eventbridge"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/convox/rack/pkg/helpers"
@@ -566,6 +567,9 @@ func (p *Provider) SystemUninstall(name string, w io.Writer, opts structs.System
 		}
 	}
 
+	ebService := eventbridge.New(s)
+	disableAutoscalerRule(cf, ebService, name, w)
+
 	asgService := autoscaling.New(s)
 	for _, d := range deps {
 		// Workaround to uninstall v2 racks:
@@ -631,6 +635,37 @@ func cleanAsg(cf *cloudformation.CloudFormation, asgservice *autoscaling.AutoSca
 	}
 
 	return nil
+}
+
+// disableAutoscalerRule best-effort disables the InstancesAutoscalerEvent
+// EventBridge rule defined by the rack stack. Stops the autoscaler Lambda
+// from issuing UpdateStack while SystemUninstall is force-deleting ASGs.
+//
+// Errors are logged to w and swallowed — uninstall should proceed even if the
+// rule can't be disabled. Worst case: the caller proceeds without the
+// optimization and (for racks pre-dating the Lambda status check) may see
+// one UPDATE_ROLLBACK_COMPLETE cycle before cleanAsg completes.
+//
+// stackName is the rack stack (or any stack); app stacks don't have this
+// logical resource, so DescribeStackResource errors and the helper no-ops.
+func disableAutoscalerRule(cf *cloudformation.CloudFormation, ev *eventbridge.EventBridge, stackName string, w io.Writer) {
+	out, err := cf.DescribeStackResource(&cloudformation.DescribeStackResourceInput{
+		StackName:         aws.String(stackName),
+		LogicalResourceId: aws.String("InstancesAutoscalerEvent"),
+	})
+	if err != nil {
+		fmt.Fprintf(w, "skip autoscaler disable (%s): %s\n", stackName, err)
+		return
+	}
+	if out.StackResourceDetail == nil || out.StackResourceDetail.PhysicalResourceId == nil {
+		return
+	}
+	ruleName := aws.StringValue(out.StackResourceDetail.PhysicalResourceId)
+	if _, err := ev.DisableRule(&eventbridge.DisableRuleInput{Name: aws.String(ruleName)}); err != nil {
+		fmt.Fprintf(w, "skip autoscaler disable (%s): %s\n", ruleName, err)
+		return
+	}
+	fmt.Fprintf(w, "disabled autoscaler rule: %s\n", ruleName)
 }
 
 func (p *Provider) Sync(name string) error {


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Rack Uninstall No Longer Hangs When Autoscaling Is Enabled**

We've fixed a bug where `convox rack uninstall` would hang indefinitely on racks with `Autoscale=Yes` (the default) and at least one installed app. The root cause was a livelock between the uninstall flow and the rack's own autoscaler Lambda. The Lambda, scheduled by an EventBridge cron rule inside the rack's CloudFormation stack, fires every 60 seconds and calls `UpdateStack`. During uninstall, the CLI force-deletes the `Instances` Auto Scaling Group via the AutoScaling API, and the next Lambda-triggered `UpdateStack` would try to apply the rack's `AutoScalingRollingUpdate` policy — which calls `SuspendProcesses` on an ASG that is now pending-delete. AWS rejects the call, CloudFormation rolls back, the Lambda fires again, and the loop continues until manually intervened.

This release adds three coordinated guards:

- **CLI-side rule disable.** `SystemUninstall` now calls a new `disableAutoscalerRule` helper that best-effort disables the `InstancesAutoscalerEvent` EventBridge rule on the rack stack before the `cleanAsg` loop starts. The helper uses `cloudformation.DescribeStackResource` to resolve the physical rule name, then calls `events.DisableRule`. Any error is logged and swallowed — uninstall proceeds regardless. This works against any rack version, including racks that predate the Lambda change.
- **Lambda-side stack-state allowlist.** The autoscaler Lambda now skips its `UpdateStack` call unless the rack stack is in `CREATE_COMPLETE` or `UPDATE_COMPLETE`. Every in-progress, failed, rollback, delete, and review state now causes the Lambda to log `skipping autoscale: stack <name> is <status>` to CloudWatch and return without side-effects. This breaks the livelock after at most one `UPDATE_ROLLBACK_COMPLETE` cycle on racks that do not yet have the new CLI.
- **Template self-healing.** The `InstancesAutoscalerEvent` CloudFormation resource now sets `"State": "ENABLED"` explicitly. This matches CloudFormation's existing default, so install behavior is unchanged — but the first `convox rack update` after upgrading to this version pushes `PutRule` with `State=ENABLED`, so any rule that was manually disabled during an aborted uninstall recovery is automatically re-enabled.

---

### How to use it?

This fix is automatically applied when you update your rack. No additional configuration is required.

```
$ convox rack update
```

The next time you run `convox rack uninstall` on a rack with `Autoscale=Yes`, the CLI silently disables the autoscaler cron rule first, and the uninstall completes cleanly:

```
$ convox rack uninstall my-rack
disabled autoscaler rule: my-rack-InstancesAutoscalerEvent-ABC123
...
```

If your rack was previously stuck in an aborted uninstall — for example, the EventBridge rule was manually disabled to break the loop — the next successful `convox rack update` reconciles the rule back to the enabled state, so the autoscaler resumes normal operation.

---

### Does it have a breaking change?

No breaking changes. The CLI-side change uses public AWS APIs that are additive to the uninstall flow; the CLI works against any rack version. The Lambda change is internal to the rack and self-contained. The CloudFormation change adds an explicit `"State": "ENABLED"` property that matches the existing default, so install behavior is unchanged and existing racks reconcile to the enabled state on their next update.

One latent behavior note: because the Lambda now requires `CREATE_COMPLETE` or `UPDATE_COMPLETE`, racks sitting in `UPDATE_ROLLBACK_COMPLETE` for extended periods — typically after a failed `convox rack params set` — will have autoscaling halted until the operator resolves the rollback. This is an intentional safety property of the allowlist; the previous behavior of continuously attempting `UpdateStack` in this state was the bug.

The uninstall path makes two additional AWS API calls (`cloudformation:DescribeStackResource` and `events:DisableRule`). These are covered by the standard operator policy required to run `convox rack install`; operators with tightly scoped custom IAM policies may need to add these two actions — if they are missing, the CLI logs a skip message and the uninstall proceeds.

---

### Requirements

To receive this fix, you must update to rack version `20260421192651` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
