### PR TITLE
Stop rotating docker TLS CA on update

### DIFF
--- a/provider/aws/lambda/formation/handler/certificate.go
+++ b/provider/aws/lambda/formation/handler/certificate.go
@@ -104,16 +104,6 @@ func CreateSelfSignedCertsForDocker(req Request) (string, map[string]string, err
 		return "", nil, err
 	}
 
-	_, err = ssmClient.PutParameter(&ssm.PutParameterInput{
-		Name:      aws.String(versionParameterName(rackKey)),
-		Overwrite: aws.Bool(true),
-		Value:     aws.String(req.ResourceProperties["Version"].(string)),
-		Type:      aws.String(ssm.ParameterTypeString),
-	})
-	if err != nil {
-		return "", nil, err
-	}
-
 	return rackKey, map[string]string{
 		"CACertSSMKey": caCertParameterName(rackKey),
 		"CAKeySSMKey":  caKeyParameterName(rackKey),
@@ -166,10 +156,9 @@ func UpdateSelfSignedCertsForDocker(req Request) (string, map[string]string, err
 	rackKey := rackHash(req.ResourceProperties["Rack"].(string))
 	ssmClient := SSM(req)
 	param, err := ssmClient.GetParameter(&ssm.GetParameterInput{
-		Name: aws.String(versionParameterName(rackKey)),
+		Name: aws.String(certParameterName(rackKey)),
 	})
-	if err != nil || param.Parameter == nil || param.Parameter.Value == nil ||
-		*param.Parameter.Value != req.ResourceProperties["Version"].(string) {
+	if err != nil {
 		return CreateSelfSignedCertsForDocker(req)
 	}
 
@@ -179,6 +168,10 @@ func UpdateSelfSignedCertsForDocker(req Request) (string, map[string]string, err
 	}
 
 	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return CreateSelfSignedCertsForDocker(req)
+	}
+
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
 		return CreateSelfSignedCertsForDocker(req)
@@ -211,10 +204,6 @@ func certParameterName(rack string) string {
 
 func keyParameterName(rack string) string {
 	return fmt.Sprintf("%s-docker-tls-key", rack)
-}
-
-func versionParameterName(rack string) string {
-	return fmt.Sprintf("%s-version-track", rack)
 }
 
 func generateSelfSignedCertsForDocker() (map[string]string, error) {

--- a/provider/aws/lambda/formation/handler/certificate.go
+++ b/provider/aws/lambda/formation/handler/certificate.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
@@ -159,26 +160,17 @@ func UpdateSelfSignedCertsForDocker(req Request) (string, map[string]string, err
 		Name: aws.String(certParameterName(rackKey)),
 	})
 	if err != nil {
+		if isParameterNotFound(err) {
+			return CreateSelfSignedCertsForDocker(req)
+		}
+		return rackKey, nil, err
+	}
+
+	if param.Parameter == nil || param.Parameter.Value == nil {
 		return CreateSelfSignedCertsForDocker(req)
 	}
 
-	pemBytes, err := base64.StdEncoding.DecodeString(*param.Parameter.Value)
-	if err != nil {
-		return CreateSelfSignedCertsForDocker(req)
-	}
-
-	block, _ := pem.Decode(pemBytes)
-	if block == nil {
-		return CreateSelfSignedCertsForDocker(req)
-	}
-
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return CreateSelfSignedCertsForDocker(req)
-	}
-
-	// renew if cert expires in 2 months
-	if cert.NotAfter.Before(time.Now().Add(2 * 30 * 24 * time.Hour)) {
+	if shouldRegenerateCert(*param.Parameter.Value, time.Now()) {
 		return CreateSelfSignedCertsForDocker(req)
 	}
 
@@ -188,6 +180,34 @@ func UpdateSelfSignedCertsForDocker(req Request) (string, map[string]string, err
 		"CertSSMKey":   certParameterName(rackKey),
 		"KeySSMKey":    keyParameterName(rackKey),
 	}, nil
+}
+
+func isParameterNotFound(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok {
+		return aerr.Code() == ssm.ErrCodeParameterNotFound
+	}
+	return false
+}
+
+// shouldRegenerateCert reports whether the stored docker TLS cert is missing,
+// unreadable, or within two months of expiry and must be regenerated.
+func shouldRegenerateCert(b64cert string, now time.Time) bool {
+	pemBytes, err := base64.StdEncoding.DecodeString(b64cert)
+	if err != nil {
+		return true
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return true
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return true
+	}
+
+	return cert.NotAfter.Before(now.Add(2 * 30 * 24 * time.Hour))
 }
 
 func caCertParameterName(rack string) string {

--- a/provider/aws/lambda/formation/handler/certificate_test.go
+++ b/provider/aws/lambda/formation/handler/certificate_test.go
@@ -1,11 +1,19 @@
 package handler
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
+	"math/big"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
 func parseCertParam(t *testing.T, b64pem string) *x509.Certificate {
@@ -50,5 +58,71 @@ func TestGenerateSelfSignedCertsForDockerChainsToCA(t *testing.T) {
 
 	if got := time.Until(leaf.NotAfter); got < 99*365*24*time.Hour {
 		t.Errorf("leaf validity too short: %s remaining", got)
+	}
+}
+
+func makeCertB64(t *testing.T, validFor time.Duration) string {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %s", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-2 * time.Hour),
+		NotAfter:     time.Now().Add(validFor),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create certificate: %s", err)
+	}
+	return base64.StdEncoding.EncodeToString(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func TestShouldRegenerateCert(t *testing.T) {
+	notPEM := base64.StdEncoding.EncodeToString([]byte("hello"))
+	pemNotCert := base64.StdEncoding.EncodeToString(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a certificate")}))
+
+	cases := []struct {
+		name string
+		cert string
+		want bool
+	}{
+		{"valid long-lived", makeCertB64(t, 100*365*24*time.Hour), false},
+		{"expiring within two months", makeCertB64(t, 30*24*time.Hour), true},
+		{"already expired", makeCertB64(t, -1*time.Hour), true},
+		{"not base64", "!!! not base64 !!!", true},
+		{"base64 but not PEM", notPEM, true},
+		{"PEM but not a certificate", pemNotCert, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldRegenerateCert(c.cert, time.Now()); got != c.want {
+				t.Errorf("shouldRegenerateCert(%q) = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsParameterNotFound(t *testing.T) {
+	if !isParameterNotFound(awserr.New(ssm.ErrCodeParameterNotFound, "not found", nil)) {
+		t.Error("ParameterNotFound should be detected")
+	}
+	if !isParameterNotFound(awserr.NewRequestFailure(awserr.New(ssm.ErrCodeParameterNotFound, "not found", nil), 400, "req-id")) {
+		t.Error("RequestFailure-wrapped ParameterNotFound should be detected")
+	}
+	if !isParameterNotFound(&ssm.ParameterNotFound{}) {
+		t.Error("typed *ssm.ParameterNotFound should be detected")
+	}
+	if isParameterNotFound(awserr.New("ThrottlingException", "slow down", nil)) {
+		t.Error("a transient aws error must not be treated as not-found")
+	}
+	if isParameterNotFound(errors.New("network blip")) {
+		t.Error("a non-aws error must not be treated as not-found")
+	}
+	if isParameterNotFound(nil) {
+		t.Error("nil error must not be treated as not-found")
 	}
 }

--- a/provider/aws/lambda/formation/handler/certificate_test.go
+++ b/provider/aws/lambda/formation/handler/certificate_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"testing"
+	"time"
+)
+
+func parseCertParam(t *testing.T, b64pem string) *x509.Certificate {
+	t.Helper()
+	der, err := base64.StdEncoding.DecodeString(b64pem)
+	if err != nil {
+		t.Fatalf("base64 decode: %s", err)
+	}
+	block, _ := pem.Decode(der)
+	if block == nil {
+		t.Fatal("pem decode returned nil block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse certificate: %s", err)
+	}
+	return cert
+}
+
+func TestGenerateSelfSignedCertsForDockerChainsToCA(t *testing.T) {
+	certs, err := generateSelfSignedCertsForDocker()
+	if err != nil {
+		t.Fatalf("generate: %s", err)
+	}
+
+	ca := parseCertParam(t, certs["CACert"])
+	leaf := parseCertParam(t, certs["Cert"])
+
+	if !ca.IsCA {
+		t.Error("CA cert is not marked IsCA")
+	}
+
+	if err := leaf.CheckSignatureFrom(ca); err != nil {
+		t.Fatalf("leaf does not chain to CA: %s", err)
+	}
+
+	roots := x509.NewCertPool()
+	roots.AddCert(ca)
+	if _, err := leaf.Verify(x509.VerifyOptions{Roots: roots, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny}}); err != nil {
+		t.Fatalf("leaf verify against CA pool: %s", err)
+	}
+
+	if got := time.Until(leaf.NotAfter); got < 99*365*24*time.Hour {
+		t.Errorf("leaf validity too short: %s remaining", got)
+	}
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Preserve Docker TLS Certificates Across Rack Updates**

The rack's internal Docker TLS certificate authority is now preserved across rack version updates. Certificates are regenerated only when the stored certificate is missing, unreadable, or close to expiry, so across version updates the rack API and the Docker daemons on rack instances continue to trust the same certificate authority.

With this change, commands that reach an instance's Docker daemon, such as `convox run` and `convox exec`, keep working on every instance immediately after a rack update, with no instance replacement needed.

---

### How to use it?

The fix is automatic. Update your rack:

```
$ convox rack update
```

No configuration or parameter changes are required.

---

### Does it have a breaking change?

No breaking changes. Certificate validity and the TLS configuration between the rack API and instance Docker daemons are unchanged; the difference is that updates preserve the existing certificates instead of reissuing them.

---

### Requirements

To receive this fix, you must update to rack version `20260714094620` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
