### PR TITLE
add ContainerInsights rack parameter

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -105,6 +105,7 @@
     "EnableALBPort80": {
       "Fn::And": [ { "Condition": "PublicRouter" }, { "Condition": "AllowALBPort80" } ]
     },
+    "ContainerInsightsEnabled": { "Fn::Equals": [ { "Ref": "ContainerInsights" }, "Yes" ] },
     "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "LogDriver" }, "CloudWatch" ] },
     "EnableSyslog": { "Fn::Equals": [ { "Ref": "LogDriver" }, "Syslog" ] },
     "EnableSharedEFSVolumeEncryptionCond": { "Fn::Equals": [ { "Ref": "EnableSharedEFSVolumeEncryption" }, "true" ] },
@@ -817,6 +818,12 @@
       "Type": "String",
       "Description": "Anonymous identifier",
       "Default": ""
+    },
+    "ContainerInsights": {
+      "Type": "String",
+      "Description": "Enable CloudWatch Container Insights on the ECS cluster",
+      "Default": "No",
+      "AllowedValues": ["Yes", "No"]
     },
     "CpuCredits": {
       "Type": "String",
@@ -4219,6 +4226,12 @@
         "CapacityProviders": [
           "FARGATE",
           "FARGATE_SPOT"
+        ],
+        "ClusterSettings": [
+          {
+            "Name": "containerInsights",
+            "Value": { "Fn::If": ["ContainerInsightsEnabled", "enabled", "disabled"] }
+          }
         ]
       }
     },


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: ContainerInsights rack parameter**

A new `ContainerInsights` rack parameter lets you turn on CloudWatch Container Insights for your rack's ECS cluster. When enabled, the cluster reports CPU, memory, network, and task-level metrics into the CloudWatch Container Insights dashboards, giving you per-service observability without standing up any additional tooling.

The parameter defaults to `No`, so existing racks keep their current behavior and incur no new cost until you opt in. Container Insights is a paid CloudWatch feature, so enabling it adds roughly 15 to 25 USD per month per rack depending on the number of tasks and metrics collected. This release covers Fargate workloads. EC2-launched services require the CloudWatch agent daemon to report Container Insights metrics, which is planned as a follow-up and is not included here.

| Parameter | Type | Default | Effect |
|-----------|------|---------|--------|
| `ContainerInsights` | `Yes/No` | `No` | Enables CloudWatch Container Insights on the rack's ECS cluster (Fargate workloads) |

---

### How to use it?

Enable Container Insights on your rack:

```
$ convox rack params set ContainerInsights=Yes -r my-rack
```

The rack stack will update in place to apply the new cluster setting. Once the update completes, confirm the parameter:

```
$ convox rack params -r my-rack
```

To turn it back off:

```
$ convox rack params set ContainerInsights=No -r my-rack
```

Existing racks that never set this parameter behave exactly as before. There is nothing to do unless you want Container Insights enabled.

---

### Does it have a breaking change?

No. This change is fully backward compatible.

The parameter defaults to `No`, which keeps the cluster's Container Insights setting disabled, matching current behavior for every existing rack. Enabling or disabling the parameter performs an in-place update of the ECS Cluster resource (it adds or changes the `ClusterSettings` property only). The cluster is never replaced, no stack Outputs or resource IDs change, and no cross-stack imports are affected.

Downgrade is safe. A rack version that does not declare the `ContainerInsights` parameter reverts the cluster setting to the AWS default (disabled). No CloudFormation parameter gets stuck, because the safe default preserves existing behavior in both directions.

---

### Requirements

To use this feature, you must update to rack version `20260531001024` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
