### PR TITLE
Add passkey browser auth to CLI

### DIFF
--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -2,10 +2,18 @@ package cli
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
 	"regexp"
+	"runtime"
+	"strings"
+	"time"
 
 	"github.com/convox/rack/pkg/token"
 	"github.com/convox/rack/sdk"
@@ -51,14 +59,22 @@ func authenticator(c *stdcli.Context) stdsdk.Authenticator {
 
 			c.Writef("Waiting for security token... ")
 
-			data, err := token.Authenticate(dres)
-			if err != nil {
-				return nil, AuthenticationError{err}
+			if os.Getenv("CONVOX_WEB_U2F_DISABLE") == "true" {
+				data, err := token.Authenticate(dres)
+				if err != nil {
+					return nil, AuthenticationError{err}
+				}
+				body = data
+			} else {
+				data, err := browserAuthenticate(c, cl, dres)
+				if err != nil {
+					return nil, AuthenticationError{err}
+				}
+				body = data
 			}
 
 			c.Writef("<ok>OK</ok>\n")
 
-			body = data
 			headers["Challenge"] = ares.Header.Get("Challenge")
 		}
 
@@ -93,5 +109,107 @@ func currentSession(c *stdcli.Context) sdk.SessionFunc {
 	return func(cl *sdk.Client) string {
 		sid, _ := c.SettingReadKey("session", cl.Endpoint.Host)
 		return sid
+	}
+}
+
+func browserAuthenticate(c *stdcli.Context, cl *stdsdk.Client, challenge []byte) ([]byte, error) {
+	target := url.URL{
+		Scheme: cl.Endpoint.Scheme,
+		Host:   cl.Endpoint.Host,
+		Path:   "/login/u2f",
+	}
+
+	dataChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+
+	addr, srv, err := u2fCallbackServer(dataChan, errChan)
+	if err != nil {
+		return nil, err
+	}
+	defer srv.Close()
+
+	q := target.Query()
+	q.Add("token", base64.StdEncoding.EncodeToString(challenge))
+	q.Add("callback_url", addr)
+	target.RawQuery = q.Encode()
+
+	c.Writef("\nOpen this link in your browser to complete authentication:\n%s\n", target.String())
+	c.Writef("(on a headless machine, set CONVOX_WEB_U2F_DISABLE=true to use a USB security key instead)\n")
+
+	if err := openBrowser(target.String()); err != nil {
+		c.Writef("Could not open a browser automatically; open the link above manually.\n")
+	}
+
+	timeout := time.NewTimer(5 * time.Minute)
+	defer timeout.Stop()
+
+	select {
+	case <-timeout.C:
+		return nil, fmt.Errorf("timed out waiting for browser authentication; set CONVOX_WEB_U2F_DISABLE=true to use a USB security key")
+	case err := <-errChan:
+		return nil, err
+	case data := <-dataChan:
+		return data, nil
+	}
+}
+
+func u2fCallbackServer(dataChan chan []byte, errChan chan error) (string, *http.Server, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to listen on port: %s", err)
+	}
+
+	addr := fmt.Sprintf("http://127.0.0.1:%d", listener.Addr().(*net.TCPAddr).Port)
+
+	srv := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			data := r.URL.Query().Get("data")
+			if data == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			// query parsing decodes '+' to a space; standard base64 never contains spaces
+			data = strings.ReplaceAll(data, " ", "+")
+
+			decoded, err := base64.StdEncoding.DecodeString(data)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "Authentication complete. You may close this window.")
+
+			select {
+			case dataChan <- decoded:
+			default:
+			}
+		}),
+	}
+
+	go func() {
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			select {
+			case errChan <- err:
+			default:
+			}
+		}
+	}()
+
+	return addr, srv, nil
+}
+
+func openBrowser(uri string) error {
+	switch runtime.GOOS {
+	case "linux":
+		return exec.Command("xdg-open", uri).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", uri).Start()
+	case "darwin":
+		return exec.Command("open", uri).Start()
+	default:
+		return fmt.Errorf("unsupported platform")
 	}
 }

--- a/pkg/cli/auth_internal_test.go
+++ b/pkg/cli/auth_internal_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestU2fCallbackServerDecodesData(t *testing.T) {
+	dataChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+	addr, srv, err := u2fCallbackServer(dataChan, errChan)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	payload := []byte(`{"id":"abc","response":{"signature":"x"}}`)
+	encoded := base64.StdEncoding.EncodeToString(payload)
+
+	res, err := http.Get(addr + "/?data=" + url.QueryEscape(encoded))
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	select {
+	case got := <-dataChan:
+		require.Equal(t, payload, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback data")
+	}
+}
+
+func TestU2fCallbackServerHandlesPlusInBase64(t *testing.T) {
+	dataChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+	addr, srv, err := u2fCallbackServer(dataChan, errChan)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	payload := append([]byte{0xfb, 0xff, 0xfe}, []byte(`{"id":"abc"}`)...)
+	encoded := base64.StdEncoding.EncodeToString(payload)
+	require.Contains(t, encoded, "+", "test payload must produce a '+' in standard base64")
+
+	// the console redirects to ...?data=<base64> without url-escaping, so the '+' arrives raw
+	res, err := http.Get(addr + "/?data=" + encoded)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	select {
+	case got := <-dataChan:
+		require.Equal(t, payload, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback data")
+	}
+}
+
+func TestU2fCallbackServerSecondCallbackDoesNotBlock(t *testing.T) {
+	dataChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+	addr, srv, err := u2fCallbackServer(dataChan, errChan)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	get := func(payload string) int {
+		enc := base64.StdEncoding.EncodeToString([]byte(payload))
+		res, err := http.Get(addr + "/?data=" + url.QueryEscape(enc))
+		require.NoError(t, err)
+		defer res.Body.Close()
+		return res.StatusCode
+	}
+
+	require.Equal(t, http.StatusOK, get("first"))
+	require.Equal(t, http.StatusOK, get("second"))
+
+	select {
+	case got := <-dataChan:
+		require.Contains(t, [][]byte{[]byte("first"), []byte("second")}, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a buffered callback value")
+	}
+
+	require.Len(t, errChan, 0)
+}
+
+func TestU2fCallbackServerRejectsMissingData(t *testing.T) {
+	dataChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+	addr, srv, err := u2fCallbackServer(dataChan, errChan)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	res, err := http.Get(addr + "/")
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Passkey Browser Authentication for the CLI**

The CLI now completes two-factor console authentication through your browser. When a session token challenge is issued, the CLI opens the console's login page in your default browser, where the WebAuthn ceremony runs with whatever authenticator you use: a passkey (Touch ID, Windows Hello, or a synced passkey) or a USB security key. The signed assertion is returned to the CLI over a short-lived local callback and the command proceeds.

The direct USB security key path remains available behind an environment variable:

| Variable | Values | Default | Effect |
|----------|--------|---------|--------|
| `CONVOX_WEB_U2F_DISABLE` | `true` / unset | unset | When `true`, skip the browser flow and authenticate directly against a physical USB security key (the previous behavior). Useful on headless machines with no browser. |

---

### How to use it?

Update your CLI, then use it as usual:

```
$ convox update
```

When a command requires the security token challenge, the CLI prints a link and opens your browser automatically. Complete the passkey or security key prompt in the browser, then return to the terminal; the CLI continues on its own. The browser must run on the same machine as the CLI, since the result is returned over a local callback. The browser step times out after 5 minutes.

On a headless machine, or to keep using a USB security key directly, set the variable in the environment of the commands you run:

```
$ export CONVOX_WEB_U2F_DISABLE=true
```

---

### Does it have a breaking change?

No breaking changes to commands or configuration. The default authentication flow changes from the direct USB key path to the browser flow, which supports USB security keys as well as passkeys. If you prefer the direct USB flow or work without a browser, set `CONVOX_WEB_U2F_DISABLE=true` to keep the previous behavior.

---

### Requirements

To use this feature, you must update your CLI to version `20260714094620` or newer.

- Check your CLI's version with `convox version`
- Update your CLI with `convox update`
