### PR TITLE
nlb config params, usage gaps

### DIFF
--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -444,3 +444,28 @@ func filterString(input string) string {
 	}
 	return builder.String()
 }
+
+// IsTerminalFn reports whether the context's writer is attached to a real
+// terminal, used to gate masking of sensitive output in `convox rack params`.
+// This is a VAR, not a function, so that tests can override it.
+//
+// Not to be confused with stdcli.IsTerminal(*os.File) — that is the
+// underlying syscall helper from the vendored stdcli package. IsTerminalFn
+// wraps the stdcli call at the *stdcli.Context layer so test code can
+// swap the behavior without producing a real PTY.
+//
+// Not public API. Exported only because test files use `package cli_test`
+// (black-box), which cannot reach unexported symbols. External consumers
+// of pkg/cli must not take a dependency on this var — it may be renamed
+// or removed without a deprecation cycle.
+//
+// Callers: pkg/cli/rack.go (RackParams).
+//
+// CONCURRENCY: this var is mutable package state. Tests that override it
+// MUST restore via t.Cleanup AND MUST NOT call t.Parallel anywhere in
+// pkg/cli that executes concurrently with an override — the race will
+// surface under `go test -race`. At patch time no test in pkg/cli
+// calls t.Parallel (verified).
+var IsTerminalFn = func(c *stdcli.Context) bool {
+	return c.Writer().IsTerminal()
+}

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -22,6 +22,278 @@ import (
 	cv "github.com/convox/version"
 )
 
+// sensitiveParams enumerates V2 rack params whose values render as
+// "**********" on a TTY when --reveal is not passed. Pipe output and
+// --reveal bypass masking. Empty values are never masked.
+var sensitiveParams = map[string]bool{
+	"Password":  true,
+	"HttpProxy": true,
+}
+
+// paramGroups categorizes V2 rack params into curated logical groups for the
+// `convox rack params -g <group>` filter. A param may belong to multiple
+// groups (5 V2 params are dual-listed). Every V2 rack.json Parameter must
+// land in at least one group — enforced by TestParamGroupsCoverRackJSON.
+//
+// When adding a new rack param to provider/aws/formation/rack.json, add it
+// to the appropriate group(s) below. The drift-detector test will fail
+// otherwise.
+var paramGroups = map[string]map[string]bool{
+	"network": {
+		"AvailabilityZones":    true,
+		"ExistingVpc":          true,
+		"HttpProxy":            true,
+		"Internal":             true,
+		"InternalOnly":         true,
+		"InternetGateway":      true,
+		"MaxAvailabilityZones": true,
+		"PlaceLambdaInVpc":     true,
+		"Private":              true,
+		"Subnet0CIDR":          true,
+		"Subnet1CIDR":          true,
+		"Subnet2CIDR":          true,
+		"SubnetPrivate0CIDR":   true,
+		"SubnetPrivate1CIDR":   true,
+		"SubnetPrivate2CIDR":   true,
+		"VPCCIDR":              true,
+	},
+	"nlb": {
+		"NLB":                           true,
+		"NLBAllowCIDR":                  true,
+		"NLBCrossZone":                  true,
+		"NLBDeletionProtection":         true,
+		"NLBInternal":                   true,
+		"NLBInternalAllowCIDR":          true,
+		"NLBInternalCrossZone":          true,
+		"NLBInternalDeletionProtection": true,
+		"NLBInternalPreserveClientIP":   true,
+		"NLBPreserveClientIP":           true,
+	},
+	"security": {
+		"BuildInstancePolicy":                   true, // dual-listed in build
+		"BuildInstanceSecurityGroup":            true,
+		"EnableContainerReadonlyRootFilesystem": true,
+		"EnableSharedEFSVolumeEncryption":       true, // dual-listed in storage
+		"EncryptEbs":                            true, // dual-listed in storage
+		"Encryption":                            true,
+		"HttpProxy":                             true, // dual-listed in network
+		"IMDSHttpPutResponseHopLimit":           true,
+		"IMDSHttpTokens":                        true,
+		"InstancePolicy":                        true, // dual-listed in instances
+		"InstanceSecurityGroup":                 true,
+		"InstancesIpToIncludInWhiteListing":     true,
+		"Key":                                   true,
+		"Password":                              true,
+		"PrivateApiSecurityGroup":               true,
+		"RouterInternalSecurityGroup":           true,
+		"RouterSecurityGroup":                   true,
+		"SslPolicy":                             true,
+		"WhiteList":                             true,
+	},
+	"scaling": {
+		"Autoscale":                      true,
+		"AutoscaleExtra":                 true,
+		"HighAvailability":               true,
+		"InstanceCount":                  true,
+		"InstanceUpdateBatchSize":        true,
+		"NoHAAutoscaleExtra":             true,
+		"NoHaInstanceCount":              true,
+		"OnDemandMinCount":               true,
+		"ScheduleRackScaleDown":          true,
+		"ScheduleRackScaleUp":            true,
+		"SpotFleetAllocationStrategy":    true,
+		"SpotFleetAllowedInstanceTypes":  true,
+		"SpotFleetExcludedInstanceTypes": true,
+		"SpotFleetMaxPrice":              true,
+		"SpotFleetMinMemoryMiB":          true,
+		"SpotFleetMinOnDemandCount":      true,
+		"SpotFleetMinVcpuCount":          true,
+		"SpotFleetTargetType":            true,
+		"SpotInstanceBid":                true,
+	},
+	"instances": {
+		"Ami":                 true,
+		"CpuCredits":          true,
+		"DefaultAmi":          true,
+		"DefaultAmiArm":       true,
+		"InstanceBootCommand": true,
+		"InstancePolicy":      true, // dual-listed in security
+		"InstanceRunCommand":  true,
+		"InstanceType":        true,
+		"SwapSize":            true,
+		"Tenancy":             true,
+		"VolumeSize":          true,
+	},
+	"build": {
+		"BuildCpu":                    true,
+		"BuildImage":                  true,
+		"BuildInstance":               true,
+		"BuildInstancePolicy":         true, // dual-listed in security
+		"BuildMemory":                 true,
+		"BuildMethod":                 true,
+		"BuildVolumeSize":             true,
+		"FargateBuildCpu":             true,
+		"FargateBuildMemory":          true,
+		"PrivateBuild":                true,
+		"PruneOlderImagesCronRunFreq": true,
+		"PruneOlderImagesInHour":      true,
+	},
+	"api": {
+		"ApiCount":                true,
+		"ApiCpu":                  true,
+		"ApiMonitorMemory":        true,
+		"ApiRouter":               true,
+		"ApiWebMemory":            true,
+		"DisableALBPort80":        true,
+		"InternalRouterSuffix":    true,
+		"LoadBalancerIdleTimeout": true,
+		"PrivateApi":              true,
+		"RouterMitigationMode":    true,
+	},
+	"logging": {
+		"LogBucket":         true,
+		"LogDriver":         true,
+		"LogRetention":      true,
+		"SyslogDestination": true,
+		"SyslogFormat":      true,
+	},
+	"storage": {
+		"DynamoDbTableDeletionProtectionEnabled":  true,
+		"DynamoDbTablePointInTimeRecoveryEnabled": true,
+		"EnableS3Versioning":                      true,
+		"EnableSharedEFSVolumeEncryption":         true, // dual-listed in security
+		"EncryptEbs":                              true, // dual-listed in security
+	},
+	"meta": {
+		"ClientId":                true,
+		"Development":             true,
+		"EcsContainerStopTimeout": true,
+		"EcsPollInterval":         true,
+		"ImagePullBehavior":       true,
+		"MaintainTimerState":      true,
+		"Telemetry":               true,
+		"Version":                 true,
+	},
+}
+
+// groupDescriptions provides the one-line label shown next to each group
+// name in error output (e.g., unknown-group and ambiguous-prefix errors).
+// Keep in sync with paramGroups keys.
+var groupDescriptions = map[string]string{
+	"network":   "VPC, subnets, gateways, connectivity, proxy",
+	"nlb":       "Network Load Balancer: listeners, cross-zone, allow-CIDR, preserve-client-IP",
+	"security":  "Credentials, allowlists, SGs, SSL, IMDS, container hardening",
+	"scaling":   "Autoscaling, spot fleet, instance counts, schedules, HA",
+	"instances": "AMI, instance type, boot/run commands, IAM policy, volumes, tenancy",
+	"build":     "Build method, build instance, Fargate build, image pruning",
+	"api":       "Rack API web process config, router, ingress toggles",
+	"logging":   "Logs destination, retention, syslog format",
+	"storage":   "S3 versioning, DynamoDB protection, EFS encryption",
+	"meta":      "Version, development mode, telemetry, client ID, ECS tuning",
+}
+
+// resolveGroup resolves a possibly-partial group name to an exact group key.
+// Priority: exact match > unique prefix match. Case-insensitive. Whitespace
+// is trimmed. Returns an error listing candidates or all groups on
+// ambiguous / unknown / empty input.
+func resolveGroup(input string) (string, error) {
+	input = strings.ToLower(strings.TrimSpace(input))
+	if input == "" {
+		return "", fmt.Errorf("group name required\n  %s", formatGroupList())
+	}
+
+	if _, ok := paramGroups[input]; ok {
+		return input, nil
+	}
+
+	var matches []string
+	for g := range paramGroups {
+		if strings.HasPrefix(g, input) {
+			matches = append(matches, g)
+		}
+	}
+	sort.Strings(matches)
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("group '%s' not found\n  %s", input, formatGroupList())
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("group '%s' matches multiple groups: %s %s\n  %s",
+			input, strings.Join(matches, ", "), formatAmbiguousHint(matches), formatGroupList())
+	}
+}
+
+// formatGroupList returns a sorted, padded two-column listing of all
+// available groups for inclusion in error output.
+func formatGroupList() string {
+	names := make([]string, 0, len(groupDescriptions))
+	maxLen := 0
+	for g := range groupDescriptions {
+		names = append(names, g)
+		if len(g) > maxLen {
+			maxLen = len(g)
+		}
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	b.WriteString("available groups:\n")
+	for _, g := range names {
+		b.WriteString(fmt.Sprintf("  %-*s    %s\n", maxLen, g, groupDescriptions[g]))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// formatAmbiguousHint returns a parenthesized hint showing a short-but-
+// readable disambiguating prefix for each ambiguous candidate, e.g.,
+// "(use 'net' or 'nlb')" for candidates ["network", "nlb"].
+func formatAmbiguousHint(candidates []string) string {
+	if len(candidates) == 0 {
+		return ""
+	}
+	hints := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		hints = append(hints, "'"+disambiguatingPrefix(c)+"'")
+	}
+	switch len(hints) {
+	case 1:
+		return "(use " + hints[0] + ")"
+	case 2:
+		return "(use " + hints[0] + " or " + hints[1] + ")"
+	default:
+		return "(use " + strings.Join(hints[:len(hints)-1], ", ") + ", or " + hints[len(hints)-1] + ")"
+	}
+}
+
+// disambiguatingPrefix returns a short-but-readable prefix of `group` that
+// resolves uniquely against all paramGroups keys. Uses a 3-character
+// minimum for human readability — a technically-unique 1- or 2-char
+// prefix like "ne" for "network" reads like an abbreviation and is avoided.
+func disambiguatingPrefix(group string) string {
+	const minLen = 3
+	if len(group) <= minLen {
+		return group
+	}
+	for n := minLen; n <= len(group); n++ {
+		prefix := group[:n]
+		hits := 0
+		for g := range paramGroups {
+			if strings.HasPrefix(g, prefix) {
+				hits++
+				if hits > 1 {
+					break
+				}
+			}
+		}
+		if hits == 1 {
+			return prefix
+		}
+	}
+	return group
+}
+
 func init() {
 	register("rack", "get information about the rack", Rack, stdcli.CommandOptions{
 		Flags:    []stdcli.Flag{flagRack},
@@ -54,7 +326,11 @@ func init() {
 	})
 
 	register("rack params", "display rack parameters", RackParams, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack},
+		Flags: []stdcli.Flag{
+			flagRack,
+			stdcli.StringFlag("group", "g", "filter to a param group (invalid name lists all)"),
+			stdcli.BoolFlag("reveal", "", "show unmasked param values"),
+		},
 		Validate: stdcli.Args(0),
 	})
 
@@ -307,26 +583,59 @@ func RackLogs(rack sdk.Interface, c *stdcli.Context) error {
 }
 
 func RackParams(rack sdk.Interface, c *stdcli.Context) error {
+	var (
+		groupFilter   map[string]bool
+		resolvedGroup string
+	)
+	if groupInput := c.String("group"); groupInput != "" {
+		resolved, rerr := resolveGroup(groupInput)
+		if rerr != nil {
+			return rerr
+		}
+		resolvedGroup = resolved
+		groupFilter = paramGroups[resolved]
+	}
+
 	s, err := rack.SystemGet()
 	if err != nil {
 		return err
 	}
 
 	keys := []string{}
-
 	for k := range s.Parameters {
 		keys = append(keys, k)
 	}
-
 	sort.Strings(keys)
 
+	shouldMask := !c.Bool("reveal") && IsTerminalFn(c)
+
 	i := c.Info()
+	rowsAdded := 0
 
 	for _, k := range keys {
-		i.Add(k, s.Parameters[k])
+		if groupFilter != nil && !groupFilter[k] {
+			continue
+		}
+		v := s.Parameters[k]
+		if shouldMask && sensitiveParams[k] && v != "" {
+			v = "**********"
+		}
+		i.Add(k, v)
+		rowsAdded++
 	}
 
-	return i.Print()
+	if err := i.Print(); err != nil {
+		return err
+	}
+
+	if groupFilter != nil && rowsAdded == 0 {
+		// Write via stdcli's captured writer so test harnesses observe the
+		// NOTICE. V3 writes to os.Stderr directly; V2 diverges here because
+		// V2's test infrastructure routes stderr through the Writer.
+		fmt.Fprintf(c.Writer().Stderr, "NOTICE: no params in group '%s' for this rack\n", resolvedGroup)
+	}
+
+	return nil
 }
 
 func RackParamsSet(rack sdk.Interface, c *stdcli.Context) error {

--- a/pkg/cli/rack_group_test.go
+++ b/pkg/cli/rack_group_test.go
@@ -1,0 +1,225 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveGroup_ExactMatch(t *testing.T) {
+	cases := []string{
+		"network", "nlb", "security", "scaling", "instances",
+		"build", "api", "logging", "storage", "meta",
+	}
+	for _, g := range cases {
+		t.Run(g, func(t *testing.T) {
+			got, err := resolveGroup(g)
+			require.NoError(t, err)
+			require.Equal(t, g, got)
+		})
+	}
+}
+
+func TestResolveGroup_CaseInsensitiveAndTrim(t *testing.T) {
+	cases := map[string]string{
+		"NETWORK":     "network",
+		"Network":     "network",
+		"  network  ": "network",
+		"\tNLB\n":     "nlb",
+		" SECURITY ":  "security",
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			got, err := resolveGroup(input)
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+func TestResolveGroup_UniquePrefix(t *testing.T) {
+	cases := map[string]string{
+		"net":  "network",
+		"netw": "network",
+		"nl":   "nlb",
+		"sec":  "security",
+		"sto":  "storage",
+		"sca":  "scaling",
+		"in":   "instances",
+		"ins":  "instances",
+		"bu":   "build",
+		"log":  "logging",
+		"me":   "meta",
+		"ap":   "api",
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			got, err := resolveGroup(input)
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+func TestResolveGroup_AmbiguousPrefix(t *testing.T) {
+	_, err := resolveGroup("n")
+	require.Error(t, err)
+	msg := err.Error()
+	require.Contains(t, msg, "matches multiple groups")
+	require.Contains(t, msg, "network")
+	require.Contains(t, msg, "nlb")
+}
+
+func TestResolveGroup_Unknown(t *testing.T) {
+	_, err := resolveGroup("not-a-group")
+	require.Error(t, err)
+	msg := err.Error()
+	require.Contains(t, msg, "not found")
+	require.Contains(t, msg, "available groups")
+	require.Contains(t, msg, "network")
+}
+
+func TestResolveGroup_Empty(t *testing.T) {
+	_, err := resolveGroup("")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "group name required")
+}
+
+func TestResolveGroup_WhitespaceOnly(t *testing.T) {
+	_, err := resolveGroup("   ")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "group name required")
+}
+
+func TestResolveGroup_AmbiguityHintFormat(t *testing.T) {
+	_, err := resolveGroup("n")
+	require.Error(t, err)
+	msg := err.Error()
+	// Hint uses disambiguatingPrefix (3-char min). For 'n' -> 'network', 'nlb':
+	// disambiguatingPrefix("network") = "net"; disambiguatingPrefix("nlb") = "nlb" (already 3 chars).
+	// Resulting hint: "(use 'net' or 'nlb')"
+	require.Contains(t, msg, "(use 'net' or 'nlb')")
+}
+
+func TestResolveGroup_FormatGroupListShowsAllTen(t *testing.T) {
+	_, err := resolveGroup("invalid-name")
+	require.Error(t, err, "expected error for unknown group")
+	msg := err.Error()
+	for _, g := range []string{
+		"api", "build", "instances", "logging", "meta",
+		"network", "nlb", "scaling", "security", "storage",
+	} {
+		require.Contains(t, msg, g, "expected group %q in error output", g)
+	}
+}
+
+func TestDisambiguatingPrefix_ThreeCharMin(t *testing.T) {
+	cases := map[string]string{
+		"network":   "net",
+		"nlb":       "nlb",
+		"security":  "sec",
+		"storage":   "sto",
+		"scaling":   "sca",
+		"instances": "ins",
+		"build":     "bui",
+		"logging":   "log",
+		"meta":      "met",
+		"api":       "api",
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			got := disambiguatingPrefix(input)
+			require.Equal(t, want, got, "disambiguating prefix for %q", input)
+		})
+	}
+}
+
+// TestFormatGroupList_SortedWithDescriptions asserts the group list in error
+// output is sorted and each group is followed by its description. The expected
+// prefix is "\n  "+group+" " (2 leading spaces) per V3 parity — see
+// formatGroupList in rack.go.
+func TestFormatGroupList_SortedWithDescriptions(t *testing.T) {
+	_, err := resolveGroup("trigger-the-error-path")
+	require.Error(t, err)
+	msg := err.Error()
+
+	expected := []string{"api", "build", "instances", "logging", "meta", "network", "nlb", "scaling", "security", "storage"}
+	lastIdx := -1
+	for _, g := range expected {
+		idx := strings.Index(msg, "\n  "+g+" ")
+		require.GreaterOrEqual(t, idx, 0, "expected group %q to appear in formatted error output (2-space-indented)", g)
+		require.Greater(t, idx, lastIdx, "group %q should appear in sorted order", g)
+		lastIdx = idx
+	}
+}
+
+// TestSensitiveParamsList asserts the exact mask list. Guards against
+// accidental additions (non-credential params slipping into masking) or
+// removals (credentials slipping OUT of masking).
+func TestSensitiveParamsList(t *testing.T) {
+	want := map[string]bool{
+		"Password":  true,
+		"HttpProxy": true,
+	}
+	require.Equal(t, want, sensitiveParams, "sensitiveParams must equal the exact mask list per spec")
+
+	for _, k := range []string{
+		"Key",
+		"SyslogDestination",
+		"InstancePolicy",
+		"BuildInstancePolicy",
+		"LogBucket",
+		"ClientId",
+		"WhiteList",
+		"NLBAllowCIDR",
+		"Encryption",
+		"VPCCIDR",
+		"Ami",
+		"Version",
+	} {
+		require.False(t, sensitiveParams[k], "%s must NOT be in sensitiveParams per spec rubric", k)
+	}
+}
+
+// TestParamGroupsCoverRackJSON asserts that every Parameter in
+// provider/aws/formation/rack.json appears in at least one group, and
+// every group member appears in rack.json. Dual-listing IS allowed — a
+// param may appear in multiple groups.
+func TestParamGroupsCoverRackJSON(t *testing.T) {
+	data, err := os.ReadFile("../../provider/aws/formation/rack.json")
+	require.NoError(t, err, "must be able to read rack.json from test cwd")
+
+	var rack struct {
+		Parameters map[string]json.RawMessage `json:"Parameters"`
+	}
+	require.NoError(t, json.Unmarshal(data, &rack))
+	require.NotEmpty(t, rack.Parameters, "rack.json should have Parameters")
+
+	allGroupMembers := map[string]bool{}
+	for _, gmembers := range paramGroups {
+		for k := range gmembers {
+			allGroupMembers[k] = true
+		}
+	}
+
+	var orphans []string
+	for k := range rack.Parameters {
+		if !allGroupMembers[k] {
+			orphans = append(orphans, k)
+		}
+	}
+	require.Empty(t, orphans, "rack.json params missing from any group in paramGroups: %v", orphans)
+
+	var stale []string
+	for k := range allGroupMembers {
+		if _, ok := rack.Parameters[k]; !ok {
+			stale = append(stale, k)
+		}
+	}
+	require.Empty(t, stale, "paramGroups members not in rack.json Parameters: %v", stale)
+
+	require.Equal(t, 110, len(rack.Parameters), "post-hardening rack.json should have 110 Parameters")
+}

--- a/pkg/cli/rack_test.go
+++ b/pkg/cli/rack_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/convox/rack/pkg/options"
 	"github.com/convox/rack/pkg/structs"
 	"github.com/convox/rack/provider"
+	"github.com/convox/stdcli"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -198,6 +199,10 @@ func TestRackLogsError(t *testing.T) {
 }
 
 func TestRackParams(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return false }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(fxSystem(), nil)
 
@@ -214,6 +219,10 @@ func TestRackParams(t *testing.T) {
 }
 
 func TestRackParamsError(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return false }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(nil, fmt.Errorf("err1"))
 
@@ -226,6 +235,10 @@ func TestRackParamsError(t *testing.T) {
 }
 
 func TestRackParamsSet(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return false }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(fxSystem(), nil)
 		opts := structs.SystemUpdateOptions{
@@ -245,6 +258,10 @@ func TestRackParamsSet(t *testing.T) {
 }
 
 func TestRackParamsSetError(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return false }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(fxSystem(), nil)
 		opts := structs.SystemUpdateOptions{
@@ -264,6 +281,10 @@ func TestRackParamsSetError(t *testing.T) {
 }
 
 func TestRackParamsSetClassic(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return false }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(fxSystemClassic(), nil)
 		i.On("AppParametersSet", "name", map[string]string{"Foo": "bar", "Baz": "qux"}).Return(nil)
@@ -277,6 +298,10 @@ func TestRackParamsSetClassic(t *testing.T) {
 }
 
 func TestRackParamsSetClassicError(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return false }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(fxSystemClassic(), nil)
 		i.On("AppParametersSet", "name", map[string]string{"Foo": "bar", "Baz": "qux"}).Return(fmt.Errorf("err1"))
@@ -286,6 +311,253 @@ func TestRackParamsSetClassicError(t *testing.T) {
 		require.Equal(t, 1, res.Code)
 		res.RequireStderr(t, []string{"ERROR: err1"})
 		res.RequireStdout(t, []string{"Updating parameters... "})
+	})
+}
+
+// --- Integration tests for `rack params` masking and -g/--reveal flags ---
+
+// fxSystemWithSensitive is a system fixture with values for masked params.
+func fxSystemWithSensitive() *structs.System {
+	return &structs.System{
+		Parameters: map[string]string{
+			"Password":     "secret123",
+			"HttpProxy":    "http://user:pass@proxy.corp:8080",
+			"VPCCIDR":      "10.0.0.0/16",
+			"Version":      "3.25.0",
+			"Autoscale":    "Yes",
+			"InstanceType": "t3.medium",
+			"Telemetry":    "Yes",
+		},
+	}
+}
+
+func TestRackParamsMaskOnTTY(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return true }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystemWithSensitive(), nil)
+
+		res, err := testExecute(e, "rack params", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"Autoscale     Yes",
+			"HttpProxy     **********",
+			"InstanceType  t3.medium",
+			"Password      **********",
+			"Telemetry     Yes",
+			"VPCCIDR       10.0.0.0/16",
+			"Version       3.25.0",
+		})
+	})
+}
+
+func TestRackParamsNoMaskOnPipe(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return false }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystemWithSensitive(), nil)
+
+		res, err := testExecute(e, "rack params", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"Autoscale     Yes",
+			"HttpProxy     http://user:pass@proxy.corp:8080",
+			"InstanceType  t3.medium",
+			"Password      secret123",
+			"Telemetry     Yes",
+			"VPCCIDR       10.0.0.0/16",
+			"Version       3.25.0",
+		})
+	})
+}
+
+func TestRackParamsRevealBypassesMaskOnTTY(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return true }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystemWithSensitive(), nil)
+
+		res, err := testExecute(e, "rack params --reveal", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"Autoscale     Yes",
+			"HttpProxy     http://user:pass@proxy.corp:8080",
+			"InstanceType  t3.medium",
+			"Password      secret123",
+			"Telemetry     Yes",
+			"VPCCIDR       10.0.0.0/16",
+			"Version       3.25.0",
+		})
+	})
+}
+
+// TestRackParamsMaskedTTYWithGroupFilter verifies masking applies inside a
+// group filter on TTY. Password is dual-listed in the security group, so
+// `-g security` on TTY must still mask Password.
+func TestRackParamsMaskedTTYWithGroupFilter(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return true }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		sys := &structs.System{
+			Parameters: map[string]string{
+				"Password":   "secret",
+				"Encryption": "Yes",
+				"WhiteList":  "1.2.3.4/32",
+				"VPCCIDR":    "10.0.0.0/16",
+				"Autoscale":  "Yes",
+			},
+		}
+		i.On("SystemGet").Return(sys, nil)
+
+		res, err := testExecute(e, "rack params -g security", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"Encryption  Yes",
+			"Password    **********",
+			"WhiteList   1.2.3.4/32",
+		})
+	})
+}
+
+// TestRackParamsSensitiveEmptyValueNotMasked verifies the `v != ""` guard:
+// a sensitive param with an empty string value stays empty, not "**********".
+func TestRackParamsSensitiveEmptyValueNotMasked(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return true }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		sys := &structs.System{
+			Parameters: map[string]string{
+				"Password":  "",
+				"HttpProxy": "",
+				"VPCCIDR":   "10.0.0.0/16",
+				"Autoscale": "Yes",
+			},
+		}
+		i.On("SystemGet").Return(sys, nil)
+
+		res, err := testExecute(e, "rack params", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.NotContains(t, res.Stdout, "**********", "empty sensitive values must not render as asterisks")
+		require.Contains(t, res.Stdout, "Password")
+		require.Contains(t, res.Stdout, "HttpProxy")
+	})
+}
+
+func TestRackParamsGroupFilterSecurity(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return false }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		sys := &structs.System{
+			Parameters: map[string]string{
+				"Password":   "secret",
+				"VPCCIDR":    "10.0.0.0/16",
+				"Autoscale":  "Yes",
+				"Encryption": "Yes",
+				"WhiteList":  "1.2.3.4/32",
+			},
+		}
+		i.On("SystemGet").Return(sys, nil)
+
+		res, err := testExecute(e, "rack params -g security", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"Encryption  Yes",
+			"Password    secret",
+			"WhiteList   1.2.3.4/32",
+		})
+	})
+}
+
+// TestRackParamsGroupFilterEmptyFallthrough: -g "" falls through to full
+// unfiltered dump per V3 parity (caller-side guard prevents resolveGroup
+// from being called with empty input).
+func TestRackParamsGroupFilterEmptyFallthrough(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return false }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		sys := &structs.System{
+			Parameters: map[string]string{
+				"Password":  "secret",
+				"VPCCIDR":   "10.0.0.0/16",
+				"Autoscale": "Yes",
+			},
+		}
+		i.On("SystemGet").Return(sys, nil)
+
+		res, err := testExecute(e, "rack params -g ''", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"Autoscale  Yes",
+			"Password   secret",
+			"VPCCIDR    10.0.0.0/16",
+		})
+	})
+}
+
+// TestRackParamsGroupFilterWhitespaceOnlyErrors: -g "   " passes the caller-
+// side non-empty guard, reaches resolveGroup, which trims to empty and
+// returns the `group name required` error. Exit non-zero.
+func TestRackParamsGroupFilterWhitespaceOnlyErrors(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		res, err := testExecute(e, "rack params -g '   '", nil)
+		require.NoError(t, err)
+		require.NotEqual(t, 0, res.Code)
+		require.Contains(t, res.Stderr, "group name required")
+		require.Contains(t, res.Stderr, "available groups")
+	})
+}
+
+func TestRackParamsGroupFilterUnknownErrors(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		res, err := testExecute(e, "rack params -g notarealgroup", nil)
+		require.NoError(t, err)
+		require.NotEqual(t, 0, res.Code)
+		require.Contains(t, res.Stderr, "not found")
+		require.Contains(t, res.Stderr, "network")
+	})
+}
+
+// TestRackParamsEmptyGroupNotice: group resolves but rack has zero matching
+// params — print stderr NOTICE + exit 0.
+func TestRackParamsEmptyGroupNotice(t *testing.T) {
+	prev := cli.IsTerminalFn
+	cli.IsTerminalFn = func(_ *stdcli.Context) bool { return false }
+	t.Cleanup(func() { cli.IsTerminalFn = prev })
+
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		sys := &structs.System{
+			Parameters: map[string]string{
+				"Autoscale": "Yes",
+				"VPCCIDR":   "10.0.0.0/16",
+			},
+		}
+		i.On("SystemGet").Return(sys, nil)
+
+		res, err := testExecute(e, "rack params -g nlb", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.Contains(t, res.Stderr, "NOTICE: no params in group 'nlb' for this rack")
 	})
 }
 

--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -82,6 +82,19 @@ func Services(rack sdk.Interface, c *stdcli.Context) error {
 				if np.Scheme == "internal" {
 					cell += "(internal)"
 				}
+				var attrs []string
+				if np.CrossZone != nil {
+					attrs = append(attrs, fmt.Sprintf("cz=%t", *np.CrossZone))
+				}
+				if len(np.AllowCIDR) > 0 {
+					attrs = append(attrs, fmt.Sprintf("allow=%d", len(np.AllowCIDR)))
+				}
+				if np.PreserveClientIP != nil {
+					attrs = append(attrs, fmt.Sprintf("pcip=%t", *np.PreserveClientIP))
+				}
+				if len(attrs) > 0 {
+					cell += "[" + strings.Join(attrs, " ") + "]"
+				}
 				nlbs = append(nlbs, cell)
 			}
 			row = append(row, strings.Join(nlbs, " "))

--- a/pkg/cli/services_test.go
+++ b/pkg/cli/services_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/convox/rack/pkg/cli"
 	mocksdk "github.com/convox/rack/pkg/mock/sdk"
+	"github.com/convox/rack/pkg/options"
 	"github.com/convox/rack/pkg/structs"
 	"github.com/stretchr/testify/require"
 )
@@ -212,6 +213,109 @@ func TestServicesWorkerOnlyNLB(t *testing.T) {
 			"SERVICE  DOMAIN  PORTS  NLB PORTS",
 			"worker                  8443:8443",
 			"web      domain  1:2    ",
+		})
+	})
+}
+
+func TestServicesNLBAllDefaults(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystem(), nil)
+		s := fxService()
+		s.Nlb = []structs.ServiceNlbPort{
+			{Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public"},
+		}
+		i.On("ServiceList", "app1").Return(structs.Services{*s}, nil)
+
+		res, err := testExecute(e, "services -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"SERVICE   DOMAIN  PORTS    NLB PORTS",
+			"service1  domain  1:2 1:2  8443:8443",
+		})
+	})
+}
+
+func TestServicesNLBCrossZoneOnly(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystem(), nil)
+		s := fxService()
+		s.Nlb = []structs.ServiceNlbPort{
+			{Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public", CrossZone: options.Bool(true)},
+		}
+		i.On("ServiceList", "app1").Return(structs.Services{*s}, nil)
+
+		res, err := testExecute(e, "services -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"SERVICE   DOMAIN  PORTS    NLB PORTS",
+			"service1  domain  1:2 1:2  8443:8443[cz=true]",
+		})
+	})
+}
+
+func TestServicesNLBCrossZoneFalse(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystem(), nil)
+		s := fxService()
+		s.Nlb = []structs.ServiceNlbPort{
+			{Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public", CrossZone: options.Bool(false)},
+		}
+		i.On("ServiceList", "app1").Return(structs.Services{*s}, nil)
+
+		res, err := testExecute(e, "services -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"SERVICE   DOMAIN  PORTS    NLB PORTS",
+			"service1  domain  1:2 1:2  8443:8443[cz=false]",
+		})
+	})
+}
+
+func TestServicesNLBAllowCIDR(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystem(), nil)
+		s := fxService()
+		s.Nlb = []structs.ServiceNlbPort{
+			{
+				Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public",
+				AllowCIDR: []string{"10.0.0.0/24", "10.1.0.0/24"},
+			},
+		}
+		i.On("ServiceList", "app1").Return(structs.Services{*s}, nil)
+
+		res, err := testExecute(e, "services -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"SERVICE   DOMAIN  PORTS    NLB PORTS",
+			"service1  domain  1:2 1:2  8443:8443[allow=2]",
+		})
+	})
+}
+
+func TestServicesNLBAllThree(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemGet").Return(fxSystem(), nil)
+		s := fxService()
+		s.Nlb = []structs.ServiceNlbPort{
+			{
+				Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public",
+				CrossZone:        options.Bool(true),
+				AllowCIDR:        []string{"10.0.0.0/24", "10.1.0.0/24"},
+				PreserveClientIP: options.Bool(false),
+			},
+		}
+		i.On("ServiceList", "app1").Return(structs.Services{*s}, nil)
+
+		res, err := testExecute(e, "services -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"SERVICE   DOMAIN  PORTS    NLB PORTS",
+			"service1  domain  1:2 1:2  8443:8443[cz=true allow=2 pcip=false]",
 		})
 	})
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"regexp"
 	"sort"
 	"strings"
@@ -248,6 +249,23 @@ func (m *Manifest) Validate() error {
 			}
 			if np.Scheme != "public" && np.Scheme != "internal" {
 				return fmt.Errorf("service %s nlb port %d: scheme must be public or internal, got %q", s.Name, np.Port, np.Scheme)
+			}
+			seenAllowCIDR := map[string]bool{}
+			for _, c := range np.AllowCIDR {
+				ip, ipnet, err := net.ParseCIDR(c)
+				if err != nil {
+					return fmt.Errorf("service %s nlb port %d: allow_cidr entry %q is not a valid IPv4 CIDR (e.g. 10.0.0.0/16)", s.Name, np.Port, c)
+				}
+				if ip.To4() == nil {
+					return fmt.Errorf("service %s nlb port %d: allow_cidr entry %q is not a valid IPv4 CIDR (IPv6 not supported)", s.Name, np.Port, c)
+				}
+				if ipnet.String() != c {
+					return fmt.Errorf("service %s nlb port %d: allow_cidr entry %q is not canonical; use %q instead", s.Name, np.Port, c, ipnet.String())
+				}
+				if seenAllowCIDR[c] {
+					return fmt.Errorf("service %s nlb port %d: allow_cidr contains duplicate entry: %s", s.Name, np.Port, c)
+				}
+				seenAllowCIDR[c] = true
 			}
 			if existing, ok := seenPorts[np.Port]; ok {
 				if existing != np.ContainerPort {

--- a/pkg/manifest/nlb_test.go
+++ b/pkg/manifest/nlb_test.go
@@ -320,3 +320,166 @@ func TestManifestValidateNLBValidatorOrderingProtocolWinsOverCert(t *testing.T) 
 		t.Errorf("validator ordering broken: got cert-error before protocol-error: %v", err)
 	}
 }
+
+func TestManifestLoadNLBNewFields(t *testing.T) {
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        cross_zone: true
+        allow_cidr: ["203.0.113.0/24", "198.51.100.5/32"]
+        preserve_client_ip: false
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, _ := m.Service("api")
+	if s.NLB[0].CrossZone == nil || *s.NLB[0].CrossZone != true {
+		t.Errorf("CrossZone: want true, got %v", s.NLB[0].CrossZone)
+	}
+	if len(s.NLB[0].AllowCIDR) != 2 {
+		t.Fatalf("AllowCIDR: want 2 entries, got %+v", s.NLB[0].AllowCIDR)
+	}
+	if s.NLB[0].AllowCIDR[0] != "203.0.113.0/24" {
+		t.Errorf("AllowCIDR[0]: got %q", s.NLB[0].AllowCIDR[0])
+	}
+	if s.NLB[0].PreserveClientIP == nil || *s.NLB[0].PreserveClientIP != false {
+		t.Errorf("PreserveClientIP: want false, got %v", s.NLB[0].PreserveClientIP)
+	}
+}
+
+func TestManifestLoadNLBNewFieldsDefaultsNil(t *testing.T) {
+	m, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, _ := m.Service("api")
+	if s.NLB[0].CrossZone != nil {
+		t.Errorf("CrossZone: want nil (inherit), got %v", s.NLB[0].CrossZone)
+	}
+	if len(s.NLB[0].AllowCIDR) != 0 {
+		t.Errorf("AllowCIDR: want empty slice, got %+v", s.NLB[0].AllowCIDR)
+	}
+	if s.NLB[0].PreserveClientIP != nil {
+		t.Errorf("PreserveClientIP: want nil (inherit), got %v", s.NLB[0].PreserveClientIP)
+	}
+}
+
+func TestManifestValidateNLBAllowCIDRMalformed(t *testing.T) {
+	_, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        allow_cidr: ["not-a-cidr"]
+`))
+	requireErrContains(t, err, `allow_cidr entry "not-a-cidr" is not a valid IPv4 CIDR`)
+}
+
+func TestManifestValidateNLBAllowCIDRIPv6Rejected(t *testing.T) {
+	_, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        allow_cidr: ["2001:db8::/32"]
+`))
+	requireErrContains(t, err, `is not a valid IPv4 CIDR`)
+}
+
+func TestManifestValidateNLBAllowCIDRInvalidOctet(t *testing.T) {
+	_, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        allow_cidr: ["256.0.0.0/8"]
+`))
+	requireErrContains(t, err, `is not a valid IPv4 CIDR`)
+}
+
+func TestManifestValidateNLBAllowCIDRInvalidMask(t *testing.T) {
+	_, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        allow_cidr: ["10.0.0.0/33"]
+`))
+	requireErrContains(t, err, `is not a valid IPv4 CIDR`)
+}
+
+func TestManifestValidateNLBAllowCIDRNonCanonical(t *testing.T) {
+	_, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        allow_cidr: ["10.0.0.1/24"]
+`))
+	requireErrContains(t, err, `not canonical`)
+}
+
+func TestManifestValidateNLBAllowCIDRDuplicate(t *testing.T) {
+	_, err := loadBytes(t, []byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        allow_cidr: ["10.0.0.0/24", "10.0.0.0/24"]
+`))
+	requireErrContains(t, err, `allow_cidr contains duplicate entry: 10.0.0.0/24`)
+}
+
+func TestManifestLoadNLBCrossZoneValue(t *testing.T) {
+	tru := true
+	fals := false
+	cases := []struct {
+		name string
+		np   manifest.ServiceNLBPort
+		want string
+	}{
+		{"nil inherits", manifest.ServiceNLBPort{}, ""},
+		{"true", manifest.ServiceNLBPort{CrossZone: &tru}, "true"},
+		{"false", manifest.ServiceNLBPort{CrossZone: &fals}, "false"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.np.CrossZoneValue(); got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestManifestLoadNLBPreserveClientIPValue(t *testing.T) {
+	tru := true
+	fals := false
+	cases := []struct {
+		name   string
+		np     manifest.ServiceNLBPort
+		pubDef string
+		intDef string
+		want   string
+	}{
+		{"nil+public default No", manifest.ServiceNLBPort{Scheme: "public"}, "No", "No", "false"},
+		{"nil+public default Yes", manifest.ServiceNLBPort{Scheme: "public"}, "Yes", "No", "true"},
+		{"nil+internal default Yes", manifest.ServiceNLBPort{Scheme: "internal"}, "No", "Yes", "true"},
+		{"nil+internal default No", manifest.ServiceNLBPort{Scheme: "internal"}, "Yes", "No", "false"},
+		{"per-port true wins", manifest.ServiceNLBPort{Scheme: "public", PreserveClientIP: &tru}, "No", "No", "true"},
+		{"per-port false wins", manifest.ServiceNLBPort{Scheme: "public", PreserveClientIP: &fals}, "Yes", "Yes", "false"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.np.PreserveClientIPValue(tc.pubDef, tc.intDef); got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -50,11 +50,14 @@ type ServiceAgentPort struct {
 }
 
 type ServiceNLBPort struct {
-	Port          int    `yaml:"port"`
-	Protocol      string `yaml:"protocol,omitempty"`
-	ContainerPort int    `yaml:"containerPort,omitempty"`
-	Scheme        string `yaml:"scheme,omitempty"`
-	Certificate   string `yaml:"certificate,omitempty"`
+	Port             int      `yaml:"port"`
+	Protocol         string   `yaml:"protocol,omitempty"`
+	ContainerPort    int      `yaml:"containerPort,omitempty"`
+	Scheme           string   `yaml:"scheme,omitempty"`
+	Certificate      string   `yaml:"certificate,omitempty"`
+	CrossZone        *bool    `yaml:"cross_zone,omitempty"`
+	AllowCIDR        []string `yaml:"allow_cidr,omitempty"`
+	PreserveClientIP *bool    `yaml:"preserve_client_ip,omitempty"`
 }
 
 type ServiceBuild struct {
@@ -189,4 +192,37 @@ func (s Service) Autoscale() bool {
 	}
 
 	return false
+}
+
+// CrossZoneValue returns "", "true", or "false". Empty means inherit from the
+// load balancer; the template omits the target-group attribute so AWS uses the
+// NLB's LB-level setting.
+func (np ServiceNLBPort) CrossZoneValue() string {
+	if np.CrossZone == nil {
+		return ""
+	}
+	if *np.CrossZone {
+		return "true"
+	}
+	return "false"
+}
+
+// PreserveClientIPValue returns "true" or "false" based on per-port override
+// or the scheme-appropriate rack default. publicDefault and internalDefault are
+// "Yes"/"No" strings as loaded from docker labels on the rack task definition.
+func (np ServiceNLBPort) PreserveClientIPValue(publicDefault, internalDefault string) string {
+	if np.PreserveClientIP != nil {
+		if *np.PreserveClientIP {
+			return "true"
+		}
+		return "false"
+	}
+	def := publicDefault
+	if np.Scheme == "internal" {
+		def = internalDefault
+	}
+	if def == "Yes" {
+		return "true"
+	}
+	return "false"
 }

--- a/pkg/structs/service.go
+++ b/pkg/structs/service.go
@@ -16,11 +16,14 @@ type Services []Service
 // intentionally to match the pkg/structs casing convention (Cpu, Nlb) rather
 // than the manifest package's all-caps initialism style.
 type ServiceNlbPort struct {
-	ContainerPort int    `json:"container-port"`
-	Port          int    `json:"port"`
-	Protocol      string `json:"protocol"`
-	Scheme        string `json:"scheme"`
-	Certificate   string `json:"certificate"`
+	ContainerPort    int      `json:"container-port"`
+	Port             int      `json:"port"`
+	Protocol         string   `json:"protocol"`
+	Scheme           string   `json:"scheme"`
+	Certificate      string   `json:"certificate"`
+	CrossZone        *bool    `json:"cross-zone,omitempty"`
+	AllowCIDR        []string `json:"allow-cidr,omitempty"`
+	PreserveClientIP *bool    `json:"preserve-client-ip,omitempty"`
 }
 
 type ServicePort struct {

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -73,6 +73,9 @@ type Provider struct {
 	LogDriver                         string
 	NLB                               bool
 	NLBInternal                       bool
+	NLBPreserveClientIP               bool
+	NLBInternalPreserveClientIP       bool
+	InstanceSecurityGroup             string
 	NotificationTopic                 string
 	OnDemandMinCount                  int
 	Password                          string
@@ -176,6 +179,9 @@ func (p *Provider) loadParams() error {
 	p.MaintainTimerState = labels["rack.MaintainTimerState"] == "Yes"
 	p.NLB = labels["rack.NLB"] == "Yes"
 	p.NLBInternal = labels["rack.NLBInternal"] == "Yes"
+	p.NLBPreserveClientIP = labels["rack.NLBPreserveClientIP"] == "Yes"
+	p.NLBInternalPreserveClientIP = labels["rack.NLBInternalPreserveClientIP"] == "Yes"
+	p.InstanceSecurityGroup = labels["rack.InstanceSecurityGroup"]
 	p.NotificationTopic = labels["rack.NotificationTopic"]
 	p.OnDemandMinCount = intParam(labels["rack.OnDemandMinCount"], 2)
 	p.Private = labels["rack.Private"] == "Yes"

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -18,6 +18,56 @@
       { "Condition": "HasNLB" },
       { "Condition": "ThirdAvailabilityZoneAndHighAvailability" }
     ] },
+    "NLBCrossZoneEnabled":                 { "Fn::Equals": [ { "Ref": "NLBCrossZone" }, "Yes" ] },
+    "NLBInternalCrossZoneEnabled":         { "Fn::Equals": [ { "Ref": "NLBInternalCrossZone" }, "Yes" ] },
+    "NLBPreserveClientIPEnabled":          { "Fn::Equals": [ { "Ref": "NLBPreserveClientIP" }, "Yes" ] },
+    "NLBInternalPreserveClientIPEnabled":  { "Fn::Equals": [ { "Ref": "NLBInternalPreserveClientIP" }, "Yes" ] },
+    "NLBDeletionProtectionEnabled":        { "Fn::Equals": [ { "Ref": "NLBDeletionProtection" }, "Yes" ] },
+    "NLBInternalDeletionProtectionEnabled":{ "Fn::Equals": [ { "Ref": "NLBInternalDeletionProtection" }, "Yes" ] },
+    "NLBInternalAllowCIDRBlank":           { "Fn::Equals": [ { "Ref": "NLBInternalAllowCIDR" }, "" ] },
+    "HasNLBAllowCIDRSlot0": { "Fn::And": [
+      { "Condition": "HasNLB" },
+      { "Fn::Not": [ { "Fn::Equals": [ { "Fn::Select": [ 0, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBAllowCIDR" }, ",,,,," ] ] } ] } ] }, "" ] } ] }
+    ] },
+    "HasNLBAllowCIDRSlot1": { "Fn::And": [
+      { "Condition": "HasNLB" },
+      { "Fn::Not": [ { "Fn::Equals": [ { "Fn::Select": [ 1, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBAllowCIDR" }, ",,,,," ] ] } ] } ] }, "" ] } ] }
+    ] },
+    "HasNLBAllowCIDRSlot2": { "Fn::And": [
+      { "Condition": "HasNLB" },
+      { "Fn::Not": [ { "Fn::Equals": [ { "Fn::Select": [ 2, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBAllowCIDR" }, ",,,,," ] ] } ] } ] }, "" ] } ] }
+    ] },
+    "HasNLBAllowCIDRSlot3": { "Fn::And": [
+      { "Condition": "HasNLB" },
+      { "Fn::Not": [ { "Fn::Equals": [ { "Fn::Select": [ 3, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBAllowCIDR" }, ",,,,," ] ] } ] } ] }, "" ] } ] }
+    ] },
+    "HasNLBAllowCIDRSlot4": { "Fn::And": [
+      { "Condition": "HasNLB" },
+      { "Fn::Not": [ { "Fn::Equals": [ { "Fn::Select": [ 4, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBAllowCIDR" }, ",,,,," ] ] } ] } ] }, "" ] } ] }
+    ] },
+    "HasNLBInternalAllowCIDRSlot0": { "Fn::And": [
+      { "Condition": "HasNLBInternal" },
+      { "Fn::Or": [
+        { "Condition": "NLBInternalAllowCIDRBlank" },
+        { "Fn::Not": [ { "Fn::Equals": [ { "Fn::Select": [ 0, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBInternalAllowCIDR" }, ",,,,," ] ] } ] } ] }, "" ] } ] }
+      ] }
+    ] },
+    "HasNLBInternalAllowCIDRSlot1": { "Fn::And": [
+      { "Condition": "HasNLBInternal" },
+      { "Fn::Not": [ { "Fn::Equals": [ { "Fn::Select": [ 1, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBInternalAllowCIDR" }, ",,,,," ] ] } ] } ] }, "" ] } ] }
+    ] },
+    "HasNLBInternalAllowCIDRSlot2": { "Fn::And": [
+      { "Condition": "HasNLBInternal" },
+      { "Fn::Not": [ { "Fn::Equals": [ { "Fn::Select": [ 2, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBInternalAllowCIDR" }, ",,,,," ] ] } ] } ] }, "" ] } ] }
+    ] },
+    "HasNLBInternalAllowCIDRSlot3": { "Fn::And": [
+      { "Condition": "HasNLBInternal" },
+      { "Fn::Not": [ { "Fn::Equals": [ { "Fn::Select": [ 3, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBInternalAllowCIDR" }, ",,,,," ] ] } ] } ] }, "" ] } ] }
+    ] },
+    "HasNLBInternalAllowCIDRSlot4": { "Fn::And": [
+      { "Condition": "HasNLBInternal" },
+      { "Fn::Not": [ { "Fn::Equals": [ { "Fn::Select": [ 4, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBInternalAllowCIDR" }, ",,,,," ] ] } ] } ] }, "" ] } ] }
+    ] },
     "BlankInstanceBootCommand": { "Fn::Equals": [ { "Ref": "InstanceBootCommand" }, "" ] },
     "BlankInstancePolicy": { "Fn::Equals": [ { "Ref": "InstancePolicy" }, "" ] },
     "BlankInstanceRunCommand": { "Fn::Equals": [ { "Ref": "InstanceRunCommand" }, "" ] },
@@ -480,6 +530,16 @@
       "Condition": "HasNLBInternal",
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBInternalHost" } },
       "Value": { "Fn::GetAtt": [ "NLBRouterInternal", "DNSName" ] }
+    },
+    "NLBSecurityGroup": {
+      "Condition": "HasNLB",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBSecurityGroup" } },
+      "Value": { "Ref": "NLBSecurity" }
+    },
+    "NLBInternalSecurityGroup": {
+      "Condition": "HasNLBInternal",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}:NLBInternalSecurityGroup" } },
+      "Value": { "Ref": "NLBInternalSecurity" }
     },
     "NotificationTopic": {
       "Value": { "Ref": "NotificationTopic" }
@@ -1007,6 +1067,52 @@
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ],
       "Description": "Create an internal Network Load Balancer for services that opt in (requires Internal=Yes)"
+    },
+    "NLBCrossZone": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ],
+      "Description": "Enable cross-zone load balancing on the public NLB. Off by default to match AWS default; enabling incurs cross-AZ data transfer charges"
+    },
+    "NLBInternalCrossZone": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ],
+      "Description": "Enable cross-zone load balancing on the internal NLB"
+    },
+    "NLBAllowCIDR": {
+      "Type": "String",
+      "Default": "0.0.0.0/0",
+      "Description": "Comma-delimited list of CIDRs permitted to reach public NLB listeners. Default 0.0.0.0/0. Maximum 5 CIDRs"
+    },
+    "NLBInternalAllowCIDR": {
+      "Type": "String",
+      "Default": "",
+      "Description": "Comma-delimited list of CIDRs permitted to reach internal NLB listeners. Empty = VPC CIDR only. Maximum 5 CIDRs. Setting this REPLACES the VPC CIDR fallback; include your VPC CIDR explicitly if you need in-rack reachability"
+    },
+    "NLBPreserveClientIP": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ],
+      "Description": "Forward real client IP to public NLB target tasks. Off by default. Cannot be enabled on a rack with a customer-supplied InstanceSecurityGroup"
+    },
+    "NLBInternalPreserveClientIP": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ],
+      "Description": "Forward real client IP to internal NLB target tasks. Same customer-SG caveat as NLBPreserveClientIP"
+    },
+    "NLBDeletionProtection": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ],
+      "Description": "Block accidental deletion of the public NLB. Must be disabled before NLB=No or rack uninstall"
+    },
+    "NLBInternalDeletionProtection": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ],
+      "Description": "Block accidental deletion of the internal NLB"
     },
     "NoHAAutoscaleExtra": {
       "Type": "Number",
@@ -3744,6 +3850,13 @@
       "Properties": {
         "Type": "network",
         "Scheme": "internet-facing",
+        "SecurityGroups": [ { "Ref": "NLBSecurity" } ],
+        "LoadBalancerAttributes": [
+          { "Key": "load_balancing.cross_zone.enabled",
+            "Value": { "Fn::If": [ "NLBCrossZoneEnabled", "true", "false" ] } },
+          { "Key": "deletion_protection.enabled",
+            "Value": { "Fn::If": [ "NLBDeletionProtectionEnabled", "true", "false" ] } }
+        ],
         "SubnetMappings": [
           { "SubnetId": { "Ref": "Subnet0" }, "AllocationId": { "Fn::GetAtt": [ "NLBAddress0", "AllocationId" ] } },
           { "SubnetId": { "Ref": "Subnet1" }, "AllocationId": { "Fn::GetAtt": [ "NLBAddress1", "AllocationId" ] } },
@@ -3763,6 +3876,13 @@
       "Properties": {
         "Type": "network",
         "Scheme": "internal",
+        "SecurityGroups": [ { "Ref": "NLBInternalSecurity" } ],
+        "LoadBalancerAttributes": [
+          { "Key": "load_balancing.cross_zone.enabled",
+            "Value": { "Fn::If": [ "NLBInternalCrossZoneEnabled", "true", "false" ] } },
+          { "Key": "deletion_protection.enabled",
+            "Value": { "Fn::If": [ "NLBInternalDeletionProtectionEnabled", "true", "false" ] } }
+        ],
         "SubnetMappings": { "Fn::If": [ "Private",
           [
             { "SubnetId": { "Ref": "SubnetPrivate0" } },
@@ -3784,6 +3904,135 @@
         "Tags": [
           { "Key": "Rack", "Value": { "Ref": "AWS::StackName" } }
         ]
+      }
+    },
+    "NLBSecurity": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Condition": "HasNLB",
+      "Properties": {
+        "GroupDescription": { "Fn::Sub": "${AWS::StackName} public NLB" },
+        "VpcId": { "Fn::If": [ "BlankExistingVpc", { "Ref": "Vpc" }, { "Ref": "ExistingVpc" } ] },
+        "Tags": [ { "Key": "Name", "Value": { "Fn::Sub": "${AWS::StackName}-nlb" } } ]
+      }
+    },
+    "NLBInternalSecurity": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Condition": "HasNLBInternal",
+      "Properties": {
+        "GroupDescription": { "Fn::Sub": "${AWS::StackName} internal NLB" },
+        "VpcId": { "Fn::If": [ "BlankExistingVpc", { "Ref": "Vpc" }, { "Ref": "ExistingVpc" } ] },
+        "Tags": [ { "Key": "Name", "Value": { "Fn::Sub": "${AWS::StackName}-nlb-internal" } } ]
+      }
+    },
+    "InstancesSecurityNLBIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLB",
+      "Properties": {
+        "GroupId": { "Ref": "InstancesSecurity" },
+        "IpProtocol": "-1",
+        "SourceSecurityGroupId": { "Ref": "NLBSecurity" }
+      }
+    },
+    "InstancesSecurityNLBInternalIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBInternal",
+      "Properties": {
+        "GroupId": { "Ref": "InstancesSecurity" },
+        "IpProtocol": "-1",
+        "SourceSecurityGroupId": { "Ref": "NLBInternalSecurity" }
+      }
+    },
+    "NLBAllowCIDRSlot0Ingress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBAllowCIDRSlot0",
+      "Properties": {
+        "GroupId": { "Ref": "NLBSecurity" },
+        "IpProtocol": "-1",
+        "CidrIp": { "Fn::Select": [ 0, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBAllowCIDR" }, ",,,,," ] ] } ] } ] }
+      }
+    },
+    "NLBAllowCIDRSlot1Ingress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBAllowCIDRSlot1",
+      "Properties": {
+        "GroupId": { "Ref": "NLBSecurity" },
+        "IpProtocol": "-1",
+        "CidrIp": { "Fn::Select": [ 1, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBAllowCIDR" }, ",,,,," ] ] } ] } ] }
+      }
+    },
+    "NLBAllowCIDRSlot2Ingress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBAllowCIDRSlot2",
+      "Properties": {
+        "GroupId": { "Ref": "NLBSecurity" },
+        "IpProtocol": "-1",
+        "CidrIp": { "Fn::Select": [ 2, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBAllowCIDR" }, ",,,,," ] ] } ] } ] }
+      }
+    },
+    "NLBAllowCIDRSlot3Ingress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBAllowCIDRSlot3",
+      "Properties": {
+        "GroupId": { "Ref": "NLBSecurity" },
+        "IpProtocol": "-1",
+        "CidrIp": { "Fn::Select": [ 3, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBAllowCIDR" }, ",,,,," ] ] } ] } ] }
+      }
+    },
+    "NLBAllowCIDRSlot4Ingress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBAllowCIDRSlot4",
+      "Properties": {
+        "GroupId": { "Ref": "NLBSecurity" },
+        "IpProtocol": "-1",
+        "CidrIp": { "Fn::Select": [ 4, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBAllowCIDR" }, ",,,,," ] ] } ] } ] }
+      }
+    },
+    "NLBInternalAllowCIDRSlot0Ingress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBInternalAllowCIDRSlot0",
+      "Properties": {
+        "GroupId": { "Ref": "NLBInternalSecurity" },
+        "IpProtocol": "-1",
+        "CidrIp": { "Fn::If": [ "NLBInternalAllowCIDRBlank",
+          { "Ref": "VPCCIDR" },
+          { "Fn::Select": [ 0, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBInternalAllowCIDR" }, ",,,,," ] ] } ] } ] }
+        ] }
+      }
+    },
+    "NLBInternalAllowCIDRSlot1Ingress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBInternalAllowCIDRSlot1",
+      "Properties": {
+        "GroupId": { "Ref": "NLBInternalSecurity" },
+        "IpProtocol": "-1",
+        "CidrIp": { "Fn::Select": [ 1, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBInternalAllowCIDR" }, ",,,,," ] ] } ] } ] }
+      }
+    },
+    "NLBInternalAllowCIDRSlot2Ingress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBInternalAllowCIDRSlot2",
+      "Properties": {
+        "GroupId": { "Ref": "NLBInternalSecurity" },
+        "IpProtocol": "-1",
+        "CidrIp": { "Fn::Select": [ 2, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBInternalAllowCIDR" }, ",,,,," ] ] } ] } ] }
+      }
+    },
+    "NLBInternalAllowCIDRSlot3Ingress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBInternalAllowCIDRSlot3",
+      "Properties": {
+        "GroupId": { "Ref": "NLBInternalSecurity" },
+        "IpProtocol": "-1",
+        "CidrIp": { "Fn::Select": [ 3, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBInternalAllowCIDR" }, ",,,,," ] ] } ] } ] }
+      }
+    },
+    "NLBInternalAllowCIDRSlot4Ingress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "HasNLBInternalAllowCIDRSlot4",
+      "Properties": {
+        "GroupId": { "Ref": "NLBInternalSecurity" },
+        "IpProtocol": "-1",
+        "CidrIp": { "Fn::Select": [ 4, { "Fn::Split": [ ",", { "Fn::Join": [ ",", [ { "Ref": "NLBInternalAllowCIDR" }, ",,,,," ] ] } ] } ] }
       }
     },
     "ApiBalancer": {
@@ -4203,6 +4452,9 @@
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
               "rack.NLB": { "Ref": "NLB" },
               "rack.NLBInternal": { "Ref": "NLBInternal" },
+              "rack.NLBPreserveClientIP":         { "Ref": "NLBPreserveClientIP" },
+              "rack.NLBInternalPreserveClientIP": { "Ref": "NLBInternalPreserveClientIP" },
+              "rack.InstanceSecurityGroup":       { "Ref": "InstanceSecurityGroup" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
@@ -4341,6 +4593,9 @@
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
               "rack.NLB": { "Ref": "NLB" },
               "rack.NLBInternal": { "Ref": "NLBInternal" },
+              "rack.NLBPreserveClientIP":         { "Ref": "NLBPreserveClientIP" },
+              "rack.NLBInternalPreserveClientIP": { "Ref": "NLBInternalPreserveClientIP" },
+              "rack.InstanceSecurityGroup":       { "Ref": "InstanceSecurityGroup" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
@@ -4471,6 +4726,9 @@
               "rack.LogBucket": { "Fn::If": [ "BlankLogBucket", { "Ref": "Logs" }, { "Ref": "LogBucket" } ] },
               "rack.NLB": { "Ref": "NLB" },
               "rack.NLBInternal": { "Ref": "NLBInternal" },
+              "rack.NLBPreserveClientIP":         { "Ref": "NLBPreserveClientIP" },
+              "rack.NLBInternalPreserveClientIP": { "Ref": "NLBInternalPreserveClientIP" },
+              "rack.InstanceSecurityGroup":       { "Ref": "InstanceSecurityGroup" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },
@@ -4623,6 +4881,9 @@
               "rack.MaintainTimerState": { "Ref": "MaintainTimerState" },
               "rack.NLB": { "Ref": "NLB" },
               "rack.NLBInternal": { "Ref": "NLBInternal" },
+              "rack.NLBPreserveClientIP":         { "Ref": "NLBPreserveClientIP" },
+              "rack.NLBInternalPreserveClientIP": { "Ref": "NLBInternalPreserveClientIP" },
+              "rack.InstanceSecurityGroup":       { "Ref": "InstanceSecurityGroup" },
               "rack.NotificationTopic": { "Ref": "NotificationTopic" },
               "rack.OnDemandMinCount": { "Ref": "OnDemandMinCount" },
               "rack.Private": { "Ref": "Private" },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -244,7 +244,10 @@
           "HealthCheckPort": "traffic-port",
           "TargetGroupAttributes": [
             { "Key": "deregistration_delay.timeout_seconds", "Value": "{{ $drain }}" },
-            { "Key": "preserve_client_ip.enabled", "Value": "false" }
+            { "Key": "preserve_client_ip.enabled", "Value": "{{ .PreserveClientIPValue $.NLBPreserveClientIPDefault $.NLBInternalPreserveClientIPDefault }}" }
+            {{ with $cz := .CrossZoneValue }},
+            { "Key": "load_balancing.cross_zone.enabled", "Value": "{{ $cz }}" }
+            {{ end }}
           ]
         }
       },
@@ -265,6 +268,20 @@
           {{ end }}
         }
       },
+      {{ end }}
+      {{ range $i, $nlb := .NLB }}
+        {{ range $j, $cidr := $nlb.AllowCIDR }}
+      "NLBPortIngress{{ $nlb.Port }}Cidr{{ $j }}": {
+        "Type": "AWS::EC2::SecurityGroupIngress",
+        "Properties": {
+          "GroupId": { "Fn::ImportValue": { "Fn::Sub": "{{ if eq $nlb.Scheme "internal" }}${Rack}:NLBInternalSecurityGroup{{ else }}${Rack}:NLBSecurityGroup{{ end }}" } },
+          "IpProtocol": "tcp",
+          "FromPort": {{ $nlb.Port }},
+          "ToPort": {{ $nlb.Port }},
+          "CidrIp": "{{ $cidr }}"
+        }
+      },
+        {{ end }}
       {{ end }}
       "MinCount": {
         "Type": "Custom::MathMin",
@@ -741,7 +758,8 @@
               { "IpProtocol": "tcp", "FromPort": "{{.Port.Port}}", "ToPort": "{{.Port.Port}}", "SourceSecurityGroupId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Router{{ if .Internal }}Internal{{ end }}SecurityGroup" } } }
             {{ end }}
             {{ range $i, $nlb := .NLB }}{{ if or $svcPort (gt $i 0) }},{{ end }}
-              { "IpProtocol": "tcp", "FromPort": {{ $nlb.ContainerPort }}, "ToPort": {{ $nlb.ContainerPort }}, "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } }
+              { "IpProtocol": "tcp", "FromPort": {{ $nlb.ContainerPort }}, "ToPort": {{ $nlb.ContainerPort }}, "CidrIp": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:VpcCidr" } } },
+              { "IpProtocol": "tcp", "FromPort": {{ $nlb.ContainerPort }}, "ToPort": {{ $nlb.ContainerPort }}, "SourceSecurityGroupId": { "Fn::ImportValue": { "Fn::Sub": "{{ if eq $nlb.Scheme "internal" }}${Rack}:NLBInternalSecurityGroup{{ else }}${Rack}:NLBSecurityGroup{{ end }}" } } }
             {{ end }}
           ],
           "Tags": [ { "Key": "Name", "Value": { "Fn::Sub": "${AWS::StackName}-service" } } ],

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -375,17 +375,19 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		}
 
 		stp := map[string]interface{}{
-			"App":            r.App,
-			"Autoscale":      autoscale,
-			"Build":          tp["Build"],
-			"DeploymentMin":  min,
-			"DeploymentMax":  max,
-			"Manifest":       tp["Manifest"],
-			"Password":       p.Password,
-			"Release":        tp["Release"],
-			"Service":        s,
-			"Tags":           s.Tags,
-			"WildcardDomain": tp["WildcardDomain"],
+			"App":                                r.App,
+			"Autoscale":                          autoscale,
+			"Build":                              tp["Build"],
+			"DeploymentMin":                      min,
+			"DeploymentMax":                      max,
+			"Manifest":                           tp["Manifest"],
+			"Password":                           p.Password,
+			"Release":                            tp["Release"],
+			"Service":                            s,
+			"Tags":                               s.Tags,
+			"WildcardDomain":                     tp["WildcardDomain"],
+			"NLBPreserveClientIPDefault":         yesNo(p.NLBPreserveClientIP),
+			"NLBInternalPreserveClientIPDefault": yesNo(p.NLBInternalPreserveClientIP),
 		}
 
 		data, err := formationTemplate("service", stp)
@@ -1083,9 +1085,13 @@ func (p *Provider) getResourceDBIdentifier(app, resourceName string) (string, er
 }
 
 // validateNLBSchemeMatch rejects releases whose manifest declares NLB ports whose
-// scheme (public/internal) does not have the corresponding rack NLB enabled.
+// scheme (public/internal) does not have the corresponding rack NLB enabled, and
+// releases that request per-port preserve_client_ip=true on a rack with a
+// customer-supplied InstanceSecurityGroup (the NLB-SG-source ingress rule is
+// added to the convox-managed InstancesSecurity SG, not the customer's SG).
 // Called early in release promote, before any CF or DynamoDB writes.
 func (p *Provider) validateNLBSchemeMatch(m *manifest.Manifest) error {
+	customSG := p.InstanceSecurityGroup != ""
 	for _, s := range m.Services {
 		for _, np := range s.NLB {
 			switch np.Scheme {
@@ -1097,6 +1103,9 @@ func (p *Provider) validateNLBSchemeMatch(m *manifest.Manifest) error {
 				if !p.NLBInternal {
 					return fmt.Errorf("service %s declares internal nlb port %d but rack does not have NLBInternal enabled; run 'convox rack params set Internal=Yes NLBInternal=Yes' first", s.Name, np.Port)
 				}
+			}
+			if customSG && np.PreserveClientIP != nil && *np.PreserveClientIP {
+				return fmt.Errorf("service %s nlb port %d: cannot set preserve_client_ip=true on a rack with a customer-supplied InstanceSecurityGroup; your instance SG must add an ingress rule from the NLB security group (exported as ${Rack}:NLBSecurityGroup / ${Rack}:NLBInternalSecurityGroup) for the NLB listener ports before this feature can be enabled safely", s.Name, np.Port)
 			}
 		}
 	}

--- a/provider/aws/releases_nlb_test.go
+++ b/provider/aws/releases_nlb_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/convox/rack/pkg/manifest"
@@ -47,5 +48,61 @@ func TestValidateNLBSchemeMatch_NoNLBPorts(t *testing.T) {
 	m := &manifest.Manifest{Services: []manifest.Service{{Name: "api"}}}
 	if err := p.validateNLBSchemeMatch(m); err != nil {
 		t.Fatalf("service without nlb should not error: %v", err)
+	}
+}
+
+func TestValidateNLBSchemeMatch_CustomerSGBlocksPreserveClientIP(t *testing.T) {
+	tru := true
+	p := &Provider{NLB: true, NLBInternal: true, InstanceSecurityGroup: "sg-customer"}
+	m := &manifest.Manifest{Services: []manifest.Service{{
+		Name: "api",
+		NLB: []manifest.ServiceNLBPort{
+			{Port: 8443, Scheme: "public", PreserveClientIP: &tru},
+		},
+	}}}
+	err := p.validateNLBSchemeMatch(m)
+	if err == nil || !strings.Contains(err.Error(), "customer-supplied InstanceSecurityGroup") {
+		t.Fatalf("expected customer-SG block on release promote, got %v", err)
+	}
+}
+
+func TestValidateNLBSchemeMatch_CustomerSGAllowsPreserveFalse(t *testing.T) {
+	fals := false
+	p := &Provider{NLB: true, InstanceSecurityGroup: "sg-customer"}
+	m := &manifest.Manifest{Services: []manifest.Service{{
+		Name: "api",
+		NLB: []manifest.ServiceNLBPort{
+			{Port: 8443, Scheme: "public", PreserveClientIP: &fals},
+		},
+	}}}
+	if err := p.validateNLBSchemeMatch(m); err != nil {
+		t.Fatalf("customer SG + preserve_client_ip=false should pass: %v", err)
+	}
+}
+
+func TestValidateNLBSchemeMatch_CustomerSGAllowsPreserveNil(t *testing.T) {
+	p := &Provider{NLB: true, InstanceSecurityGroup: "sg-customer"}
+	m := &manifest.Manifest{Services: []manifest.Service{{
+		Name: "api",
+		NLB: []manifest.ServiceNLBPort{
+			{Port: 8443, Scheme: "public"},
+		},
+	}}}
+	if err := p.validateNLBSchemeMatch(m); err != nil {
+		t.Fatalf("customer SG + no per-port override should pass (inherits rack default): %v", err)
+	}
+}
+
+func TestValidateNLBSchemeMatch_BlankInstanceSGAllowsPreserveTrue(t *testing.T) {
+	tru := true
+	p := &Provider{NLB: true}
+	m := &manifest.Manifest{Services: []manifest.Service{{
+		Name: "api",
+		NLB: []manifest.ServiceNLBPort{
+			{Port: 8443, Scheme: "public", PreserveClientIP: &tru},
+		},
+	}}}
+	if err := p.validateNLBSchemeMatch(m); err != nil {
+		t.Fatalf("blank InstanceSecurityGroup + preserve=true should pass: %v", err)
 	}
 }

--- a/provider/aws/service.go
+++ b/provider/aws/service.go
@@ -278,10 +278,13 @@ func manifestToServiceNlbPorts(ports []manifest.ServiceNLBPort) []structs.Servic
 	var out []structs.ServiceNlbPort
 	for _, p := range ports {
 		out = append(out, structs.ServiceNlbPort{
-			ContainerPort: p.ContainerPort,
-			Port:          p.Port,
-			Protocol:      p.Protocol,
-			Scheme:        p.Scheme,
+			ContainerPort:    p.ContainerPort,
+			Port:             p.Port,
+			Protocol:         p.Protocol,
+			Scheme:           p.Scheme,
+			CrossZone:        p.CrossZone,
+			AllowCIDR:        p.AllowCIDR,
+			PreserveClientIP: p.PreserveClientIP,
 		})
 	}
 	return out

--- a/provider/aws/service_test.go
+++ b/provider/aws/service_test.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 
 	"github.com/convox/rack/pkg/manifest"
+	"github.com/convox/rack/pkg/options"
 	"github.com/convox/rack/pkg/structs"
 	"github.com/stretchr/testify/require"
 )
@@ -204,6 +205,57 @@ func TestManifestToServiceNlbPorts(t *testing.T) {
 			want: []structs.ServiceNlbPort{
 				{Port: 9443, Protocol: "tcp", ContainerPort: 8080, Scheme: "internal"},
 				{Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public"},
+			},
+		},
+		{
+			name: "all three new fields set",
+			in: []manifest.ServiceNLBPort{
+				{
+					Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public",
+					CrossZone:        options.Bool(true),
+					AllowCIDR:        []string{"10.0.0.0/24", "10.1.0.0/24"},
+					PreserveClientIP: options.Bool(false),
+				},
+			},
+			want: []structs.ServiceNlbPort{
+				{
+					Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public",
+					CrossZone:        options.Bool(true),
+					AllowCIDR:        []string{"10.0.0.0/24", "10.1.0.0/24"},
+					PreserveClientIP: options.Bool(false),
+				},
+			},
+		},
+		{
+			name: "CrossZone and PreserveClientIP false not nil",
+			in: []manifest.ServiceNLBPort{
+				{
+					Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public",
+					CrossZone:        options.Bool(false),
+					PreserveClientIP: options.Bool(false),
+				},
+			},
+			want: []structs.ServiceNlbPort{
+				{
+					Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public",
+					CrossZone:        options.Bool(false),
+					PreserveClientIP: options.Bool(false),
+				},
+			},
+		},
+		{
+			name: "AllowCIDR only",
+			in: []manifest.ServiceNLBPort{
+				{
+					Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public",
+					AllowCIDR: []string{"192.168.0.0/16"},
+				},
+			},
+			want: []structs.ServiceNlbPort{
+				{
+					Port: 8443, Protocol: "tcp", ContainerPort: 8443, Scheme: "public",
+					AllowCIDR: []string{"192.168.0.0/16"},
+				},
 			},
 		},
 	}

--- a/provider/aws/service_test.go
+++ b/provider/aws/service_test.go
@@ -36,17 +36,19 @@ func renderServiceTemplate(t *testing.T, m *manifest.Manifest, serviceName strin
 	require.True(t, found, "service %q not in manifest", serviceName)
 
 	stp := map[string]interface{}{
-		"App":            "testapp",
-		"Autoscale":      false,
-		"Build":          &structs.Build{Id: "B12345", App: "testapp"},
-		"DeploymentMin":  50,
-		"DeploymentMax":  200,
-		"Manifest":       m,
-		"Password":       "testpass",
-		"Release":        &structs.Release{Id: "R12345", App: "testapp", Build: "B12345"},
-		"Service":        svc,
-		"Tags":           svc.Tags,
-		"WildcardDomain": false,
+		"App":                                "testapp",
+		"Autoscale":                          false,
+		"Build":                              &structs.Build{Id: "B12345", App: "testapp"},
+		"DeploymentMin":                      50,
+		"DeploymentMax":                      200,
+		"Manifest":                           m,
+		"Password":                           "testpass",
+		"Release":                            &structs.Release{Id: "R12345", App: "testapp", Build: "B12345"},
+		"Service":                            svc,
+		"Tags":                               svc.Tags,
+		"WildcardDomain":                     false,
+		"NLBPreserveClientIPDefault":         "No",
+		"NLBInternalPreserveClientIPDefault": "No",
 	}
 
 	path := filepath.Join("formation", "service.json.tmpl")
@@ -58,6 +60,56 @@ func renderServiceTemplate(t *testing.T, m *manifest.Manifest, serviceName strin
 
 	// Round-trip through json.Unmarshal/MarshalIndent to mirror formationTemplate's
 	// pretty-printed normalization.
+	var v interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &v))
+	out, err := json.MarshalIndent(v, "", "  ")
+	require.NoError(t, err)
+	return out
+}
+
+// renderServiceTemplateWithStp is identical to renderServiceTemplate except it
+// merges caller-supplied stp entries into the default map. Use this when a test
+// needs to vary rack-level defaults (e.g., NLBPreserveClientIPDefault="Yes").
+func renderServiceTemplateWithStp(t *testing.T, m *manifest.Manifest, serviceName string, overrides map[string]interface{}) []byte {
+	t.Helper()
+
+	var svc manifest.Service
+	found := false
+	for _, s := range m.Services {
+		if s.Name == serviceName {
+			svc = s
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "service %q not in manifest", serviceName)
+
+	stp := map[string]interface{}{
+		"App":                                "testapp",
+		"Autoscale":                          false,
+		"Build":                              &structs.Build{Id: "B12345", App: "testapp"},
+		"DeploymentMin":                      50,
+		"DeploymentMax":                      200,
+		"Manifest":                           m,
+		"Password":                           "testpass",
+		"Release":                            &structs.Release{Id: "R12345", App: "testapp", Build: "B12345"},
+		"Service":                            svc,
+		"Tags":                               svc.Tags,
+		"WildcardDomain":                     false,
+		"NLBPreserveClientIPDefault":         "No",
+		"NLBInternalPreserveClientIPDefault": "No",
+	}
+	for k, v := range overrides {
+		stp[k] = v
+	}
+
+	path := filepath.Join("formation", "service.json.tmpl")
+	tpl, err := template.New("service.json.tmpl").Funcs(formationHelpers()).ParseFiles(path)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, tpl.Execute(&buf, stp))
+
 	var v interface{}
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &v))
 	out, err := json.MarshalIndent(v, "", "  ")
@@ -323,4 +375,109 @@ func TestServiceTemplateNLBMixedTCPAndTLSTargetGroupsBothTCP(t *testing.T) {
 		"TLS-listener target group must still be Protocol=TCP")
 	require.Equal(t, "TCP", parseTG(tcpTG),
 		"TCP-listener target group must be Protocol=TCP (unchanged)")
+}
+
+func TestServiceTemplateRenderNLB_DefaultOff(t *testing.T) {
+	m, err := manifest.Load([]byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+`), nil)
+	require.NoError(t, err)
+	out := renderServiceTemplate(t, m, "api")
+	require.Contains(t, string(out), `"preserve_client_ip.enabled"`, "preserve_client_ip attribute must be present")
+	tg := extractResource(t, out, "NLBTargetGroup8443")
+	require.Contains(t, string(tg), `"Value": "false"`, "default preserve_client_ip must be false")
+	require.NotContains(t, string(out), `"load_balancing.cross_zone.enabled"`, "cross_zone must be absent when no per-port override")
+}
+
+func TestServiceTemplateRenderNLB_RackDefaultPreserveYes(t *testing.T) {
+	m, err := manifest.Load([]byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+`), nil)
+	require.NoError(t, err)
+	out := renderServiceTemplateWithStp(t, m, "api", map[string]interface{}{
+		"NLBPreserveClientIPDefault": "Yes",
+	})
+	tg := extractResource(t, out, "NLBTargetGroup8443")
+	require.Contains(t, string(tg), `"Key": "preserve_client_ip.enabled"`, "preserve_client_ip attribute must be present")
+	require.Contains(t, string(tg), `"Value": "true"`, "rack default should propagate to target group")
+}
+
+func TestServiceTemplateRenderNLB_PerPortCrossZoneOverride(t *testing.T) {
+	m, err := manifest.Load([]byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        cross_zone: true
+`), nil)
+	require.NoError(t, err)
+	out := renderServiceTemplate(t, m, "api")
+	tg := extractResource(t, out, "NLBTargetGroup8443")
+	require.Contains(t, string(tg), `"Key": "load_balancing.cross_zone.enabled"`, "cross_zone attribute must render when per-port override set")
+	require.Contains(t, string(tg), `"Value": "true"`, "per-port cross_zone=true must render as true")
+}
+
+func TestServiceTemplateRenderNLB_PerPortPreserveOverrideFalse(t *testing.T) {
+	m, err := manifest.Load([]byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        preserve_client_ip: false
+`), nil)
+	require.NoError(t, err)
+	out := renderServiceTemplateWithStp(t, m, "api", map[string]interface{}{
+		"NLBPreserveClientIPDefault": "Yes",
+	})
+	tg := extractResource(t, out, "NLBTargetGroup8443")
+	require.Contains(t, string(tg), `"Value": "false"`, "per-port preserve_client_ip=false must override rack default=Yes")
+}
+
+func TestServiceTemplateRenderNLB_AllowCIDRPerPort(t *testing.T) {
+	m, err := manifest.Load([]byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 8443
+        allow_cidr: ["10.0.0.0/24"]
+`), nil)
+	require.NoError(t, err)
+	out := renderServiceTemplate(t, m, "api")
+	ing := extractResource(t, out, "NLBPortIngress8443Cidr0")
+	require.Contains(t, string(ing), `"CidrIp": "10.0.0.0/24"`, "CidrIp must match per-port allow_cidr value")
+	require.Contains(t, string(ing), `${Rack}:NLBSecurityGroup`, "public scheme imports NLBSecurityGroup")
+}
+
+func TestServiceTemplateRenderNLB_AllowCIDRInternal(t *testing.T) {
+	m, err := manifest.Load([]byte(`services:
+  api:
+    image: x
+    nlb:
+      - port: 5000
+        scheme: internal
+        allow_cidr: ["192.168.1.0/24"]
+`), nil)
+	require.NoError(t, err)
+	out := renderServiceTemplate(t, m, "api")
+	ing := extractResource(t, out, "NLBPortIngress5000Cidr0")
+	require.Contains(t, string(ing), `${Rack}:NLBInternalSecurityGroup`, "internal scheme imports NLBInternalSecurityGroup")
+}
+
+func TestServiceTemplateRenderNLB_NoNLBPortsNoResources(t *testing.T) {
+	m, err := manifest.Load([]byte(`services:
+  api:
+    image: x
+    port: http:3000
+`), nil)
+	require.NoError(t, err)
+	out := renderServiceTemplate(t, m, "api")
+	require.NotContains(t, string(out), `"NLBTargetGroup`, "no NLB ports should mean no NLBTargetGroup resource")
+	require.NotContains(t, string(out), `"NLBListener`, "no NLB ports should mean no NLBListener resource")
+	require.NotContains(t, string(out), `"NLBPortIngress`, "no NLB ports should mean no per-port allow_cidr ingress")
 }

--- a/provider/aws/system.go
+++ b/provider/aws/system.go
@@ -543,6 +543,10 @@ func (p *Provider) SystemUninstall(name string, w io.Writer, opts structs.System
 		return fmt.Errorf("could not find rack: %s", name)
 	}
 
+	if err := p.validateNLBUninstall(name); err != nil {
+		return err
+	}
+
 	deps, err := rackDependencies(name)
 	if err != nil {
 		return err

--- a/provider/aws/system_nlb.go
+++ b/provider/aws/system_nlb.go
@@ -2,12 +2,62 @@ package aws
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 
 	"github.com/convox/rack/pkg/manifest"
 	"github.com/convox/rack/pkg/structs"
 )
+
+// validateNLBAllowCIDRParam applies the list-shape rules to
+// NLBAllowCIDR / NLBInternalAllowCIDR: at most 5 non-empty entries, each a
+// valid IPv4 CIDR (octets 0-255, mask 0-32), no duplicates, no leading/
+// trailing whitespace (CF `Fn::Split` does not trim, so spaces in stored
+// values slip through to AWS and surface as opaque CF errors). Empty input
+// returns nil — blank is valid, and for the internal variant selects the
+// VPCCIDR fallback in CF.
+func validateNLBAllowCIDRParam(paramName, value string) error {
+	if value == "" {
+		return nil
+	}
+	entries := strings.Split(value, ",")
+	seen := map[string]bool{}
+	nonEmpty := 0
+	for _, e := range entries {
+		if e == "" {
+			continue
+		}
+		trimmed := strings.TrimSpace(e)
+		if trimmed == "" {
+			continue
+		}
+		if trimmed != e {
+			return fmt.Errorf("%s entry %q has leading or trailing whitespace; remove the spaces and retry", paramName, e)
+		}
+		ip, ipnet, err := net.ParseCIDR(trimmed)
+		if err != nil {
+			return fmt.Errorf("%s entry %q is not a valid IPv4 CIDR", paramName, trimmed)
+		}
+		if ip.To4() == nil {
+			return fmt.Errorf("%s entry %q is not a valid IPv4 CIDR (IPv6 not supported)", paramName, trimmed)
+		}
+		// Guard against non-canonical forms like "10.0.0.1/24" (host bits set);
+		// normalize to the network form and compare.
+		if ipnet.String() != trimmed {
+			return fmt.Errorf("%s entry %q is not canonical; use %q instead", paramName, trimmed, ipnet.String())
+		}
+		if seen[trimmed] {
+			return fmt.Errorf("%s contains duplicate entry: %s", paramName, trimmed)
+		}
+		seen[trimmed] = true
+		nonEmpty++
+	}
+	if nonEmpty > 5 {
+		return fmt.Errorf("%s accepts at most 5 CIDRs; got %d", paramName, nonEmpty)
+	}
+	return nil
+}
 
 // appsUsingNLBScheme returns the list of gen2 apps on the rack whose current running release
 // declares at least one service with an NLB port of the given scheme ("public" or "internal").
@@ -56,10 +106,22 @@ func (p *Provider) appsUsingNLBScheme(scheme string) ([]string, error) {
 	return blockers, nil
 }
 
+// yesNo maps a bool to "Yes"/"No" — package-level so provider/aws can share
+// the conversion between validator, render-context plumbing, and ad-hoc callers.
+func yesNo(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}
+
 // validateNLBParams enforces the NLB rack-param rules:
 //   - NLB=Yes incompatible with InternalOnly=Yes
 //   - NLBInternal=Yes requires Internal=Yes (either already set or set in the same call)
 //   - Disabling NLB/NLBInternal requires no dependent gen2 apps
+//   - Allowlist CIDR params shape/limit/dedup
+//   - Deletion protection + NLB=No interlock
+//   - Customer-InstanceSecurityGroup incompatible with preserve_client_ip
 func (p *Provider) validateNLBParams(opts structs.SystemUpdateOptions) error {
 	want := func(key string) (string, bool) {
 		if opts.Parameters == nil {
@@ -69,17 +131,21 @@ func (p *Provider) validateNLBParams(opts structs.SystemUpdateOptions) error {
 		return v, ok
 	}
 
-	yesNo := func(b bool) string {
-		if b {
-			return "Yes"
-		}
-		return "No"
-	}
-
 	currentNLB := yesNo(p.NLB)
 	currentNLBInternal := yesNo(p.NLBInternal)
 	currentInternal := yesNo(p.Internal)
 	currentInternalOnly := yesNo(p.InternalOnly)
+
+	if v, ok := want("NLBAllowCIDR"); ok {
+		if err := validateNLBAllowCIDRParam("NLBAllowCIDR", v); err != nil {
+			return err
+		}
+	}
+	if v, ok := want("NLBInternalAllowCIDR"); ok {
+		if err := validateNLBAllowCIDRParam("NLBInternalAllowCIDR", v); err != nil {
+			return err
+		}
+	}
 
 	nextNLB, nlbSet := want("NLB")
 	if !nlbSet {
@@ -115,6 +181,13 @@ func (p *Provider) validateNLBParams(opts structs.SystemUpdateOptions) error {
 			sort.Strings(blockers)
 			return fmt.Errorf("cannot disable NLB: apps %s still declare public nlb ports; remove nlb: from their manifests and redeploy first", strings.Join(blockers, ", "))
 		}
+		curProt, err := p.stackParameter(p.Rack, "NLBDeletionProtection")
+		if err == nil && curProt == "Yes" {
+			nextProt, protSet := want("NLBDeletionProtection")
+			if !protSet || nextProt == "Yes" {
+				return fmt.Errorf("cannot disable NLB while NLBDeletionProtection=Yes; unset protection first, wait for the update to complete, then toggle NLB off")
+			}
+		}
 	}
 
 	if nlbiSet && currentNLBInternal == "Yes" && nextNLBInternal == "No" {
@@ -126,7 +199,62 @@ func (p *Provider) validateNLBParams(opts structs.SystemUpdateOptions) error {
 			sort.Strings(blockers)
 			return fmt.Errorf("cannot disable NLBInternal: apps %s still declare internal nlb ports; remove nlb: from their manifests and redeploy first", strings.Join(blockers, ", "))
 		}
+		curProt, err := p.stackParameter(p.Rack, "NLBInternalDeletionProtection")
+		if err == nil && curProt == "Yes" {
+			nextProt, protSet := want("NLBInternalDeletionProtection")
+			if !protSet || nextProt == "Yes" {
+				return fmt.Errorf("cannot disable NLBInternal while NLBInternalDeletionProtection=Yes; unset protection first, wait for the update to complete, then toggle NLBInternal off")
+			}
+		}
 	}
 
+	if p.InstanceSecurityGroup != "" {
+		if v, ok := want("NLBPreserveClientIP"); ok && v == "Yes" {
+			return fmt.Errorf("cannot enable NLBPreserveClientIP on a rack with a customer-supplied InstanceSecurityGroup; your instance SG must add an ingress rule from the NLB security group (exported as ${Rack}:NLBSecurityGroup) for the NLB listener ports before this feature can be enabled safely")
+		}
+		if v, ok := want("NLBInternalPreserveClientIP"); ok && v == "Yes" {
+			return fmt.Errorf("cannot enable NLBInternalPreserveClientIP on a rack with a customer-supplied InstanceSecurityGroup; your instance SG must add an ingress rule from the NLB security group (exported as ${Rack}:NLBInternalSecurityGroup) for the NLB listener ports before this feature can be enabled safely")
+		}
+	}
+
+	// Inverse interlock: setting a customer InstanceSecurityGroup on a rack
+	// where preserve_client_ip is already enabled would break NLB traffic
+	// silently (the convox-managed InstancesSecurityNLBIngress no longer
+	// applies — the customer SG replaces InstancesSecurity on hosts). Block
+	// unless the same call also disables preserve_client_ip.
+	if nextSG, sgSet := want("InstanceSecurityGroup"); sgSet && nextSG != "" && p.InstanceSecurityGroup == "" {
+		preserveWillBeOn := func(paramName string, curOn bool) bool {
+			v, ok := want(paramName)
+			if ok {
+				return v == "Yes"
+			}
+			return curOn
+		}
+		if preserveWillBeOn("NLBPreserveClientIP", p.NLBPreserveClientIP) {
+			return fmt.Errorf("cannot set a customer InstanceSecurityGroup while NLBPreserveClientIP=Yes; set NLBPreserveClientIP=No in this same command (or unset it first), then set the custom SG. After the customer SG is in place, re-enable NLBPreserveClientIP only after adding an ingress rule from ${Rack}:NLBSecurityGroup to your SG")
+		}
+		if preserveWillBeOn("NLBInternalPreserveClientIP", p.NLBInternalPreserveClientIP) {
+			return fmt.Errorf("cannot set a customer InstanceSecurityGroup while NLBInternalPreserveClientIP=Yes; set NLBInternalPreserveClientIP=No in this same command (or unset it first), then set the custom SG")
+		}
+	}
+
+	return nil
+}
+
+// validateNLBUninstall blocks `convox rack uninstall` when NLB deletion
+// protection is enabled on either NLB. AWS rejects NLB delete calls while
+// protection is on, which would strand the rack stack in DELETE_FAILED
+// mid-uninstall. Takes the stack name directly so it honors the SystemUninstall
+// signature rather than implicitly using p.Rack.
+func (p *Provider) validateNLBUninstall(name string) error {
+	for _, key := range []string{"NLBDeletionProtection", "NLBInternalDeletionProtection"} {
+		v, err := p.stackParameter(name, key)
+		if err != nil {
+			continue
+		}
+		if v == "Yes" {
+			return fmt.Errorf("cannot uninstall rack while NLB deletion protection is enabled; run 'convox rack params set NLBDeletionProtection=No NLBInternalDeletionProtection=No' first (current: %s=%s)", key, v)
+		}
+	}
 	return nil
 }

--- a/provider/aws/system_nlb_test.go
+++ b/provider/aws/system_nlb_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/convox/rack/pkg/structs"
@@ -53,5 +54,196 @@ func TestValidateNLBParams_NilParameters(t *testing.T) {
 	err := p.validateNLBParams(structs.SystemUpdateOptions{})
 	if err != nil {
 		t.Fatalf("nil parameters should not error: %v", err)
+	}
+}
+
+func TestValidateNLBParams_AllowCIDRTooMany(t *testing.T) {
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBAllowCIDR": "1.0.0.0/24,2.0.0.0/24,3.0.0.0/24,4.0.0.0/24,5.0.0.0/24,6.0.0.0/24",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "accepts at most 5") {
+		t.Fatalf("expected limit error, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_AllowCIDRMalformed(t *testing.T) {
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBAllowCIDR": "not-a-cidr",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "not a valid IPv4 CIDR") {
+		t.Fatalf("expected shape error, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_AllowCIDRDuplicate(t *testing.T) {
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBAllowCIDR": "10.0.0.0/24,10.0.0.0/24",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "duplicate entry: 10.0.0.0/24") {
+		t.Fatalf("expected dedup error, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_AllowCIDRInternalMirror(t *testing.T) {
+	p := &Provider{NLB: true, NLBInternal: true, Internal: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBInternalAllowCIDR": "1.0.0.0/24,1.0.0.0/24",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "NLBInternalAllowCIDR contains duplicate entry") {
+		t.Fatalf("expected internal dedup error, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_AllowCIDREmptyOK(t *testing.T) {
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBAllowCIDR": "",
+	}}
+	if err := p.validateNLBParams(opts); err != nil {
+		t.Fatalf("empty NLBAllowCIDR should pass: %v", err)
+	}
+}
+
+func TestValidateNLBParams_AllowCIDRTrailingCommaOK(t *testing.T) {
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBAllowCIDR": "10.0.0.0/24,",
+	}}
+	if err := p.validateNLBParams(opts); err != nil {
+		t.Fatalf("trailing comma should be tolerated: %v", err)
+	}
+}
+
+func TestValidateNLBParams_CustomerSGBlocksPreserveClientIP(t *testing.T) {
+	p := &Provider{NLB: true, InstanceSecurityGroup: "sg-customer"}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBPreserveClientIP": "Yes",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "customer-supplied InstanceSecurityGroup") {
+		t.Fatalf("expected customer-SG block, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_CustomerSGBlocksPreserveClientIPInternal(t *testing.T) {
+	p := &Provider{NLB: true, NLBInternal: true, Internal: true, InstanceSecurityGroup: "sg-customer"}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBInternalPreserveClientIP": "Yes",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "NLBInternalPreserveClientIP on a rack with a customer-supplied") {
+		t.Fatalf("expected customer-SG block (internal), got %v", err)
+	}
+}
+
+func TestValidateNLBParams_BlankInstanceSGAllowsPreserve(t *testing.T) {
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBPreserveClientIP": "Yes",
+	}}
+	if err := p.validateNLBParams(opts); err != nil {
+		t.Fatalf("blank InstanceSecurityGroup should allow preserve_client_ip, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_InverseInterlockBlocksSettingCustomSG(t *testing.T) {
+	// Rack currently has preserve_client_ip=Yes and no customer SG. Operator
+	// tries to set a customer SG — must be blocked because the SG substitution
+	// would silently break NLB traffic.
+	p := &Provider{NLB: true, NLBPreserveClientIP: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"InstanceSecurityGroup": "sg-customer",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "cannot set a customer InstanceSecurityGroup while NLBPreserveClientIP=Yes") {
+		t.Fatalf("expected inverse interlock error, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_InverseInterlockInternal(t *testing.T) {
+	p := &Provider{NLB: true, NLBInternal: true, Internal: true, NLBInternalPreserveClientIP: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"InstanceSecurityGroup": "sg-customer",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "cannot set a customer InstanceSecurityGroup while NLBInternalPreserveClientIP=Yes") {
+		t.Fatalf("expected inverse interlock (internal) error, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_InverseInterlockAllowsSimultaneousDisable(t *testing.T) {
+	// Operator flips preserve_client_ip=No AND sets custom SG in the same call.
+	// Must be allowed — at the end of the update, preserve_client_ip is off and
+	// the customer-SG caveat doesn't apply.
+	p := &Provider{NLB: true, NLBPreserveClientIP: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"InstanceSecurityGroup": "sg-customer",
+		"NLBPreserveClientIP":   "No",
+	}}
+	if err := p.validateNLBParams(opts); err != nil {
+		t.Fatalf("same-call disable should be allowed: %v", err)
+	}
+}
+
+func TestValidateNLBParams_InverseInterlockAllowsBlankPreserve(t *testing.T) {
+	// Rack with no preserve_client_ip and no custom SG; operator adds custom SG.
+	// Should pass — no preserve_client_ip in force to worry about.
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"InstanceSecurityGroup": "sg-customer",
+	}}
+	if err := p.validateNLBParams(opts); err != nil {
+		t.Fatalf("custom SG on rack without preserve_client_ip should pass: %v", err)
+	}
+}
+
+func TestValidateNLBParams_AllowCIDRLeadingSpaceRejected(t *testing.T) {
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBAllowCIDR": "10.0.0.0/24, 10.0.0.1/32",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "leading or trailing whitespace") {
+		t.Fatalf("expected whitespace rejection, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_AllowCIDRInvalidOctet(t *testing.T) {
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBAllowCIDR": "256.0.0.0/8",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "not a valid IPv4 CIDR") {
+		t.Fatalf("expected invalid-octet rejection, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_AllowCIDRInvalidMask(t *testing.T) {
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBAllowCIDR": "10.0.0.0/33",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "not a valid IPv4 CIDR") {
+		t.Fatalf("expected invalid-mask rejection, got %v", err)
+	}
+}
+
+func TestValidateNLBParams_AllowCIDRNonCanonicalRejected(t *testing.T) {
+	p := &Provider{NLB: true}
+	opts := structs.SystemUpdateOptions{Parameters: map[string]string{
+		"NLBAllowCIDR": "10.0.0.1/24",
+	}}
+	err := p.validateNLBParams(opts)
+	if err == nil || !strings.Contains(err.Error(), "not canonical") {
+		t.Fatalf("expected non-canonical rejection, got %v", err)
 	}
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Group Filter and Credential Masking for `convox rack params`**

We've made the `convox rack params` output easier to scan and safer to share. The rack-params surface has grown to 110 parameters covering every aspect of rack configuration — network, NLB, scaling, instances, storage, logging, and more — and dumping all of them in a single alphabetical list made it hard to find the knobs relevant to a given task. At the same time, two of those parameters — the rack API `Password` and the `HttpProxy` URL (which can embed `user:pass@` credentials) — were being rendered in the clear every time an operator ran the command, with the obvious risks of shoulder-surfing, screenshares, and terminal history.

This release adds two complementary improvements. A new `-g` / `--group` flag filters the output to a curated logical group so you can focus on one slice of the parameter surface at a time. Ten groups cover the full set of rack parameters: `network`, `nlb`, `security`, `scaling`, `instances`, `build`, `api`, `logging`, `storage`, and `meta`. Group names are matched by unique prefix — `-g net` resolves to `network`, `-g nl` resolves to `nlb`, and ambiguous prefixes produce a helpful error showing the candidates and the shortest disambiguating prefix for each. Unknown group names and empty inputs produce a listing of all available groups alongside a one-line description of each.

Credential masking applies automatically on interactive terminals. The two credential-bearing parameters — `Password` and `HttpProxy` — render as `**********` when the CLI detects a TTY, and as real values when the output is piped or redirected. This preserves every existing automation workflow that grep-parses `convox rack params` output or redirects it to a backup file, while protecting against accidental exposure during live demos and screenshares. A `--reveal` flag bypasses the mask on a TTY when you genuinely need to see the values inline. Empty parameter values never mask (an empty `Password` stays empty, not `**********`), preserving the "absent" signal.

---

### How to use it?

This change is automatically available after updating your rack. No configuration is required.

```
$ convox rack update
```

Filter to a group:

```
$ convox rack params -g nlb
NLB                            Yes
NLBAllowCIDR                   0.0.0.0/0
NLBCrossZone                   No
NLBDeletionProtection          No
NLBInternal                    Yes
NLBInternalAllowCIDR
NLBInternalCrossZone           No
NLBInternalDeletionProtection  No
NLBInternalPreserveClientIP    No
NLBPreserveClientIP            No
```

Unique prefixes work:

```
$ convox rack params -g net      # resolves to network
$ convox rack params -g sec      # resolves to security
$ convox rack params -g sto      # resolves to storage
```

Ambiguous prefixes get an actionable error:

```
$ convox rack params -g n
ERROR: group 'n' matches multiple groups: network, nlb (use 'net' or 'nlb')
  available groups:
    api        Rack API web process config, router, ingress toggles
    build      Build method, build instance, Fargate build, image pruning
    instances  AMI, instance type, boot/run commands, IAM policy, volumes, tenancy
    logging    Logs destination, retention, syslog format
    meta       Version, development mode, telemetry, client ID, ECS tuning
    network    VPC, subnets, gateways, connectivity, proxy
    nlb        Network Load Balancer: listeners, cross-zone, allow-CIDR, preserve-client-IP
    scaling    Autoscaling, spot fleet, instance counts, schedules, HA
    security   Credentials, allowlists, SGs, SSL, IMDS, container hardening
    storage    S3 versioning, DynamoDB protection, EFS encryption
```

Credential masking on a TTY:

```
$ convox rack params
Autoscale   Yes
HttpProxy   **********
Password    **********
VPCCIDR     10.0.0.0/16
Version     20260421192651
...
```

Reveal when you need the value inline:

```
$ convox rack params --reveal
HttpProxy   http://user:pass@proxy.example.com:8080
Password    s3cr3t
...
```

Piping or redirecting output bypasses masking, so your existing scripts keep working unchanged:

```
$ convox rack params | grep Password
Password  s3cr3t

$ convox rack params > rack-backup.txt    # real values
```

Combine the group filter with `--reveal` to audit credentials for a specific slice:

```
$ convox rack params -g security --reveal
```

---

### Does it have a breaking change?

No breaking changes to scripts and automation. Piped or redirected `convox rack params` output is byte-identical to the previous release — all existing grep-parsing, backup, and configuration-capture workflows continue to work without changes.

There is one intentional behavior change on interactive terminals: the `Password` and `HttpProxy` rows render as `**********` instead of their literal values. Scripts that grep `Password` still match (the masked value is a non-empty string), but scripts that parse the value out of TTY output will need either the `--reveal` flag or a redirect to a file or pipe. This is the stated security improvement; redirection is the recommended escape hatch. A TTY paste-and-reapply workflow that uses `convox rack params` to capture state and then re-feeds the masked value into `convox rack params set` would write the literal `**********` — use `--reveal` or pipe to a file for that round-trip.

---

### Requirements

To use this feature, you must update to rack version `20260421192651` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
