### PR TITLE
add ECS Exec support with Docker fallback

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -72,6 +72,7 @@ var paramGroups = map[string]map[string]bool{
 	"security": {
 		"BuildInstancePolicy":                   true, // dual-listed in build
 		"BuildInstanceSecurityGroup":            true,
+		"ECSExec":                               true,
 		"EnableContainerReadonlyRootFilesystem": true,
 		"EnableSharedEFSVolumeEncryption":       true, // dual-listed in storage
 		"EncryptEbs":                            true, // dual-listed in storage

--- a/pkg/cli/rack_group_test.go
+++ b/pkg/cli/rack_group_test.go
@@ -221,5 +221,5 @@ func TestParamGroupsCoverRackJSON(t *testing.T) {
 	}
 	require.Empty(t, stale, "paramGroups members not in rack.json Parameters: %v", stale)
 
-	require.Equal(t, 110, len(rack.Parameters), "post-hardening rack.json should have 110 Parameters")
+	require.Equal(t, 111, len(rack.Parameters), "post-hardening rack.json should have 111 Parameters")
 }

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -61,6 +61,7 @@ type Provider struct {
 	DynamoBuilds                      string
 	DynamoReleases                    string
 	DockerTLS                         *structs.TLSPemCertBytes
+	ECSExec                           bool
 	EcsPollInterval                   int
 	EncryptionKey                     string
 	Fargate                           bool
@@ -167,6 +168,7 @@ func (p *Provider) loadParams() error {
 	p.CustomEncryptionKey = labels["rack.CustomEncryptionKey"]
 	p.DynamoBuilds = labels["rack.DynamoBuilds"]
 	p.DynamoReleases = labels["rack.DynamoReleases"]
+	p.ECSExec = labels["rack.ECSExec"] == "Yes"
 	p.EcsPollInterval = intParam(labels["rack.EcsPollInterval"], 1)
 	p.EncryptionKey = labels["rack.EncryptionKey"]
 	p.Fargate = labels["rack.Fargate"] == "Yes"

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -8,6 +8,7 @@
     "BlankLogRetention": { "Fn::Equals": [ { "Ref": "LogRetention" }, "" ] },
     "BlankResourcePassword": { "Fn::Equals": [ { "Ref": "ResourcePassword" }, "" ] },
     "CircuitBreaker": { "Fn::Equals": [ { "Ref": "CircuitBreaker" }, "Yes" ] },
+    "ECSExecEnabled": { "Fn::Equals": [ { "Ref": "ECSExec" }, "Yes" ] },
     "EC2Services": { "Fn::Not": [ { "Condition": "FargateServicesEither" } ] },
     "EC2Timers": { "Fn::Not": [ { "Condition": "FargateTimersEither" } ] },
     "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "LogDriver" }, "CloudWatch" ] },
@@ -62,6 +63,11 @@
       "AllowedValues" : [ "true", "false" ]
     },
     "CircuitBreaker": {
+      "Type": "String",
+      "Default": "No",
+      "AllowedValues": [ "Yes", "No" ]
+    },
+    "ECSExec": {
       "Type": "String",
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
@@ -350,16 +356,40 @@
         { "Fn::ImportValue": { "Fn::Sub": "${Rack}:CMKPolicy" } }
       ],
       "Path": "/convox/",
-      "Policies": [ {
-        "PolicyName": "convox-env",
-        "PolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            { "Effect": "Allow", "Action": "s3:GetObject", "Resource": { "Fn::Sub": "arn:${AWS::Partition}:s3:::${Settings}/*" } },
-            { "Effect": "Allow", "Action": "kms:Decrypt", "Resource": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:EncryptionKey" } } }
-          ]
-        }
-      } ]
+      "Policies": [
+        {
+          "PolicyName": "convox-env",
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              { "Effect": "Allow", "Action": "s3:GetObject", "Resource": { "Fn::Sub": "arn:${AWS::Partition}:s3:::${Settings}/*" } },
+              { "Effect": "Allow", "Action": "kms:Decrypt", "Resource": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:EncryptionKey" } } }
+            ]
+          }
+        },
+        { "Fn::If": [
+          "ECSExecEnabled",
+          {
+            "PolicyName": "ssm-exec",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "ssmmessages:CreateControlChannel",
+                    "ssmmessages:CreateDataChannel",
+                    "ssmmessages:OpenControlChannel",
+                    "ssmmessages:OpenDataChannel"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          },
+          { "Ref": "AWS::NoValue" }
+        ] }
+      ]
     }
   },
   {{ range .Manifest.Services }}
@@ -383,6 +413,7 @@
             "Certificate": { "Ref": "Balancer{{ upper .Name }}Certificate" },
           {{ end }}
           "CircuitBreaker": { "Ref": "CircuitBreaker" },
+          "ECSExec": { "Ref": "ECSExec" },
           "EnableContainerReadonlyRootFilesystem": { "Ref": "EnableContainerReadonlyRootFilesystem" },
           "Count": { "Fn::Select": [ 0, { "Ref": "{{ upper .Name }}Formation" } ] },
           "Cpu": { "Fn::Select": [ 1, { "Ref": "{{ upper .Name }}Formation" } ] },

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -856,6 +856,12 @@
       "Default": "false",
       "AllowedValues": [ "true", "false" ]
     },
+    "ECSExec": {
+      "Type": "String",
+      "Default": "No",
+      "Description": "Enable ECS Exec for interactive shell access to containers",
+      "AllowedValues": [ "Yes", "No" ]
+    },
     "EcsPollInterval": {
       "Type": "Number",
       "Default": "1",
@@ -4441,6 +4447,7 @@
               "rack.Cluster": { "Ref": "Cluster" },
               "rack.DynamoBuilds": { "Ref": "DynamoBuilds" },
               "rack.DynamoReleases": { "Ref": "DynamoReleases" },
+              "rack.ECSExec": { "Ref": "ECSExec" },
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
               "rack.LogDriver": { "Ref": "LogDriver" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
@@ -4582,6 +4589,7 @@
               "rack.Cluster": { "Ref": "Cluster" },
               "rack.DynamoBuilds": { "Ref": "DynamoBuilds" },
               "rack.DynamoReleases": { "Ref": "DynamoReleases" },
+              "rack.ECSExec": { "Ref": "ECSExec" },
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
               "rack.LogDriver": { "Ref": "LogDriver" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
@@ -4715,6 +4723,7 @@
               "rack.Cluster": { "Ref": "Cluster" },
               "rack.DynamoBuilds": { "Ref": "DynamoBuilds" },
               "rack.DynamoReleases": { "Ref": "DynamoReleases" },
+              "rack.ECSExec": { "Ref": "ECSExec" },
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
               "rack.LogDriver": { "Ref": "LogDriver" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },
@@ -4869,6 +4878,7 @@
               "rack.DockerTlsCAKey": { "Fn::GetAtt": [ "DockertTLSCAKey", "Value" ] },
               "rack.DockerTlsCert": { "Fn::GetAtt": [ "DockertTLSCert", "Value" ] },
               "rack.DockerTlsKey": { "Fn::GetAtt": [ "DockertTLSKey", "Value" ] },
+              "rack.ECSExec": { "Ref": "ECSExec" },
               "rack.EcsPollInterval": { "Ref": "EcsPollInterval" },
               "rack.LogDriver": { "Ref": "LogDriver" },
               "rack.EncryptionKey": { "Ref": "EncryptionKey" },

--- a/provider/aws/formation/service.json.tmpl
+++ b/provider/aws/formation/service.json.tmpl
@@ -3,6 +3,7 @@
     "AWSTemplateFormatVersion" : "2010-09-09",
     "Conditions": {
       "CircuitBreaker": { "Fn::Equals": [ { "Ref": "CircuitBreaker" }, "Yes" ] },
+      "ECSExecEnabled": { "Fn::Equals": [ { "Ref": "ECSExec" }, "Yes" ] },
       "DedicatedRole": { "Fn::Not":[{"Fn::Equals":[{"Ref":"Policies"},""]} ] },
       "EC2Launch": { "Fn::Not": [ { "Condition": "FargateEither" } ] },
       "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "LogDriver" }, "CloudWatch" ] },
@@ -66,6 +67,11 @@
         "Type": "String"
       },
       "CircuitBreaker": {
+        "Type": "String",
+        "Default": "No",
+        "AllowedValues": [ "Yes", "No" ]
+      },
+      "ECSExec": {
         "Type": "String",
         "Default": "No",
         "AllowedValues": [ "Yes", "No" ]
@@ -790,6 +796,7 @@
             ] }
           ] },
           "Cluster": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Cluster" } },
+          "EnableExecuteCommand": { "Fn::If": [ "ECSExecEnabled", true, false ] },
           "DeploymentConfiguration": {
             "DeploymentCircuitBreaker" : { "Fn::If": ["CircuitBreaker",
               { "Enable": "true", "Rollback": "true" },
@@ -863,16 +870,40 @@
           },
           "ManagedPolicyArns": {"Fn::Split":[",",{"Fn::Join":[",",[{"Ref":"Policies"},{"Fn::ImportValue":{"Fn::Sub":"${Rack}:CMKPolicy"}}]]}]},
           "Path": "/convox/",
-          "Policies": [ {
-            "PolicyName": "convox-env",
-            "PolicyDocument": {
-              "Version": "2012-10-17",
-              "Statement": [
-                { "Effect": "Allow", "Action": "s3:GetObject", "Resource": { "Fn::Sub": "arn:${AWS::Partition}:s3:::${Settings}/*" } },
-                { "Effect": "Allow", "Action": "kms:Decrypt", "Resource": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:EncryptionKey" } } }
-              ]
-            }
-          } ]
+          "Policies": [
+            {
+              "PolicyName": "convox-env",
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  { "Effect": "Allow", "Action": "s3:GetObject", "Resource": { "Fn::Sub": "arn:${AWS::Partition}:s3:::${Settings}/*" } },
+                  { "Effect": "Allow", "Action": "kms:Decrypt", "Resource": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:EncryptionKey" } } }
+                ]
+              }
+            },
+            { "Fn::If": [
+              "ECSExecEnabled",
+              {
+                "PolicyName": "ssm-exec",
+                "PolicyDocument": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Action": [
+                        "ssmmessages:CreateControlChannel",
+                        "ssmmessages:CreateDataChannel",
+                        "ssmmessages:OpenControlChannel",
+                        "ssmmessages:OpenDataChannel"
+                      ],
+                      "Resource": "*"
+                    }
+                  ]
+                }
+              },
+              { "Ref": "AWS::NoValue" }
+            ] }
+          ]
         }
       },
       "Tasks": {

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/convox/logger"
 	"github.com/convox/rack/pkg/cache"
 	"github.com/convox/rack/pkg/manifest"
 	"github.com/convox/rack/pkg/manifest1"
@@ -28,6 +29,15 @@ import (
 // StatusCodePrefix is sent to the client to let it know the exit code is coming next
 const StatusCodePrefix = "F1E49A85-0AD7-4AEF-A618-C249C6E6568D:"
 
+const ecsExecSessionByte = '\x00'
+
+type ecsExecSession struct {
+	SessionID  string `json:"sessionId"`
+	StreamURL  string `json:"streamUrl"`
+	TokenValue string `json:"tokenValue"`
+	Region     string `json:"region"`
+}
+
 // ProcessExec runs a command in an existing Process
 func (p *Provider) ProcessExec(app, pid, command string, rw io.ReadWriter, opts structs.ProcessExecOptions) (int, error) {
 	log := Logger.At("ProcessExec").Namespace("app=%q pid=%q command=%q", app, pid, command).Start()
@@ -38,8 +48,8 @@ func (p *Provider) ProcessExec(app, pid, command string, rw io.ReadWriter, opts 
 	}
 
 	pidFound := false
-	for _, p := range pss {
-		if p.Id == pid {
+	for _, ps := range pss {
+		if ps.Id == pid {
 			pidFound = true
 			break
 		}
@@ -49,8 +59,42 @@ func (p *Provider) ProcessExec(app, pid, command string, rw io.ReadWriter, opts 
 		return -1, errorNotFound(fmt.Sprintf("process id not found for %s", app))
 	}
 
+	a, err := p.AppGet(app)
+	if err != nil {
+		return -1, log.Error(err)
+	}
+
+	useECSExec := p.ECSExec && a.Tags["Generation"] == "2"
+
+	if useECSExec {
+		code, err := p.processExecECS(app, pid, command, rw, opts, log)
+		if err != nil {
+			if reqErr, ok := err.(awserr.Error); ok {
+				switch reqErr.Code() {
+				case "InvalidParameterException":
+					log.At("ProcessExec").Logf("audit-gap=true reason=pre-enable-task app=%s pid=%s", app, pid)
+					fmt.Fprintf(rw, "\r\nWARNING: task was started before ECS Exec was enabled, falling back to Docker exec (this session will not appear in CloudTrail). Redeploy the app to enable ECS Exec on all tasks.\r\n")
+					return p.processExecDocker(app, pid, command, rw, opts, a, log)
+				case "AccessDeniedException":
+					return -1, fmt.Errorf("ECS Exec access denied: verify the task role has ssmmessages permissions and the rack has ECSExec=Yes. Raw error: %s", reqErr.Message())
+				case "TargetNotConnectedException":
+					return -1, fmt.Errorf("container SSM agent is not ready; wait a few seconds and retry")
+				}
+			}
+			return -1, log.Error(err)
+		}
+		return code, log.Success()
+	}
+
+	return p.processExecDocker(app, pid, command, rw, opts, a, log)
+}
+
+func (p *Provider) processExecDocker(app, pid, command string, rw io.ReadWriter, opts structs.ProcessExecOptions, a *structs.App, log *logger.Logger) (int, error) {
 	dc, err := p.dockerClientFromPid(pid)
 	if err != nil {
+		if strings.Contains(err.Error(), "could not find instance") {
+			return -1, fmt.Errorf("cannot exec into Fargate task without ECS Exec enabled; set ECSExec=Yes on the rack and redeploy")
+		}
 		return -1, err
 	}
 
@@ -66,11 +110,6 @@ func (p *Provider) ProcessExec(app, pid, command string, rw io.ReadWriter, opts 
 	if opts.Entrypoint != nil && *opts.Entrypoint {
 		cmd = append(c.Config.Entrypoint, cmd...)
 	} else {
-		a, err := p.AppGet(app)
-		if err != nil {
-			return -1, err
-		}
-
 		if a.Tags["Generation"] == "2" {
 			cmd = append([]string{"/convox-env"}, cmd...)
 		}
@@ -118,6 +157,70 @@ func (p *Provider) ProcessExec(app, pid, command string, rw io.ReadWriter, opts 
 	}
 
 	return ires.ExitCode, log.Success()
+}
+
+func (p *Provider) processExecECS(app, pid, command string, rw io.ReadWriter, opts structs.ProcessExecOptions, log *logger.Logger) (int, error) {
+	arn, err := p.taskArnFromAppPid(app, pid)
+	if err != nil {
+		return -1, err
+	}
+
+	task, err := p.describeTask(arn)
+	if err != nil {
+		return -1, err
+	}
+
+	if task.TaskDefinitionArn == nil {
+		return -1, fmt.Errorf("task has no task definition")
+	}
+
+	res, err := p.ecs().DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: task.TaskDefinitionArn,
+	})
+	if err != nil {
+		return -1, err
+	}
+
+	if len(res.TaskDefinition.ContainerDefinitions) < 1 {
+		return -1, fmt.Errorf("no container definitions in task definition")
+	}
+
+	containerName := aws.StringValue(res.TaskDefinition.ContainerDefinitions[0].Name)
+
+	tty := cb(opts.Tty, true)
+
+	execRes, err := p.ecs().ExecuteCommand(&ecs.ExecuteCommandInput{
+		Cluster:     aws.String(p.Cluster),
+		Task:        aws.String(arn),
+		Container:   aws.String(containerName),
+		Command:     aws.String(command),
+		Interactive: aws.Bool(tty),
+	})
+	if err != nil {
+		return -1, err
+	}
+
+	if execRes.Session == nil || execRes.Session.SessionId == nil || execRes.Session.StreamUrl == nil || execRes.Session.TokenValue == nil {
+		return -1, fmt.Errorf("ECS ExecuteCommand returned incomplete session credentials")
+	}
+
+	session := ecsExecSession{
+		SessionID:  aws.StringValue(execRes.Session.SessionId),
+		StreamURL:  aws.StringValue(execRes.Session.StreamUrl),
+		TokenValue: aws.StringValue(execRes.Session.TokenValue),
+		Region:     p.Region,
+	}
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		return -1, err
+	}
+
+	if _, err := rw.Write(append([]byte{ecsExecSessionByte}, data...)); err != nil {
+		return -1, err
+	}
+
+	return 0, nil
 }
 
 // ProcessGet returns the specified process for an app
@@ -462,6 +565,16 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 		Count:          aws.Int64(1),
 		StartedBy:      aws.String(fmt.Sprintf("convox.%s", app)),
 		TaskDefinition: aws.String(td),
+	}
+
+	if p.ECSExec {
+		a, err := p.AppGet(app)
+		if err != nil {
+			return nil, log.Error(err)
+		}
+		if a.Tags["Generation"] == "2" {
+			req.EnableExecuteCommand = aws.Bool(true)
+		}
 	}
 
 	if opts.Command != nil {

--- a/provider/aws/processes_test.go
+++ b/provider/aws/processes_test.go
@@ -2,6 +2,7 @@ package aws_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"testing"
 
@@ -36,19 +37,19 @@ func TestProcessExec(t *testing.T) {
 		cycleProcessDescribeRackInstances,
 		cycleECSListServices,
 		cycleECSDescribeServices,
-		cycleProcessListTasksRunning,
-		cycleProcessListTasksStopped,
-		cycleProcessDescribeTasks,
-		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessListTasksRunning,
-		cycleProcessListTasksStopped,
-		cycleProcessDescribeTasks,
-		cycleProcessDescribeContainerInstances,
-		cycleProcessDescribeInstances,
-		cycleProcessListTasksRunning,
-		cycleProcessListTasksStopped,
 		cycleProcessDescribeStacks,
+		cycleProcessListTasksRunning,
+		cycleProcessListTasksStopped,
+		cycleProcessDescribeTasks,
+		cycleProcessDescribeContainerInstances,
+		cycleProcessDescribeInstances,
+		cycleProcessListTasksRunning,
+		cycleProcessListTasksStopped,
+		cycleProcessDescribeTasks,
+		cycleProcessDescribeContainerInstances,
+		cycleProcessDescribeInstances,
+		cycleProcessListTasksRunning,
+		cycleProcessListTasksStopped,
 		cycleProcessDescribeStackResources,
 	)
 	defer provider.Close()
@@ -74,6 +75,67 @@ func TestProcessExec(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("foo"), out.Bytes())
 	assert.Equal(t, 0, code)
+}
+
+func TestProcessExecECS(t *testing.T) {
+	provider := StubAwsProvider(
+		// ProcessList
+		cycleProcessListStackResources,
+		cycleProcessDescribeStacks,
+		cycleProcessListTasksByStack,
+		cycleProcessListTasksByService1,
+		cycleProcessListTasksByService2,
+		cycleProcessListTasksByStarted,
+		cycleProcessDescribeTasksAll,
+		cycleProcessDescribeTaskDefinition1,
+		cycleProcessDescribeContainerInstances,
+		cycleProcessDescribeTaskDefinition1,
+		cycleProcessDescribeContainerInstances,
+		cycleProcessDescribeRackInstances,
+		cycleECSListServices,
+		cycleECSDescribeServices,
+		// AppGet (with Generation=2)
+		cycleProcessDescribeStacksGen2,
+		// taskArnFromAppPid -> appTaskARNs -> stackTasks
+		cycleProcessListStackResources,
+		cycleProcessDescribeStacks,
+		cycleProcessListTasksByStack,
+		cycleProcessListTasksByService1,
+		cycleProcessListTasksByService2,
+		cycleProcessListTasksByStarted,
+		// describeTask
+		cycleProcessDescribeTasks,
+		// DescribeTaskDefinition (for container name)
+		cycleProcessDescribeTaskDefinition1,
+		// ExecuteCommand
+		cycleProcessExecuteCommand,
+	)
+	defer provider.Close()
+
+	provider.ECSExec = true
+
+	in := &bytes.Buffer{}
+	out := &bytes.Buffer{}
+
+	code, err := provider.ProcessExec("myapp", "5850760f0845", "ls -la", streamTester{in, out}, structs.ProcessExecOptions{
+		Height: options.Int(10),
+		Width:  options.Int(20),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, code)
+
+	data := out.Bytes()
+	assert.True(t, len(data) > 1, "expected session data in output")
+	assert.Equal(t, byte(0x00), data[0])
+
+	var session map[string]string
+	err = json.Unmarshal(data[1:], &session)
+	assert.NoError(t, err)
+	assert.Equal(t, "ecs-execute-command-abc123", session["sessionId"])
+	assert.Equal(t, "wss://ssmmessages.us-test-1.amazonaws.com/v1/data-channel/ecs-execute-command-abc123", session["streamUrl"])
+	assert.Equal(t, "token-value-xyz", session["tokenValue"])
+	assert.Equal(t, "us-test-1", session["region"])
 }
 
 func TestProcessList(t *testing.T) {
@@ -506,6 +568,77 @@ var cycleProcessDescribeStacks = awsutil.Cycle{
 								<member>
 									<Value>myapp</Value>
 									<Key>Name</Key>
+								</member>
+							</Tags>
+							<LastUpdatedTime>2016-09-10T04:32:19.081Z</LastUpdatedTime>
+							<Parameters>
+							</Parameters>
+						</member>
+					</Stacks>
+				</DescribeStacksResult>
+				<ResponseMetadata>
+					<RequestId>9627285a-7903-11e6-a36d-77452275e1ca</RequestId>
+				</ResponseMetadata>
+			</DescribeStacksResponse>
+		`,
+	},
+}
+
+var cycleProcessDescribeStacksGen2 = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Body:       `Action=DescribeStacks&StackName=convox-myapp&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `
+			<DescribeStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+				<DescribeStacksResult>
+					<Stacks>
+						<member>
+							<Outputs>
+								<member>
+									<OutputKey>RegistryId</OutputKey>
+									<OutputValue>778743527532</OutputValue>
+								</member>
+								<member>
+									<OutputKey>RegistryRepository</OutputKey>
+									<OutputValue>convox-myapp-nkdecwppkq</OutputValue>
+								</member>
+								<member>
+									<OutputKey>ServiceWebService</OutputKey>
+									<OutputValue>service-web</OutputValue>
+								</member>
+							</Outputs>
+							<Capabilities>
+								<member>CAPABILITY_IAM</member>
+							</Capabilities>
+							<CreationTime>2016-08-29T17:45:22.396Z</CreationTime>
+							<NotificationARNs/>
+							<StackId>arn:aws:cloudformation:us-east-1:778743527532:stack/convox-myapp/5c05e0c0-6e10-11e6-8a4e-50fae98a10d2</StackId>
+							<StackName>convox-myapp</StackName>
+							<StackStatus>UPDATE_COMPLETE</StackStatus>
+							<DisableRollback>false</DisableRollback>
+							<Tags>
+								<member>
+									<Value>convox</Value>
+									<Key>Rack</Key>
+								</member>
+								<member>
+									<Value>app</Value>
+									<Key>Type</Key>
+								</member>
+								<member>
+									<Value>convox</Value>
+									<Key>System</Key>
+								</member>
+								<member>
+									<Value>myapp</Value>
+									<Key>Name</Key>
+								</member>
+								<member>
+									<Value>2</Value>
+									<Key>Generation</Key>
 								</member>
 							</Tags>
 							<LastUpdatedTime>2016-09-10T04:32:19.081Z</LastUpdatedTime>
@@ -1725,5 +1858,33 @@ var cycleProcessDockerInspectExec = awsutil.Cycle{
 	Response: awsutil.Response{
 		StatusCode: 200,
 		Body:       `{"ExitCode":0}`,
+	},
+}
+
+var cycleProcessExecuteCommand = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Operation:  "AmazonEC2ContainerServiceV20141113.ExecuteCommand",
+		Body: `{
+			"cluster": "cluster-test",
+			"command": "ls -la",
+			"container": "web",
+			"interactive": true,
+			"task": "arn:aws:ecs:us-east-1:778743527532:task/cluster-test/50b8de99-f94f-4ecd-a98f-5850760f0845"
+		}`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `{
+			"session": {
+				"sessionId": "ecs-execute-command-abc123",
+				"streamUrl": "wss://ssmmessages.us-test-1.amazonaws.com/v1/data-channel/ecs-execute-command-abc123",
+				"tokenValue": "token-value-xyz"
+			},
+			"clusterArn": "arn:aws:ecs:us-east-1:778743527532:cluster/cluster-test",
+			"containerName": "web",
+			"interactive": true,
+			"taskArn": "arn:aws:ecs:us-east-1:778743527532:task/cluster-test/50b8de99-f94f-4ecd-a98f-5850760f0845"
+		}`,
 	},
 }

--- a/provider/aws/releases.go
+++ b/provider/aws/releases.go
@@ -454,6 +454,11 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		return err
 	}
 
+	ecsExec, err := p.stackParameter(p.Rack, "ECSExec")
+	if err != nil {
+		ecsExec = "No"
+	}
+
 	updates := map[string]string{
 		"LogBucket":                             p.LogBucket,
 		"LogDriver":                             p.LogDriver,
@@ -462,6 +467,7 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		"SyslogDestination":                     p.SyslogDestination,
 		"SyslogFormat":                          p.SyslogFormat,
 		"EnableContainerReadonlyRootFilesystem": readonlyRootFilesystem,
+		"ECSExec":                               ecsExec,
 	}
 
 	if m.Params != nil {

--- a/sdk/methods.go
+++ b/sdk/methods.go
@@ -1,8 +1,10 @@
 package sdk
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/convox/rack/pkg/structs"
@@ -504,14 +506,64 @@ func (c *Client) ProcessExec(app string, pid string, command string, rw io.ReadW
 	ro.Headers["command"] = command
 	ro.Body = rw
 
-	var v int
-
-	v, err = c.WebsocketExit(fmt.Sprintf("/apps/%s/processes/%s/exec", app, pid), ro, rw)
+	ws, err := c.Websocket(fmt.Sprintf("/apps/%s/processes/%s/exec", app, pid), ro)
 	if err != nil {
 		return 0, err
 	}
+	defer ws.Close()
 
-	return v, err
+	buf := make([]byte, 10*1024)
+	code := 0
+	var ecsSessionData []byte
+
+	for {
+		n, err := ws.Read(buf)
+		if err == io.EOF {
+			return code, nil
+		}
+		if err != nil {
+			return code, err
+		}
+
+		if ecsSessionData != nil {
+			ecsSessionData = append(ecsSessionData, buf[0:n]...)
+			var session ecsExecSession
+			if err := json.Unmarshal(ecsSessionData, &session); err != nil {
+				continue
+			}
+			return runSessionManagerPlugin(session)
+		}
+
+		if len(buf) > 0 && n > 0 && buf[0] == ecsExecSessionByte {
+			ecsSessionData = make([]byte, 0, n)
+			ecsSessionData = append(ecsSessionData, buf[1:n]...)
+			var session ecsExecSession
+			if err := json.Unmarshal(ecsSessionData, &session); err != nil {
+				continue
+			}
+			return runSessionManagerPlugin(session)
+		}
+
+		data := string(buf[0:n])
+
+		if i := strings.Index(data, statusCodePrefix); i > -1 {
+			if _, err := rw.Write(buf[0:i]); err != nil {
+				return 0, err
+			}
+
+			m := i + len(statusCodePrefix)
+			code, err = strconv.Atoi(strings.TrimSpace(string(buf[m:n])))
+			if err != nil {
+				return 0, fmt.Errorf("unable to read exit code")
+			}
+
+			continue
+		}
+
+		if _, err := rw.Write(buf[0:n]); err != nil {
+			return 0, err
+		}
+	}
 }
 
 func (c *Client) ProcessGet(app string, pid string) (*structs.Process, error) {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -3,11 +3,13 @@ package sdk
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -17,9 +19,17 @@ import (
 )
 
 const (
-	sortableTime     = "20060102.150405.000000000"
-	statusCodePrefix = "F1E49A85-0AD7-4AEF-A618-C249C6E6568D:"
+	sortableTime        = "20060102.150405.000000000"
+	statusCodePrefix    = "F1E49A85-0AD7-4AEF-A618-C249C6E6568D:"
+	ecsExecSessionByte  = '\x00'
 )
+
+type ecsExecSession struct {
+	SessionID  string `json:"sessionId"`
+	StreamURL  string `json:"streamUrl"`
+	TokenValue string `json:"tokenValue"`
+	Region     string `json:"region"`
+}
 
 var (
 	Version = "dev"
@@ -134,6 +144,53 @@ func (c *Client) WebsocketExit(path string, ro stdsdk.RequestOptions, rw io.Read
 			return 0, err
 		}
 	}
+}
+
+func runSessionManagerPlugin(session ecsExecSession) (int, error) {
+	pluginPath, err := exec.LookPath("session-manager-plugin")
+	if err != nil {
+		return -1, fmt.Errorf("session-manager-plugin not found in PATH. Install it: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html")
+	}
+
+	sessionJSON, err := json.Marshal(map[string]string{
+		"SessionId":  session.SessionID,
+		"StreamUrl":  session.StreamURL,
+		"TokenValue": session.TokenValue,
+	})
+	if err != nil {
+		return -1, err
+	}
+
+	endpoint := fmt.Sprintf("https://ssm.%s.amazonaws.com", session.Region)
+
+	targetJSON, err := json.Marshal(map[string]string{
+		"Target": session.SessionID,
+	})
+	if err != nil {
+		return -1, err
+	}
+
+	cmd := exec.Command(pluginPath,
+		string(sessionJSON),
+		session.Region,
+		"StartSession",
+		"",
+		string(targetJSON),
+		endpoint,
+	)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), nil
+		}
+		return -1, err
+	}
+
+	return 0, nil
 }
 
 func (c *Client) WithContext(ctx context.Context) structs.Provider {


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: ECS Exec with Docker Fallback**

`convox exec` and `convox run` can now open interactive container sessions through ECS Exec, which tunnels the session over AWS SSM Session Manager instead of relying on a direct connection to the Docker daemon on the host instance. This is the same mechanism behind `aws ecs execute-command`. The rack passes short-lived session credentials back to the CLI, and the CLI launches `session-manager-plugin` locally to attach your terminal to the container. Because the session no longer depends on reaching the Docker socket, you can exec into Fargate tasks and into tasks running on instances that are not directly reachable.

The behavior is controlled by a single rack parameter. It is off by default, so existing racks are unaffected until you opt in.

| Parameter | Type | Default | Effect |
|-----------|------|---------|--------|
| `ECSExec` | Yes/No | `No` | Enables ECS Exec for interactive shell access to running containers via SSM Session Manager |

When `ECSExec=Yes`, `convox exec` uses ECS Exec. It automatically falls back to Docker exec in three cases: gen1 apps, racks that have `ECSExec=No`, and tasks that were started before ECS Exec was enabled (those tasks need a redeploy to gain the capability). `convox run` likewise enables the execute-command capability on new tasks when the rack has `ECSExec=Yes`. When enabled, the relevant task roles receive a scoped inline `ssm-exec` policy granting only the `ssmmessages` channel permissions, and the ECS service is created with `EnableExecuteCommand` set to true.

---

### How to use it?

Enable ECS Exec on the rack:

```
$ convox rack params set ECSExec=Yes -r my-rack
```

Wait for the rack update to finish, then confirm the value:

```
$ convox rack params -r my-rack | grep ECSExec
ECSExec  Yes
```

Redeploy each app so its tasks pick up the execute-command capability and the SSM agent:

```
$ convox deploy -a my-app -r my-rack
```

Exec into a running process. For ECS Exec sessions you must have `session-manager-plugin` installed locally (the CLI prints the AWS install link if it is missing):

```
$ convox ps -a my-app -r my-rack
$ convox exec my-app-web-12345 "bash" -a my-app -r my-rack
```

To turn the feature back off:

```
$ convox rack params set ECSExec=No -r my-rack
```

---

### Does it have a breaking change?

No breaking changes. The `ECSExec` parameter defaults to `No`, so racks that do not set it behave exactly as before, and `convox exec` continues to use Docker exec.

A few operational notes apply when you adopt the feature:

- Upgrading to this rack version triggers a rolling restart of the rack API because the rack task definitions gain new docker labels. This is the normal rack update flow and requires no action.
- After you set `ECSExec=Yes`, tasks that are already running were started before the capability was added, so `convox exec` falls back to Docker exec for them and prints a warning. These pre-enable sessions are not visible in CloudTrail. Redeploy the app to move all tasks onto ECS Exec.
- Each user running `convox exec` against an ECS Exec enabled rack must install `session-manager-plugin` on their own machine.
- Racks in fully private VPCs without NAT may need VPC interface endpoints for `ssmmessages` and `ssm` so the SSM agent in the container can reach the service.
- Downgrading to a rack version that predates this parameter requires first setting `ECSExec=No`, then performing the downgrade.

CloudFormation changes are additive and update in place. A new `ECSExec` parameter (default `No`) is added to the rack, app, and service templates, a new `ECSExecEnabled` condition gates the conditional `EnableExecuteCommand` property on the ECS service and the conditional `ssm-exec` inline policy on the task roles. There are no resource renames, no Output changes, and no `Fn::ImportValue` changes. Stacks update rather than replace.

---

### Requirements

To use this feature, you must update to rack version `20260531001024` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
