### PR TITLE
Add build cache support to EC2 and Fargate BuildMethods

### DIFF
--- a/cmd/build/Dockerfile
+++ b/cmd/build/Dockerfile
@@ -22,7 +22,8 @@ RUN curl -sL "https://github.com/google/go-containerregistry/releases/download/$
     rm go-containerregistry.tar.gz
 
 # Kaniko runtime
-FROM gcr.io/kaniko-project/executor:v1.23.2-debug
+FROM ghcr.io/osscontainertools/kaniko:v1.27.5-debug
+ENV FF_KANIKO_OCI_STAGES=0
 
 # Create /tmp so Kaniko can write
 RUN mkdir -p /tmp && chmod 1777 /tmp

--- a/cmd/build/Dockerfile.arm
+++ b/cmd/build/Dockerfile.arm
@@ -24,7 +24,8 @@ RUN curl -sL "https://github.com/google/go-containerregistry/releases/download/$
     rm go-containerregistry.tar.gz
 
 # Kaniko runtime
-FROM gcr.io/kaniko-project/executor:v1.23.2-debug
+FROM ghcr.io/osscontainertools/kaniko:v1.27.5-debug
+ENV FF_KANIKO_OCI_STAGES=0
 
 # Create /tmp so Kaniko can write
 RUN mkdir -p /tmp && chmod 1777 /tmp

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -26,7 +26,9 @@ var (
 	flagApp         string
 	flagAuth        string
 	flagBuildArgs   StringSlice
+	flagBuildCache  string
 	flagCache       string
+	flagCacheRepo   string
 	flagDevelopment string
 	flagEnvWrapper  string
 	flagGeneration  string
@@ -58,7 +60,9 @@ func execute() error {
 	fs.StringVar(&flagApp, "app", "example", "app name")
 	fs.StringVar(&flagAuth, "auth", "", "docker auth data (json)")
 	fs.Var(&flagBuildArgs, "build-args", "docker build time args")
+	fs.StringVar(&flagBuildCache, "build-cache", "", "enable build cache")
 	fs.StringVar(&flagCache, "cache", "true", "use docker cache")
+	fs.StringVar(&flagCacheRepo, "cache-repo", "", "ECR repo for cache")
 	fs.StringVar(&flagDevelopment, "development", "false", "create a development build")
 	fs.StringVar(&flagEnvWrapper, "env-wrapper", "false", "wrap with convox-env")
 	fs.StringVar(&flagGeneration, "generation", "", "app generation")
@@ -118,11 +122,20 @@ func execute() error {
 		flagRuntime = v
 	}
 
+	if v := os.Getenv("BUILD_CACHE"); v != "" {
+		flagBuildCache = v
+	}
+	if v := os.Getenv("BUILD_CACHE_REPO"); v != "" {
+		flagCacheRepo = v
+	}
+
 	opts := build.Options{
 		App:         flagApp,
 		Auth:        flagAuth,
 		BuildArgs:   flagBuildArgs,
+		BuildCache:  flagBuildCache == "true",
 		Cache:       flagCache == "true",
+		CacheRepo:   flagCacheRepo,
 		Development: flagDevelopment == "true",
 		EnvWrapper:  flagEnvWrapper == "true",
 		Generation:  flagGeneration,

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -30,6 +30,8 @@ type Options struct {
 	Auth        string
 	BuildArgs   []string
 	Cache       bool
+	BuildCache  bool
+	CacheRepo   string
 	Development bool
 	EnvWrapper  bool
 	Generation  string

--- a/pkg/build/docker.go
+++ b/pkg/build/docker.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/convox/rack/pkg/helpers"
@@ -53,6 +54,13 @@ func (bb *Build) buildGeneration2(dir string) error {
 	pushes := map[string]string{}
 	tags := map[string][]string{}
 
+	hostSupportsCache := bb.BuildCache && bb.hostSupportsRegistryCache()
+	if bb.BuildCache && !hostSupportsCache {
+		bb.Printf("WARNING: BuildCache enabled but host Docker does not support registry cache (requires 23.0+)\n")
+	}
+
+	cacheRefs := map[string]string{}
+
 	for _, s := range m.Services {
 		hash := s.BuildHash(bb.Id)
 		target := fmt.Sprintf("%s:%s.%s", prefix, s.Name, bb.Id)
@@ -68,12 +76,18 @@ func (bb *Build) buildGeneration2(dir string) error {
 		if bb.Push != "" {
 			pushes[target] = fmt.Sprintf("%s:%s.%s", bb.Push, s.Name, bb.Id)
 		}
+
+		if s.Image == "" && bb.Push != "" && hostSupportsCache {
+			if _, exists := cacheRefs[hash]; !exists {
+				cacheRefs[hash] = fmt.Sprintf("%s:%s.buildcache", bb.Push, s.Name)
+			}
+		}
 	}
 
 	for hash, b := range builds {
 		bb.Printf("Building: %s\n", b.Path)
 
-		if err := bb.build(filepath.Join(dir, b.Path), b.Manifest, hash, env); err != nil {
+		if err := bb.build(filepath.Join(dir, b.Path), b.Manifest, hash, env, cacheRefs[hash]); err != nil {
 			return err
 		}
 	}
@@ -115,7 +129,7 @@ func (bb *Build) buildGeneration2(dir string) error {
 	return nil
 }
 
-func (bb *Build) build(path, dockerfile, tag string, env map[string]string) error {
+func (bb *Build) build(path, dockerfile, tag string, env map[string]string, cacheRef string) error {
 	if path == "" {
 		return fmt.Errorf("build path cannot be empty")
 	}
@@ -125,6 +139,14 @@ func (bb *Build) build(path, dockerfile, tag string, env map[string]string) erro
 	args := []string{"build"}
 	if !bb.Cache {
 		args = append(args, "--no-cache")
+	}
+
+	if cacheRef != "" {
+		args = append(args, "--progress=plain")
+		if bb.Cache {
+			args = append(args, fmt.Sprintf("--cache-from=type=registry,ref=%s,ignore-error=true", cacheRef))
+		}
+		args = append(args, fmt.Sprintf("--cache-to=type=registry,ref=%s,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true,compression=estargz", cacheRef))
 	}
 
 	args = append(args, "-t", tag, "-f", df, "--network", "host")
@@ -165,6 +187,21 @@ var (
 	reArg  = regexp.MustCompile(`(?i)^\s*ARG\s+([^=\s]+)`)
 	reFrom = regexp.MustCompile(`(?i)^\s*FROM\s+.*\bAS\s+development\b`)
 )
+
+func (bb *Build) hostSupportsRegistryCache() bool {
+	out, err := bb.Exec.Execute("docker", "info", "--format", "{{.ServerVersion}}")
+	if err != nil {
+		return false
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	version := strings.TrimSpace(lines[len(lines)-1])
+	parts := strings.Split(version, ".")
+	if len(parts) == 0 {
+		return false
+	}
+	major, err := strconv.Atoi(parts[0])
+	return err == nil && major >= 23
+}
 
 // buildArgs returns CLI "--build-arg" flags derived from ARG statements that
 // have matches in the supplied env map.  It also adds "--target development"

--- a/pkg/build/kaniko.go
+++ b/pkg/build/kaniko.go
@@ -150,7 +150,12 @@ func (bb *Build) buildDaemonless(path, dockerfile, tag string, env map[string]st
 		"--destination", tag,
 		"--ignore-path=" + path,
 		"--no-push",
-		"--cache=false",
+	}
+
+	if bb.BuildCache && bb.CacheRepo != "" && bb.Cache {
+		args = append(args, "--cache=true", "--cache-repo="+bb.CacheRepo)
+	} else {
+		args = append(args, "--cache=false")
 	}
 
 	df := filepath.Join(path, dockerfile)

--- a/pkg/build/kaniko.go
+++ b/pkg/build/kaniko.go
@@ -146,7 +146,7 @@ func (bb *Build) buildDaemonless(path, dockerfile, tag string, env map[string]st
 	args := []string{
 		"--dockerfile", dockerfile,
 		"--context", contextDir,
-		"--tarPath", tarPath,
+		"--tar-path", tarPath,
 		"--destination", tag,
 		"--ignore-path=" + path,
 		"--no-push",

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -132,7 +132,7 @@ var paramGroups = map[string]map[string]bool{
 		"BuildMemory":                 true,
 		"BuildMethod":                 true,
 		"BuildVolumeSize":             true,
-		"FargateBuildCache":           true,
+		"BuildCache":                  true,
 		"FargateBuildCpu":             true,
 		"FargateBuildMemory":          true,
 		"PrivateBuild":                true,

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -132,6 +132,7 @@ var paramGroups = map[string]map[string]bool{
 		"BuildMemory":                 true,
 		"BuildMethod":                 true,
 		"BuildVolumeSize":             true,
+		"FargateBuildCache":           true,
 		"FargateBuildCpu":             true,
 		"FargateBuildMemory":          true,
 		"PrivateBuild":                true,

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -960,6 +960,9 @@ func (p *Provider) runBuild(build *structs.Build, burl string, opts structs.Buil
 	if nc != nil && nc.AwsvpcConfiguration != nil {
 		req.NetworkConfiguration = nc
 	}
+	if aws.StringValue(launchType) == "FARGATE" {
+		req.PlatformVersion = aws.String("1.4.0")
+	}
 
 	task, err := p.runTask(req)
 	if err != nil {

--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -796,6 +796,8 @@ func (p *Provider) runBuild(build *structs.Build, burl string, opts structs.Buil
 		buildTaskName = "ApiBuildFargate"
 	}
 
+	buildCache, _ := p.stackParameter(p.Rack, "BuildCache")
+
 	br, err := p.stackResource(p.Rack, buildTaskName)
 	if err != nil {
 		log.Error(err)
@@ -931,6 +933,19 @@ func (p *Provider) runBuild(build *structs.Build, burl string, opts structs.Buil
 			Value: aws.String(build.Id),
 		},
 	}...)
+
+	if buildCache == "Yes" {
+		env = append(env, &ecs.KeyValuePair{
+			Name:  aws.String("BUILD_CACHE"),
+			Value: aws.String("true"),
+		})
+		if buildMethod == "fargate" && a.Tags["Generation"] == "2" {
+			env = append(env, &ecs.KeyValuePair{
+				Name:  aws.String("BUILD_CACHE_REPO"),
+				Value: aws.String(fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", aid, p.Region, reg)),
+			})
+		}
+	}
 
 	if opts.BuildArgs != nil {
 		for _, v := range *opts.BuildArgs {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -90,6 +90,18 @@
       { "Condition": "RegionHasEFS" },
       { "Fn::Equals": [ { "Ref": "BuildMethod" }, "fargate" ] }
     ]},
+    "FargateBuildCacheEnabled": {
+      "Fn::And": [
+        { "Condition": "UseFargateBuild" },
+        { "Fn::Equals": [{ "Ref": "FargateBuildCache" }, "Yes"] }
+      ]
+    },
+    "FargateBuildCacheEnabledAndThirdAZAndHA": {
+      "Fn::And": [
+        { "Condition": "FargateBuildCacheEnabled" },
+        { "Condition": "ThirdAvailabilityZoneAndHighAvailability" }
+      ]
+    },
     "CreateThirdPrivateSubnet": {"Fn::Or": [
       {"Condition": "PrivateApiAndThirdAvailabilityZoneAndHighAvailability"},
       {"Condition": "PrivateAndThirdAvailabilityZoneAndHighAvailability"}
@@ -895,6 +907,12 @@
       "Description": "This will enable aws kms encryption on shared efs volume. Enabling this will remove exsiting data and recreate the efs volume.",
       "Default": "false",
       "AllowedValues": [ "true", "false" ]
+    },
+    "FargateBuildCache": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": ["Yes", "No"],
+      "Description": "Enable EFS-backed cache for Fargate builds"
     },
     "FargateBuildCpu": {
       "Type": "String",
@@ -3602,6 +3620,67 @@
         "SecurityGroups": [ { "Ref": "VolumeSecurity" } ]
       }
     },
+    "BuildCacheFilesystem": {
+      "Type": "AWS::EFS::FileSystem",
+      "Condition": "FargateBuildCacheEnabled",
+      "Properties": {
+        "Encrypted": true,
+        "FileSystemTags": [
+          { "Key": "Name", "Value": { "Fn::Join": ["-", [{ "Ref": "AWS::StackName" }, "build-cache"]] } }
+        ]
+      }
+    },
+    "BuildCacheSecurity": {
+      "DependsOn": "ApiRole",
+      "Type": "AWS::EC2::SecurityGroup",
+      "Condition": "FargateBuildCacheEnabled",
+      "Properties": {
+        "GroupDescription": { "Fn::Sub": "${AWS::StackName} build-cache" },
+        "SecurityGroupIngress": [{
+          "IpProtocol": "tcp",
+          "FromPort": "2049",
+          "ToPort": "2049",
+          "SourceSecurityGroupId": {
+            "Fn::If": ["BlankBuildInstanceSecurityGroup",
+              { "Fn::If": ["BlankInstanceSecurityGroup",
+                { "Ref": "InstancesSecurity" },
+                { "Ref": "InstanceSecurityGroup" }
+              ]},
+              { "Ref": "BuildInstanceSecurityGroup" }
+            ]
+          }
+        }],
+        "Tags": [{ "Key": "Name", "Value": { "Fn::Sub": "${AWS::StackName}-build-cache" } }],
+        "VpcId": { "Fn::If": ["BlankExistingVpc", { "Ref": "Vpc" }, { "Ref": "ExistingVpc" }] }
+      }
+    },
+    "BuildCacheTarget0": {
+      "Type": "AWS::EFS::MountTarget",
+      "Condition": "FargateBuildCacheEnabled",
+      "Properties": {
+        "FileSystemId": { "Ref": "BuildCacheFilesystem" },
+        "SubnetId": { "Fn::If": ["PrivateInstances", { "Ref": "SubnetPrivate0" }, { "Ref": "Subnet0" }] },
+        "SecurityGroups": [{ "Ref": "BuildCacheSecurity" }]
+      }
+    },
+    "BuildCacheTarget1": {
+      "Type": "AWS::EFS::MountTarget",
+      "Condition": "FargateBuildCacheEnabled",
+      "Properties": {
+        "FileSystemId": { "Ref": "BuildCacheFilesystem" },
+        "SubnetId": { "Fn::If": ["PrivateInstances", { "Ref": "SubnetPrivate1" }, { "Ref": "Subnet1" }] },
+        "SecurityGroups": [{ "Ref": "BuildCacheSecurity" }]
+      }
+    },
+    "BuildCacheTarget2": {
+      "Type": "AWS::EFS::MountTarget",
+      "Condition": "FargateBuildCacheEnabledAndThirdAZAndHA",
+      "Properties": {
+        "FileSystemId": { "Ref": "BuildCacheFilesystem" },
+        "SubnetId": { "Fn::If": ["PrivateInstances", { "Ref": "SubnetPrivate2" }, { "Ref": "Subnet2" }] },
+        "SecurityGroups": [{ "Ref": "BuildCacheSecurity" }]
+      }
+    },
     "AccountEvents": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
@@ -4682,7 +4761,11 @@
             "Secrets": [{
               "Name": "PASSWORD",
               "ValueFrom": { "Fn::Sub": "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}RackApiSecret" }
-            }]
+            }],
+            "MountPoints": { "Fn::If": ["FargateBuildCacheEnabled",
+              [{ "SourceVolume": "build-cache", "ContainerPath": "/kaniko/caches" }],
+              { "Ref": "AWS::NoValue" }
+            ]}
           }
         ],
         "RuntimePlatform": {
@@ -4696,7 +4779,17 @@
         },
         "ExecutionRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
         "Family": { "Fn::Sub": "${AWS::StackName}-build" },
-        "TaskRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] }
+        "TaskRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
+        "Volumes": { "Fn::If": ["FargateBuildCacheEnabled",
+          [{
+            "Name": "build-cache",
+            "EFSVolumeConfiguration": {
+              "FilesystemId": { "Ref": "BuildCacheFilesystem" },
+              "TransitEncryption": "ENABLED"
+            }
+          }],
+          { "Ref": "AWS::NoValue" }
+        ]}
       }
     },
     "ApiMonitorTasks": {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -90,15 +90,18 @@
       { "Condition": "RegionHasEFS" },
       { "Fn::Equals": [ { "Ref": "BuildMethod" }, "fargate" ] }
     ]},
-    "FargateBuildCacheEnabled": {
+    "BuildCacheEnabled": {
+      "Fn::Equals": [{ "Ref": "BuildCache" }, "Yes"]
+    },
+    "BuildCacheFargateEFS": {
       "Fn::And": [
-        { "Condition": "UseFargateBuild" },
-        { "Fn::Equals": [{ "Ref": "FargateBuildCache" }, "Yes"] }
+        { "Condition": "BuildCacheEnabled" },
+        { "Condition": "UseFargateBuild" }
       ]
     },
-    "FargateBuildCacheEnabledAndThirdAZAndHA": {
+    "BuildCacheFargateEFSThirdAZ": {
       "Fn::And": [
-        { "Condition": "FargateBuildCacheEnabled" },
+        { "Condition": "BuildCacheFargateEFS" },
         { "Condition": "ThirdAvailabilityZoneAndHighAvailability" }
       ]
     },
@@ -908,11 +911,11 @@
       "Default": "false",
       "AllowedValues": [ "true", "false" ]
     },
-    "FargateBuildCache": {
+    "BuildCache": {
       "Type": "String",
       "Default": "No",
       "AllowedValues": ["Yes", "No"],
-      "Description": "Enable EFS-backed cache for Fargate builds"
+      "Description": "Enable persistent build caching"
     },
     "FargateBuildCpu": {
       "Type": "String",
@@ -3622,9 +3625,13 @@
     },
     "BuildCacheFilesystem": {
       "Type": "AWS::EFS::FileSystem",
-      "Condition": "FargateBuildCacheEnabled",
+      "Condition": "BuildCacheFargateEFS",
       "Properties": {
         "Encrypted": true,
+        "KmsKeyId": { "Fn::If": ["EnableSharedEFSVolumeEncryptionCond",
+          { "Ref": "CustomerManagedKey" },
+          { "Ref": "AWS::NoValue" }
+        ]},
         "FileSystemTags": [
           { "Key": "Name", "Value": { "Fn::Join": ["-", [{ "Ref": "AWS::StackName" }, "build-cache"]] } }
         ]
@@ -3633,7 +3640,7 @@
     "BuildCacheSecurity": {
       "DependsOn": "ApiRole",
       "Type": "AWS::EC2::SecurityGroup",
-      "Condition": "FargateBuildCacheEnabled",
+      "Condition": "BuildCacheFargateEFS",
       "Properties": {
         "GroupDescription": { "Fn::Sub": "${AWS::StackName} build-cache" },
         "SecurityGroupIngress": [{
@@ -3656,7 +3663,7 @@
     },
     "BuildCacheTarget0": {
       "Type": "AWS::EFS::MountTarget",
-      "Condition": "FargateBuildCacheEnabled",
+      "Condition": "BuildCacheFargateEFS",
       "Properties": {
         "FileSystemId": { "Ref": "BuildCacheFilesystem" },
         "SubnetId": { "Fn::If": ["PrivateInstances", { "Ref": "SubnetPrivate0" }, { "Ref": "Subnet0" }] },
@@ -3665,7 +3672,7 @@
     },
     "BuildCacheTarget1": {
       "Type": "AWS::EFS::MountTarget",
-      "Condition": "FargateBuildCacheEnabled",
+      "Condition": "BuildCacheFargateEFS",
       "Properties": {
         "FileSystemId": { "Ref": "BuildCacheFilesystem" },
         "SubnetId": { "Fn::If": ["PrivateInstances", { "Ref": "SubnetPrivate1" }, { "Ref": "Subnet1" }] },
@@ -3674,7 +3681,7 @@
     },
     "BuildCacheTarget2": {
       "Type": "AWS::EFS::MountTarget",
-      "Condition": "FargateBuildCacheEnabledAndThirdAZAndHA",
+      "Condition": "BuildCacheFargateEFSThirdAZ",
       "Properties": {
         "FileSystemId": { "Ref": "BuildCacheFilesystem" },
         "SubnetId": { "Fn::If": ["PrivateInstances", { "Ref": "SubnetPrivate2" }, { "Ref": "Subnet2" }] },
@@ -4571,7 +4578,8 @@
               { "Name": "HTTPS_PROXY", "Value": { "Ref": "HttpProxy" } },
               { "Name": "PROVIDER", "Value": "aws" },
               { "Name": "RACK", "Value": { "Ref": "AWS::StackName" } },
-              { "Name": "STACK_ID", "Value": { "Ref": "AWS::StackId" } }
+              { "Name": "STACK_ID", "Value": { "Ref": "AWS::StackId" } },
+              { "Name": "DOCKER_BUILDKIT", "Value": "1" }
             ],
             "Image": {
               "Fn::If": [
@@ -4762,7 +4770,7 @@
               "Name": "PASSWORD",
               "ValueFrom": { "Fn::Sub": "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}RackApiSecret" }
             }],
-            "MountPoints": { "Fn::If": ["FargateBuildCacheEnabled",
+            "MountPoints": { "Fn::If": ["BuildCacheFargateEFS",
               [{ "SourceVolume": "build-cache", "ContainerPath": "/kaniko/caches" }],
               { "Ref": "AWS::NoValue" }
             ]}
@@ -4780,7 +4788,7 @@
         "ExecutionRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
         "Family": { "Fn::Sub": "${AWS::StackName}-build" },
         "TaskRoleArn": { "Fn::GetAtt": [ "ApiRole", "Arn" ] },
-        "Volumes": { "Fn::If": ["FargateBuildCacheEnabled",
+        "Volumes": { "Fn::If": ["BuildCacheFargateEFS",
           [{
             "Name": "build-cache",
             "EFSVolumeConfiguration": {


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Persistent Build Cache (EC2 and Fargate)**

Apps can now reuse build layers across builds through a persistent cache. When enabled, build layers are written to a dedicated `{rack}-build-cache` ECR repository and pulled back on later builds, so unchanged layers are restored instead of rebuilt. The cache repository is created separately from your app image registries, so cache data is never co-mingled with deployable images. This works on both build methods: EC2 builds (which use `docker buildx`) and Fargate builds (which use kaniko) both write to and read from the same cache repository.

Caching is off by default and is controlled entirely through rack parameters. The cache repository is created only when you enable caching, and a separate parameter controls whether old cache images are automatically expired. The new parameters are:

| Parameter | Type | Default | Effect |
|-----------|------|---------|--------|
| `BuildCache` | String (`Yes`/`No`) | `No` | Enable persistent build caching. Builds write layers to the dedicated `{rack}-build-cache` ECR repository and reuse them on later builds. |
| `BuildCacheCleanup` | String (`Yes`/`No`) | `No` | Automatically expire old cache images. When `No`, cache images are kept indefinitely. |
| `BuildCacheRetentionDays` | Number (1-365) | `30` | Days to retain cache images before expiry. Applies only when `BuildCacheCleanup=Yes`. |

The cache repository is created only when `BuildCache=Yes` and is removed together with the rack (it uses `EmptyOnDelete`). Cleanup is a CloudFormation-managed ECR lifecycle policy that is attached to the cache repository only when `BuildCacheCleanup=Yes`. With cleanup off there is no expiry policy, so cache images are kept indefinitely. This is a storage-cost consideration rather than a data-loss concern, since cache images are regenerable. Disabling `BuildCache` removes the cache repository and all of its images.

---

### How to use it?

Build caching is opt-in. Enable it with a single rack parameter change. Batch related parameters into one command:

```
convox rack params set BuildCache=Yes -r my-rack
```

To enable caching and also expire old cache images automatically (for example, after 14 days):

```
convox rack params set BuildCache=Yes BuildCacheCleanup=Yes BuildCacheRetentionDays=14 -r my-rack
```

After the rack update completes, your next build populates the cache, and subsequent builds reuse the cached layers. There is nothing to change in `convox.yml` or your Dockerfiles.

To turn caching off again (this also removes the `my-rack-build-cache` repository and its images):

```
convox rack params set BuildCache=No -r my-rack
```

Confirm the parameter values at any time:

```
convox rack params -r my-rack
```

---

### Does it have a breaking change?

No. This change is purely additive and backward compatible.

All three parameters default to behavior-preserving values (`BuildCache=No`, `BuildCacheCleanup=No`, `BuildCacheRetentionDays=30`), so a rack that does not set them builds exactly as it did before. The cache repository and its lifecycle policy are created only when you opt in. No CloudFormation Outputs, Parameters, or resource logical IDs are removed or renamed, and no existing parameter defaults change.

A note on coverage and expectations: the build cache does not apply to gen1 apps, which continue to build exactly as before without it. Fargate (kaniko) caching is less aggressive than EC2 (buildkit). On Fargate it does not resume after the first cache miss, does not cache `COPY` layers by default, and has limited multi-stage caching, so hit rates on Fargate are lower than on EC2 for the same Dockerfile. On the EC2 build method, if the `docker buildx` plugin is unavailable the build proceeds normally without caching and prints a warning.

Downgrade is clean. Because the parameters are additive with safe defaults, a downgrade to a version that does not declare them drops them without breaking stack updates.

---

### Requirements

To use this feature, you must update to rack version `20260531001024` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
