### PR TITLE
fix ECS Exec binary output truncation

### DIFF
--- a/sdk/methods.go
+++ b/sdk/methods.go
@@ -514,11 +514,15 @@ func (c *Client) ProcessExec(app string, pid string, command string, rw io.ReadW
 
 	buf := make([]byte, 10*1024)
 	code := 0
+	first := true
 	var ecsSessionData []byte
 
 	for {
 		n, err := ws.Read(buf)
 		if err == io.EOF {
+			if ecsSessionData != nil {
+				return -1, fmt.Errorf("ECS Exec session ended before it was established; please retry")
+			}
 			return code, nil
 		}
 		if err != nil {
@@ -534,14 +538,17 @@ func (c *Client) ProcessExec(app string, pid string, command string, rw io.ReadW
 			return runSessionManagerPlugin(session)
 		}
 
-		if len(buf) > 0 && n > 0 && buf[0] == ecsExecSessionByte {
-			ecsSessionData = make([]byte, 0, n)
-			ecsSessionData = append(ecsSessionData, buf[1:n]...)
-			var session ecsExecSession
-			if err := json.Unmarshal(ecsSessionData, &session); err != nil {
-				continue
+		if first {
+			first = false
+			if n > 0 && buf[0] == ecsExecSessionByte {
+				ecsSessionData = make([]byte, 0, n)
+				ecsSessionData = append(ecsSessionData, buf[1:n]...)
+				var session ecsExecSession
+				if err := json.Unmarshal(ecsSessionData, &session); err != nil {
+					continue
+				}
+				return runSessionManagerPlugin(session)
 			}
-			return runSessionManagerPlugin(session)
 		}
 
 		data := string(buf[0:n])


### PR DESCRIPTION
# Fix ECS Exec binary output truncation in the CLI

## Problem

ECS Exec signals a session by writing a single payload to the exec websocket that begins with a sentinel byte (`0x00`) followed by the SSM session JSON. The CLI read loop (`sdk/methods.go` `ProcessExec`) checked for that sentinel on the first byte of **every** read frame while no session was in progress.

The websocket transport re-chunks the stream into fixed 1024-byte frames. When a command's output contains `0x00` bytes (any binary output: a binary file, gzip/tar, a database dump, an image) and one lands on a 1024-byte chunk boundary, that frame begins with `0x00` and false-triggers the session branch. The loop then treats the rest of the stream as a session blob, fails to parse it, and silently discards all remaining output, returning exit code 0. A script that does `convox exec <pid> cat /path/to/binary > file` gets a truncated file and a success exit code.

## Fix

1. Only evaluate the sentinel on the **first** frame of the stream. The rack always writes the session marker as the very first payload, so first-frame detection is exactly correct, and a `0x00` appearing later in normal output is no longer misread.
2. On end-of-stream, if a session marker was seen on the first frame but the JSON never completed (a dropped session handshake), return an error instead of a silent exit 0.

## Safety / blast radius

- Legitimate ECS Exec is unaffected: the rack sends the marker as the first payload, which the first-frame check still catches (including multi-frame SSM tokens, which accumulate via the existing continuation branch).
- Normal exec (interactive and scripted), exit-code parsing, and `convox run` are unchanged.
- No CloudFormation change, no IAM change, no wire-protocol change. Client-read-loop only.