### PR TITLE
[RELEASE] 20260708102410

### DIFF
--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -2,10 +2,18 @@ package cli
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
 	"regexp"
+	"runtime"
+	"strings"
+	"time"
 
 	"github.com/convox/rack/pkg/token"
 	"github.com/convox/rack/sdk"
@@ -51,14 +59,22 @@ func authenticator(c *stdcli.Context) stdsdk.Authenticator {
 
 			c.Writef("Waiting for security token... ")
 
-			data, err := token.Authenticate(dres)
-			if err != nil {
-				return nil, AuthenticationError{err}
+			if os.Getenv("CONVOX_WEB_U2F_DISABLE") == "true" {
+				data, err := token.Authenticate(dres)
+				if err != nil {
+					return nil, AuthenticationError{err}
+				}
+				body = data
+			} else {
+				data, err := browserAuthenticate(c, cl, dres)
+				if err != nil {
+					return nil, AuthenticationError{err}
+				}
+				body = data
 			}
 
 			c.Writef("<ok>OK</ok>\n")
 
-			body = data
 			headers["Challenge"] = ares.Header.Get("Challenge")
 		}
 
@@ -93,5 +109,107 @@ func currentSession(c *stdcli.Context) sdk.SessionFunc {
 	return func(cl *sdk.Client) string {
 		sid, _ := c.SettingReadKey("session", cl.Endpoint.Host)
 		return sid
+	}
+}
+
+func browserAuthenticate(c *stdcli.Context, cl *stdsdk.Client, challenge []byte) ([]byte, error) {
+	target := url.URL{
+		Scheme: cl.Endpoint.Scheme,
+		Host:   cl.Endpoint.Host,
+		Path:   "/login/u2f",
+	}
+
+	dataChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+
+	addr, srv, err := u2fCallbackServer(dataChan, errChan)
+	if err != nil {
+		return nil, err
+	}
+	defer srv.Close()
+
+	q := target.Query()
+	q.Add("token", base64.StdEncoding.EncodeToString(challenge))
+	q.Add("callback_url", addr)
+	target.RawQuery = q.Encode()
+
+	c.Writef("\nOpen this link in your browser to complete authentication:\n%s\n", target.String())
+	c.Writef("(on a headless machine, set CONVOX_WEB_U2F_DISABLE=true to use a USB security key instead)\n")
+
+	if err := openBrowser(target.String()); err != nil {
+		c.Writef("Could not open a browser automatically; open the link above manually.\n")
+	}
+
+	timeout := time.NewTimer(5 * time.Minute)
+	defer timeout.Stop()
+
+	select {
+	case <-timeout.C:
+		return nil, fmt.Errorf("timed out waiting for browser authentication; set CONVOX_WEB_U2F_DISABLE=true to use a USB security key")
+	case err := <-errChan:
+		return nil, err
+	case data := <-dataChan:
+		return data, nil
+	}
+}
+
+func u2fCallbackServer(dataChan chan []byte, errChan chan error) (string, *http.Server, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to listen on port: %s", err)
+	}
+
+	addr := fmt.Sprintf("http://127.0.0.1:%d", listener.Addr().(*net.TCPAddr).Port)
+
+	srv := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			data := r.URL.Query().Get("data")
+			if data == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			// query parsing decodes '+' to a space; standard base64 never contains spaces
+			data = strings.ReplaceAll(data, " ", "+")
+
+			decoded, err := base64.StdEncoding.DecodeString(data)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "Authentication complete. You may close this window.")
+
+			select {
+			case dataChan <- decoded:
+			default:
+			}
+		}),
+	}
+
+	go func() {
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			select {
+			case errChan <- err:
+			default:
+			}
+		}
+	}()
+
+	return addr, srv, nil
+}
+
+func openBrowser(uri string) error {
+	switch runtime.GOOS {
+	case "linux":
+		return exec.Command("xdg-open", uri).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", uri).Start()
+	case "darwin":
+		return exec.Command("open", uri).Start()
+	default:
+		return fmt.Errorf("unsupported platform")
 	}
 }

--- a/pkg/cli/auth_internal_test.go
+++ b/pkg/cli/auth_internal_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestU2fCallbackServerDecodesData(t *testing.T) {
+	dataChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+	addr, srv, err := u2fCallbackServer(dataChan, errChan)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	payload := []byte(`{"id":"abc","response":{"signature":"x"}}`)
+	encoded := base64.StdEncoding.EncodeToString(payload)
+
+	res, err := http.Get(addr + "/?data=" + url.QueryEscape(encoded))
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	select {
+	case got := <-dataChan:
+		require.Equal(t, payload, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback data")
+	}
+}
+
+func TestU2fCallbackServerHandlesPlusInBase64(t *testing.T) {
+	dataChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+	addr, srv, err := u2fCallbackServer(dataChan, errChan)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	payload := append([]byte{0xfb, 0xff, 0xfe}, []byte(`{"id":"abc"}`)...)
+	encoded := base64.StdEncoding.EncodeToString(payload)
+	require.Contains(t, encoded, "+", "test payload must produce a '+' in standard base64")
+
+	// the console redirects to ...?data=<base64> without url-escaping, so the '+' arrives raw
+	res, err := http.Get(addr + "/?data=" + encoded)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	select {
+	case got := <-dataChan:
+		require.Equal(t, payload, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback data")
+	}
+}
+
+func TestU2fCallbackServerSecondCallbackDoesNotBlock(t *testing.T) {
+	dataChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+	addr, srv, err := u2fCallbackServer(dataChan, errChan)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	get := func(payload string) int {
+		enc := base64.StdEncoding.EncodeToString([]byte(payload))
+		res, err := http.Get(addr + "/?data=" + url.QueryEscape(enc))
+		require.NoError(t, err)
+		defer res.Body.Close()
+		return res.StatusCode
+	}
+
+	require.Equal(t, http.StatusOK, get("first"))
+	require.Equal(t, http.StatusOK, get("second"))
+
+	select {
+	case got := <-dataChan:
+		require.Contains(t, [][]byte{[]byte("first"), []byte("second")}, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a buffered callback value")
+	}
+
+	require.Len(t, errChan, 0)
+}
+
+func TestU2fCallbackServerRejectsMissingData(t *testing.T) {
+	dataChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+	addr, srv, err := u2fCallbackServer(dataChan, errChan)
+	require.NoError(t, err)
+	defer srv.Close()
+
+	res, err := http.Get(addr + "/")
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+}

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -838,11 +838,11 @@
       "AllowedValues": [ "standard", "unlimited", "" ]
     },
     "DefaultAmi": {
-      "Default": "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id",
+      "Default": "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
     },
     "DefaultAmiArm": {
-      "Default": "/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id",
+      "Default": "/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
     },
     "Development": {
@@ -2212,10 +2212,12 @@
               "  - echo '", { "Fn::GetAtt": [ "DockertTLSKey", "Value" ] }, "' | base64 -d > /etc/key.pem\n",
               "  - echo 'OPTIONS=\"--default-ulimit nofile=1024000:1024000 --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock --host=0.0.0.0:2376 --tls --tlscacert /etc/ca.pem --tlscert /etc/cert.pem --tlskey /etc/key.pem\"' >> /etc/sysconfig/docker\n",
               "  - echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"}' >> /etc/ecs/ecs.config\n",
-              "  - echo 'docker image prune -a --filter=\"until=", { "Ref": "PruneOlderImagesInHour" }, "h\" --force' > /etc/cron.", { "Ref": "PruneOlderImagesCronRunFreq" }, "/docker-prune\n",
-              "  - chmod +x /etc/cron.", { "Ref": "PruneOlderImagesCronRunFreq" }, "/docker-prune\n",
-              "  - echo 'docker builder prune -a --filter=\"until=", { "Ref": "PruneOlderImagesInHour" }, "h\" --force' > /etc/cron.", { "Ref": "PruneOlderImagesCronRunFreq" }, "/docker-builder-prune\n",
-              "  - chmod +x /etc/cron.", { "Ref": "PruneOlderImagesCronRunFreq" }, "/docker-builder-prune\n",
+              "  - printf '[Unit]\\nDescription=prune docker images\\nAfter=docker.service\\n[Service]\\nType=oneshot\\nExecStart=/usr/bin/docker image prune -a --filter until=", { "Ref": "PruneOlderImagesInHour" }, "h --force\\n' > /etc/systemd/system/docker-prune.service\n",
+              "  - printf '[Unit]\\nDescription=prune docker images\\n[Timer]\\nOnCalendar=", { "Ref": "PruneOlderImagesCronRunFreq" }, "\\nPersistent=true\\n[Install]\\nWantedBy=timers.target\\n' > /etc/systemd/system/docker-prune.timer\n",
+              "  - printf '[Unit]\\nDescription=prune docker builder cache\\nAfter=docker.service\\n[Service]\\nType=oneshot\\nExecStart=/usr/bin/docker builder prune -a --filter until=", { "Ref": "PruneOlderImagesInHour" }, "h --force\\n' > /etc/systemd/system/docker-builder-prune.service\n",
+              "  - printf '[Unit]\\nDescription=prune docker builder cache\\n[Timer]\\nOnCalendar=", { "Ref": "PruneOlderImagesCronRunFreq" }, "\\nPersistent=true\\n[Install]\\nWantedBy=timers.target\\n' > /etc/systemd/system/docker-builder-prune.timer\n",
+              "  - systemctl daemon-reload\n",
+              "  - systemctl enable --now docker-prune.timer docker-builder-prune.timer\n",
               { "Fn::If": [ "HttpProxy",
                 { "Fn::Join": ["", ["  - echo \"export HTTP_PROXY=", { "Ref": "HttpProxy" }, "/\" >> /etc/sysconfig/docker\n"
                 ] ] },
@@ -2461,8 +2463,10 @@
               "  - echo '", { "Fn::GetAtt": [ "DockertTLSKey", "Value" ] }, "' | base64 -d > /etc/key.pem\n",
               "  - echo 'OPTIONS=\"--default-ulimit nofile=1024000:1024000 --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock --host=0.0.0.0:2376 --tls --tlscacert /etc/ca.pem --tlscert /etc/cert.pem --tlskey /etc/key.pem\"' >> /etc/sysconfig/docker\n",
               "  - echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"}' >> /etc/ecs/ecs.config\n",
-              "  - echo 'docker image prune -a --filter=\"until=", { "Ref": "PruneOlderImagesInHour" }, "h\" --force' > /etc/cron.", { "Ref": "PruneOlderImagesCronRunFreq" }, "/docker-prune\n",
-              "  - chmod +x /etc/cron.", { "Ref": "PruneOlderImagesCronRunFreq" }, "/docker-prune\n",
+              "  - printf '[Unit]\\nDescription=prune docker images\\nAfter=docker.service\\n[Service]\\nType=oneshot\\nExecStart=/usr/bin/docker image prune -a --filter until=", { "Ref": "PruneOlderImagesInHour" }, "h --force\\n' > /etc/systemd/system/docker-prune.service\n",
+              "  - printf '[Unit]\\nDescription=prune docker images\\n[Timer]\\nOnCalendar=", { "Ref": "PruneOlderImagesCronRunFreq" }, "\\nPersistent=true\\n[Install]\\nWantedBy=timers.target\\n' > /etc/systemd/system/docker-prune.timer\n",
+              "  - systemctl daemon-reload\n",
+              "  - systemctl enable --now docker-prune.timer\n",
               { "Fn::If": [ "HttpProxy",
                 { "Fn::Join": ["", ["  - echo \"export HTTP_PROXY=", { "Ref": "HttpProxy" }, "/\" >> /etc/sysconfig/docker\n"
                 ] ] },
@@ -3028,8 +3032,10 @@
               "  - echo '", { "Fn::GetAtt": [ "DockertTLSKey", "Value" ] }, "' | base64 -d > /etc/key.pem\n",
               "  - echo 'OPTIONS=\"--default-ulimit nofile=1024000:1024000 --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock --host=0.0.0.0:2376 --tls --tlscacert /etc/ca.pem --tlscert /etc/cert.pem --tlskey /etc/key.pem\"' >> /etc/sysconfig/docker\n",
               "  - echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"}' >> /etc/ecs/ecs.config\n",
-              "  - echo 'docker image prune -a --filter=\"until=", { "Ref": "PruneOlderImagesInHour" }, "h\" --force' > /etc/cron.", { "Ref": "PruneOlderImagesCronRunFreq" }, "/docker-prune\n",
-              "  - chmod +x /etc/cron.", { "Ref": "PruneOlderImagesCronRunFreq" }, "/docker-prune\n",
+              "  - printf '[Unit]\\nDescription=prune docker images\\nAfter=docker.service\\n[Service]\\nType=oneshot\\nExecStart=/usr/bin/docker image prune -a --filter until=", { "Ref": "PruneOlderImagesInHour" }, "h --force\\n' > /etc/systemd/system/docker-prune.service\n",
+              "  - printf '[Unit]\\nDescription=prune docker images\\n[Timer]\\nOnCalendar=", { "Ref": "PruneOlderImagesCronRunFreq" }, "\\nPersistent=true\\n[Install]\\nWantedBy=timers.target\\n' > /etc/systemd/system/docker-prune.timer\n",
+              "  - systemctl daemon-reload\n",
+              "  - systemctl enable --now docker-prune.timer\n",
               { "Fn::If": [ "HttpProxy",
                 { "Fn::Join": ["", ["  - echo \"export HTTP_PROXY=", { "Ref": "HttpProxy" }, "/\" >> /etc/sysconfig/docker\n"
                 ] ] },
@@ -3390,8 +3396,10 @@
               "  - echo '", { "Fn::GetAtt": [ "DockertTLSKey", "Value" ] }, "' | base64 -d > /etc/key.pem\n",
               "  - echo 'OPTIONS=\"--default-ulimit nofile=1024000:1024000 --log-opt max-file=2 --log-opt max-size=50m --host=unix:///var/run/docker.sock --host=0.0.0.0:2376 --tls --tlscacert /etc/ca.pem --tlscert /etc/cert.pem --tlskey /etc/key.pem\"' >> /etc/sysconfig/docker\n",
               "  - echo 'ECS_ENGINE_AUTH_DATA={\"index.docker.io\":{\"username\":\"\",\"password\":\"\",\"email\":\"\"}' >> /etc/ecs/ecs.config\n",
-              "  - echo 'docker image prune -a --filter=\"until=", { "Ref": "PruneOlderImagesInHour" }, "h\" --force' > /etc/cron.", { "Ref": "PruneOlderImagesCronRunFreq" }, "/docker-prune\n",
-              "  - chmod +x /etc/cron.", { "Ref": "PruneOlderImagesCronRunFreq" }, "/docker-prune\n",
+              "  - printf '[Unit]\\nDescription=prune docker images\\nAfter=docker.service\\n[Service]\\nType=oneshot\\nExecStart=/usr/bin/docker image prune -a --filter until=", { "Ref": "PruneOlderImagesInHour" }, "h --force\\n' > /etc/systemd/system/docker-prune.service\n",
+              "  - printf '[Unit]\\nDescription=prune docker images\\n[Timer]\\nOnCalendar=", { "Ref": "PruneOlderImagesCronRunFreq" }, "\\nPersistent=true\\n[Install]\\nWantedBy=timers.target\\n' > /etc/systemd/system/docker-prune.timer\n",
+              "  - systemctl daemon-reload\n",
+              "  - systemctl enable --now docker-prune.timer\n",
               { "Fn::If": [ "HttpProxy",
                 { "Fn::Join": ["", ["  - echo \"export HTTP_PROXY=", { "Ref": "HttpProxy" }, "/\" >> /etc/sysconfig/docker\n"
                 ] ] },

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -1247,6 +1247,54 @@ func (p *Provider) taskDefinitionRelease(arn string) (string, error) {
 	return *release, nil
 }
 
+var retiredAmiPaths = map[string]struct{ old, new string }{
+	"DefaultAmi": {
+		old: "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id",
+		new: "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id",
+	},
+	"DefaultAmiArm": {
+		old: "/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id",
+		new: "/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id",
+	},
+}
+
+// migratedAmiPath returns the replacement SSM path for an AMI parameter still
+// set to a retired Amazon Linux 2 default
+func migratedAmiPath(param, current string) (string, bool) {
+	m, ok := retiredAmiPaths[param]
+	if !ok || current != m.old {
+		return "", false
+	}
+
+	return m.new, true
+}
+
+// isNoUpdatesError reports whether err is CloudFormation rejecting an update
+// that changes no resources
+func isNoUpdatesError(err error) bool {
+	if ae, ok := err.(awserr.Error); ok {
+		return ae.Code() == "ValidationError" && strings.Contains(ae.Message(), "No updates are to be performed")
+	}
+
+	return false
+}
+
+// rackHasRetiredAmi reports whether the rack stack still holds a retired AMI path
+func (p *Provider) rackHasRetiredAmi() (bool, error) {
+	stack, err := p.describeStack(p.Rack)
+	if err != nil {
+		return false, err
+	}
+
+	for _, param := range stack.Parameters {
+		if _, ok := migratedAmiPath(aws.StringValue(param.ParameterKey), aws.StringValue(param.ParameterValue)); ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // updateStack updates a stack
 //
 //	template is url to a template or empty string to reuse previous
@@ -1267,6 +1315,7 @@ func (p *Provider) updateStack(name string, template []byte, changes map[string]
 
 	params := map[string]bool{}
 	pexisting := map[string]bool{}
+	pvalues := map[string]string{}
 
 	stack, err := p.describeStack(name)
 	if err != nil {
@@ -1275,6 +1324,7 @@ func (p *Provider) updateStack(name string, template []byte, changes map[string]
 
 	for _, p := range stack.Parameters {
 		pexisting[*p.ParameterKey] = true
+		pvalues[*p.ParameterKey] = aws.StringValue(p.ParameterValue)
 	}
 
 	if template != nil {
@@ -1323,6 +1373,11 @@ func (p *Provider) updateStack(name string, template []byte, changes map[string]
 
 	for _, param := range sorted {
 		if value, ok := changes[param]; ok {
+			req.Parameters = append(req.Parameters, &cloudformation.Parameter{
+				ParameterKey:   aws.String(param),
+				ParameterValue: aws.String(value),
+			})
+		} else if value, ok := migratedAmiPath(param, pvalues[param]); ok {
 			req.Parameters = append(req.Parameters, &cloudformation.Parameter{
 				ParameterKey:   aws.String(param),
 				ParameterValue: aws.String(value),

--- a/provider/aws/helpers_ami_test.go
+++ b/provider/aws/helpers_ami_test.go
@@ -1,0 +1,241 @@
+package aws
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/convox/rack/pkg/test/awsutil"
+)
+
+func TestMigratedAmiPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		param   string
+		current string
+		want    string
+		wantOk  bool
+	}{
+		{
+			name:    "DefaultAmi on retired al2 path",
+			param:   "DefaultAmi",
+			current: "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id",
+			want:    "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id",
+			wantOk:  true,
+		},
+		{
+			name:    "DefaultAmiArm on retired al2 path",
+			param:   "DefaultAmiArm",
+			current: "/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id",
+			want:    "/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id",
+			wantOk:  true,
+		},
+		{
+			name:    "DefaultAmi with custom path",
+			param:   "DefaultAmi",
+			current: "/custom/ami/path",
+			wantOk:  false,
+		},
+		{
+			name:    "DefaultAmi already migrated",
+			param:   "DefaultAmi",
+			current: "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id",
+			wantOk:  false,
+		},
+		{
+			name:    "DefaultAmi with arm path does not cross match",
+			param:   "DefaultAmi",
+			current: "/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id",
+			wantOk:  false,
+		},
+		{
+			name:    "unrelated parameter",
+			param:   "InstanceType",
+			current: "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id",
+			wantOk:  false,
+		},
+		{
+			name:    "DefaultAmi empty value",
+			param:   "DefaultAmi",
+			current: "",
+			wantOk:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := migratedAmiPath(tt.param, tt.current)
+			if ok != tt.wantOk || got != tt.want {
+				t.Fatalf("migratedAmiPath(%q, %q) = (%q, %v), want (%q, %v)", tt.param, tt.current, got, ok, tt.want, tt.wantOk)
+			}
+		})
+	}
+}
+
+func stubRackDescribeStacks(t *testing.T, params string) *Provider {
+	handler := awsutil.NewHandler([]awsutil.Cycle{
+		{
+			Request: awsutil.Request{
+				RequestURI: "/",
+				Body:       `Action=DescribeStacks&StackName=convox&Version=2010-05-15`,
+			},
+			Response: awsutil.Response{
+				StatusCode: 200,
+				Body: fmt.Sprintf(`<DescribeStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+					<DescribeStacksResult>
+						<Stacks>
+							<member>
+								<StackId>arn:aws:cloudformation:us-east-1:778743527532:stack/convox/eb743e00-7d8e-11e5-8280-50ba0727c06e</StackId>
+								<StackName>convox</StackName>
+								<StackStatus>UPDATE_COMPLETE</StackStatus>
+								<CreationTime>2015-10-28T16:14:09.590Z</CreationTime>
+								<Parameters>%s</Parameters>
+							</member>
+						</Stacks>
+					</DescribeStacksResult>
+				</DescribeStacksResponse>`, params),
+			},
+		},
+	})
+
+	s := httptest.NewServer(handler)
+	t.Cleanup(s.Close)
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+
+	return &Provider{
+		Region:    "us-test-1",
+		Endpoint:  s.URL,
+		Rack:      "convox",
+		SkipCache: true,
+	}
+}
+
+func TestRackHasRetiredAmi(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		want   bool
+	}{
+		{
+			name: "retired al2 path present",
+			params: `<member><ParameterKey>DefaultAmi</ParameterKey><ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id</ParameterValue></member>
+				<member><ParameterKey>DefaultAmiArm</ParameterKey><ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id</ParameterValue></member>`,
+			want: true,
+		},
+		{
+			name: "already migrated",
+			params: `<member><ParameterKey>DefaultAmi</ParameterKey><ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id</ParameterValue></member>
+				<member><ParameterKey>DefaultAmiArm</ParameterKey><ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id</ParameterValue></member>`,
+			want: false,
+		},
+		{
+			name:   "no ami parameters",
+			params: `<member><ParameterKey>InstanceType</ParameterKey><ParameterValue>t2.small</ParameterValue></member>`,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := stubRackDescribeStacks(t, tt.params)
+			got, err := p.rackHasRetiredAmi()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("rackHasRetiredAmi() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRackHasRetiredAmiDescribeError(t *testing.T) {
+	handler := awsutil.NewHandler([]awsutil.Cycle{})
+	s := httptest.NewServer(handler)
+	t.Cleanup(s.Close)
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+
+	p := &Provider{Region: "us-test-1", Endpoint: s.URL, Rack: "convox", SkipCache: true}
+
+	if _, err := p.rackHasRetiredAmi(); err == nil {
+		t.Fatal("rackHasRetiredAmi() should return an error when the stack cannot be described")
+	}
+}
+
+func TestIsNoUpdatesError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "cloudformation no updates validation error",
+			err:  awserr.New("ValidationError", "No updates are to be performed.", nil),
+			want: true,
+		},
+		{
+			name: "other validation error",
+			err:  awserr.New("ValidationError", "Parameter validation failed", nil),
+			want: false,
+		},
+		{
+			name: "no updates message with different code",
+			err:  awserr.New("Throttling", "No updates are to be performed.", nil),
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("No updates are to be performed."),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNoUpdatesError(tt.err); got != tt.want {
+				t.Fatalf("isNoUpdatesError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormationAmiDefaultsMatchMigrationTargets(t *testing.T) {
+	data, err := os.ReadFile("formation/rack.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var formation struct {
+		Parameters map[string]struct {
+			Default interface{} `json:"Default"`
+		} `json:"Parameters"`
+	}
+
+	if err := json.Unmarshal(data, &formation); err != nil {
+		t.Fatal(err)
+	}
+
+	for param, m := range retiredAmiPaths {
+		fp, ok := formation.Parameters[param]
+		if !ok {
+			t.Fatalf("parameter %s not found in formation/rack.json", param)
+		}
+
+		if fp.Default != m.new {
+			t.Errorf("parameter %s default is %q, want %q", param, fp.Default, m.new)
+		}
+	}
+}

--- a/provider/aws/lambda/formation/handler/certificate.go
+++ b/provider/aws/lambda/formation/handler/certificate.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
@@ -104,16 +105,6 @@ func CreateSelfSignedCertsForDocker(req Request) (string, map[string]string, err
 		return "", nil, err
 	}
 
-	_, err = ssmClient.PutParameter(&ssm.PutParameterInput{
-		Name:      aws.String(versionParameterName(rackKey)),
-		Overwrite: aws.Bool(true),
-		Value:     aws.String(req.ResourceProperties["Version"].(string)),
-		Type:      aws.String(ssm.ParameterTypeString),
-	})
-	if err != nil {
-		return "", nil, err
-	}
-
 	return rackKey, map[string]string{
 		"CACertSSMKey": caCertParameterName(rackKey),
 		"CAKeySSMKey":  caKeyParameterName(rackKey),
@@ -166,26 +157,20 @@ func UpdateSelfSignedCertsForDocker(req Request) (string, map[string]string, err
 	rackKey := rackHash(req.ResourceProperties["Rack"].(string))
 	ssmClient := SSM(req)
 	param, err := ssmClient.GetParameter(&ssm.GetParameterInput{
-		Name: aws.String(versionParameterName(rackKey)),
+		Name: aws.String(certParameterName(rackKey)),
 	})
-	if err != nil || param.Parameter == nil || param.Parameter.Value == nil ||
-		*param.Parameter.Value != req.ResourceProperties["Version"].(string) {
-		return CreateSelfSignedCertsForDocker(req)
-	}
-
-	pemBytes, err := base64.StdEncoding.DecodeString(*param.Parameter.Value)
 	if err != nil {
+		if isParameterNotFound(err) {
+			return CreateSelfSignedCertsForDocker(req)
+		}
+		return rackKey, nil, err
+	}
+
+	if param.Parameter == nil || param.Parameter.Value == nil {
 		return CreateSelfSignedCertsForDocker(req)
 	}
 
-	block, _ := pem.Decode(pemBytes)
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return CreateSelfSignedCertsForDocker(req)
-	}
-
-	// renew if cert expires in 2 months
-	if cert.NotAfter.Before(time.Now().Add(2 * 30 * 24 * time.Hour)) {
+	if shouldRegenerateCert(*param.Parameter.Value, time.Now()) {
 		return CreateSelfSignedCertsForDocker(req)
 	}
 
@@ -195,6 +180,34 @@ func UpdateSelfSignedCertsForDocker(req Request) (string, map[string]string, err
 		"CertSSMKey":   certParameterName(rackKey),
 		"KeySSMKey":    keyParameterName(rackKey),
 	}, nil
+}
+
+func isParameterNotFound(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok {
+		return aerr.Code() == ssm.ErrCodeParameterNotFound
+	}
+	return false
+}
+
+// shouldRegenerateCert reports whether the stored docker TLS cert is missing,
+// unreadable, or within two months of expiry and must be regenerated.
+func shouldRegenerateCert(b64cert string, now time.Time) bool {
+	pemBytes, err := base64.StdEncoding.DecodeString(b64cert)
+	if err != nil {
+		return true
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return true
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return true
+	}
+
+	return cert.NotAfter.Before(now.Add(2 * 30 * 24 * time.Hour))
 }
 
 func caCertParameterName(rack string) string {
@@ -211,10 +224,6 @@ func certParameterName(rack string) string {
 
 func keyParameterName(rack string) string {
 	return fmt.Sprintf("%s-docker-tls-key", rack)
-}
-
-func versionParameterName(rack string) string {
-	return fmt.Sprintf("%s-version-track", rack)
 }
 
 func generateSelfSignedCertsForDocker() (map[string]string, error) {

--- a/provider/aws/lambda/formation/handler/certificate_test.go
+++ b/provider/aws/lambda/formation/handler/certificate_test.go
@@ -1,0 +1,128 @@
+package handler
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+func parseCertParam(t *testing.T, b64pem string) *x509.Certificate {
+	t.Helper()
+	der, err := base64.StdEncoding.DecodeString(b64pem)
+	if err != nil {
+		t.Fatalf("base64 decode: %s", err)
+	}
+	block, _ := pem.Decode(der)
+	if block == nil {
+		t.Fatal("pem decode returned nil block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse certificate: %s", err)
+	}
+	return cert
+}
+
+func TestGenerateSelfSignedCertsForDockerChainsToCA(t *testing.T) {
+	certs, err := generateSelfSignedCertsForDocker()
+	if err != nil {
+		t.Fatalf("generate: %s", err)
+	}
+
+	ca := parseCertParam(t, certs["CACert"])
+	leaf := parseCertParam(t, certs["Cert"])
+
+	if !ca.IsCA {
+		t.Error("CA cert is not marked IsCA")
+	}
+
+	if err := leaf.CheckSignatureFrom(ca); err != nil {
+		t.Fatalf("leaf does not chain to CA: %s", err)
+	}
+
+	roots := x509.NewCertPool()
+	roots.AddCert(ca)
+	if _, err := leaf.Verify(x509.VerifyOptions{Roots: roots, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny}}); err != nil {
+		t.Fatalf("leaf verify against CA pool: %s", err)
+	}
+
+	if got := time.Until(leaf.NotAfter); got < 99*365*24*time.Hour {
+		t.Errorf("leaf validity too short: %s remaining", got)
+	}
+}
+
+func makeCertB64(t *testing.T, validFor time.Duration) string {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %s", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-2 * time.Hour),
+		NotAfter:     time.Now().Add(validFor),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create certificate: %s", err)
+	}
+	return base64.StdEncoding.EncodeToString(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func TestShouldRegenerateCert(t *testing.T) {
+	notPEM := base64.StdEncoding.EncodeToString([]byte("hello"))
+	pemNotCert := base64.StdEncoding.EncodeToString(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a certificate")}))
+
+	cases := []struct {
+		name string
+		cert string
+		want bool
+	}{
+		{"valid long-lived", makeCertB64(t, 100*365*24*time.Hour), false},
+		{"expiring within two months", makeCertB64(t, 30*24*time.Hour), true},
+		{"already expired", makeCertB64(t, -1*time.Hour), true},
+		{"not base64", "!!! not base64 !!!", true},
+		{"base64 but not PEM", notPEM, true},
+		{"PEM but not a certificate", pemNotCert, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldRegenerateCert(c.cert, time.Now()); got != c.want {
+				t.Errorf("shouldRegenerateCert(%q) = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsParameterNotFound(t *testing.T) {
+	if !isParameterNotFound(awserr.New(ssm.ErrCodeParameterNotFound, "not found", nil)) {
+		t.Error("ParameterNotFound should be detected")
+	}
+	if !isParameterNotFound(awserr.NewRequestFailure(awserr.New(ssm.ErrCodeParameterNotFound, "not found", nil), 400, "req-id")) {
+		t.Error("RequestFailure-wrapped ParameterNotFound should be detected")
+	}
+	if !isParameterNotFound(&ssm.ParameterNotFound{}) {
+		t.Error("typed *ssm.ParameterNotFound should be detected")
+	}
+	if isParameterNotFound(awserr.New("ThrottlingException", "slow down", nil)) {
+		t.Error("a transient aws error must not be treated as not-found")
+	}
+	if isParameterNotFound(errors.New("network blip")) {
+		t.Error("a non-aws error must not be treated as not-found")
+	}
+	if isParameterNotFound(nil) {
+		t.Error("nil error must not be treated as not-found")
+	}
+}

--- a/provider/aws/system.go
+++ b/provider/aws/system.go
@@ -749,6 +749,8 @@ func (p *Provider) SystemUpdate(opts structs.SystemUpdateOptions) error {
 		changes["version"] = *opts.Version
 	}
 
+	forcedMigration := false
+
 	// if there is a version update then record it
 	if v, ok := changes["version"]; ok {
 		if !hasOtherChange {
@@ -759,7 +761,16 @@ func (p *Provider) SystemUpdate(opts structs.SystemUpdateOptions) error {
 
 			// check rack already in that version or not
 			if rDetails.Version == v {
-				return nil
+				retired, err := p.rackHasRetiredAmi()
+				if err != nil {
+					return err
+				}
+
+				if !retired {
+					return nil
+				}
+
+				forcedMigration = true
 			}
 		}
 		_, err := p.dynamodb().PutItem(&dynamodb.PutItemInput{
@@ -785,6 +796,12 @@ func (p *Provider) SystemUpdate(opts structs.SystemUpdateOptions) error {
 	}
 
 	if err := p.updateStack(p.Rack, template, params, tags, ""); err != nil {
+		// a migration-forced update changes nothing on stacks whose AMI
+		// parameters are unused (custom Ami set)
+		if forcedMigration && isNoUpdatesError(err) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/provider/aws/system_ami_test.go
+++ b/provider/aws/system_ami_test.go
@@ -1,0 +1,396 @@
+package aws_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/convox/rack/pkg/options"
+	"github.com/convox/rack/pkg/structs"
+	"github.com/convox/rack/pkg/test/awsutil"
+	"github.com/convox/rack/provider/aws"
+	"github.com/stretchr/testify/assert"
+)
+
+func stubAwsProviderCounting(t *testing.T, calls *int32, cycles ...awsutil.Cycle) *aws.Provider {
+	handler := awsutil.NewHandler(cycles)
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(calls, 1)
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(s.Close)
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+
+	return &aws.Provider{
+		Region:         "us-test-1",
+		Endpoint:       s.URL,
+		Rack:           "convox",
+		DynamoReleases: "convox-releases",
+		SettingsBucket: "convox-settings",
+		SkipCache:      true,
+	}
+}
+
+func cycleDescribeStacksVersioned(version, amiParams string) awsutil.Cycle {
+	return awsutil.Cycle{
+		Request: awsutil.Request{
+			RequestURI: "/",
+			Body:       `Action=DescribeStacks&StackName=convox&Version=2010-05-15`,
+		},
+		Response: awsutil.Response{
+			StatusCode: 200,
+			Body: fmt.Sprintf(`<DescribeStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+				<DescribeStacksResult>
+					<Stacks>
+						<member>
+							<StackId>arn:aws:cloudformation:us-east-1:778743527532:stack/convox/eb743e00-7d8e-11e5-8280-50ba0727c06e</StackId>
+							<StackName>convox</StackName>
+							<StackStatus>UPDATE_IN_PROGRESS</StackStatus>
+							<CreationTime>2015-10-28T16:14:09.590Z</CreationTime>
+							<Parameters>
+								<member><ParameterKey>Version</ParameterKey><ParameterValue>%s</ParameterValue></member>
+								<member><ParameterKey>InstanceCount</ParameterKey><ParameterValue>3</ParameterValue></member>
+								<member><ParameterKey>InstanceType</ParameterKey><ParameterValue>t2.small</ParameterValue></member>
+								%s
+							</Parameters>
+						</member>
+					</Stacks>
+				</DescribeStacksResult>
+			</DescribeStacksResponse>`, version, amiParams),
+		},
+	}
+}
+
+const retiredAmiStackParams = `<member><ParameterKey>DefaultAmi</ParameterKey><ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id</ParameterValue></member>
+	<member><ParameterKey>DefaultAmiArm</ParameterKey><ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id</ParameterValue></member>`
+
+const migratedAmiStackParams = `<member><ParameterKey>DefaultAmi</ParameterKey><ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id</ParameterValue></member>
+	<member><ParameterKey>DefaultAmiArm</ParameterKey><ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id</ParameterValue></member>`
+
+const pinnedRetiredAmiStackParams = `<member><ParameterKey>Ami</ParameterKey><ParameterValue>ami-0123456789abcdef0</ParameterValue></member>
+	<member><ParameterKey>DefaultAmi</ParameterKey><ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id</ParameterValue></member>
+	<member><ParameterKey>DefaultAmiArm</ParameterKey><ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id</ParameterValue></member>`
+
+func TestSystemUpdateSameVersionRunsAmiMigration(t *testing.T) {
+	var calls int32
+
+	provider := stubAwsProviderCounting(t, &calls,
+		cycleDescribeStacksVersioned("20260530110127", retiredAmiStackParams),
+		cycleDescribeStacksVersioned("20260530110127", retiredAmiStackParams),
+		cycleSameVersionReleasePutItem,
+		cycleDescribeStacksVersioned("20260530110127", retiredAmiStackParams),
+		cycleSystemListStackResources,
+		cycleSystemTemplatePut,
+		cycleSameVersionUpdateStack,
+		cycleSameVersionNotificationPublish,
+	)
+
+	err := provider.SystemUpdate(structs.SystemUpdateOptions{
+		Version: options.String("20260530110127"),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, int32(8), atomic.LoadInt32(&calls))
+}
+
+func TestSystemUpdateSameVersionNoopWhenMigrated(t *testing.T) {
+	var calls int32
+
+	provider := stubAwsProviderCounting(t, &calls,
+		cycleDescribeStacksVersioned("20260530110127", migratedAmiStackParams),
+		cycleDescribeStacksVersioned("20260530110127", migratedAmiStackParams),
+	)
+
+	err := provider.SystemUpdate(structs.SystemUpdateOptions{
+		Version: options.String("20260530110127"),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestSystemUpdateSameVersionPinnedAmiNoUpdatesTolerated(t *testing.T) {
+	var calls int32
+
+	provider := stubAwsProviderCounting(t, &calls,
+		cycleDescribeStacksVersioned("20260530110127", pinnedRetiredAmiStackParams),
+		cycleDescribeStacksVersioned("20260530110127", pinnedRetiredAmiStackParams),
+		cycleSameVersionReleasePutItem,
+		cycleDescribeStacksVersioned("20260530110127", pinnedRetiredAmiStackParams),
+		cycleSystemListStackResources,
+		cycleSystemTemplatePut,
+		cyclePinnedAmiUpdateStackNoUpdates,
+	)
+
+	err := provider.SystemUpdate(structs.SystemUpdateOptions{
+		Version: options.String("20260530110127"),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, int32(7), atomic.LoadInt32(&calls))
+}
+
+func TestSystemUpdateSameVersionRealUpdateErrorPropagates(t *testing.T) {
+	var calls int32
+
+	provider := stubAwsProviderCounting(t, &calls,
+		cycleDescribeStacksVersioned("20260530110127", retiredAmiStackParams),
+		cycleDescribeStacksVersioned("20260530110127", retiredAmiStackParams),
+		cycleSameVersionReleasePutItem,
+		cycleDescribeStacksVersioned("20260530110127", retiredAmiStackParams),
+		cycleSystemListStackResources,
+		cycleSystemTemplatePut,
+		cycleSameVersionUpdateStackInProgress,
+	)
+
+	err := provider.SystemUpdate(structs.SystemUpdateOptions{
+		Version: options.String("20260530110127"),
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "UPDATE_IN_PROGRESS")
+	assert.Equal(t, int32(7), atomic.LoadInt32(&calls))
+}
+
+var cycleSameVersionReleasePutItem = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Operation:  "DynamoDB_20120810.PutItem",
+		Body:       `{"Item":{"app":{"S":"convox"},"created":{"S":"00010101.000000.000000000"},"id":{"S":"20260530110127"}},"TableName":"convox-releases"}`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body:       `{}`,
+	},
+}
+
+var cycleSameVersionUpdateStack = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Body:       `Action=UpdateStack&Capabilities.member.1=CAPABILITY_IAM&NotificationARNs.member.1=&Parameters.member.1.ParameterKey=AvailabilityZones&Parameters.member.1.ParameterValue=&Parameters.member.2.ParameterKey=DefaultAmi&Parameters.member.2.ParameterValue=%2Faws%2Fservice%2Fecs%2Foptimized-ami%2Famazon-linux-2023%2Frecommended%2Fimage_id&Parameters.member.3.ParameterKey=DefaultAmiArm&Parameters.member.3.ParameterValue=%2Faws%2Fservice%2Fecs%2Foptimized-ami%2Famazon-linux-2023%2Farm64%2Frecommended%2Fimage_id&Parameters.member.4.ParameterKey=InstanceCount&Parameters.member.4.UsePreviousValue=true&Parameters.member.5.ParameterKey=InstanceType&Parameters.member.5.UsePreviousValue=true&Parameters.member.6.ParameterKey=Version&Parameters.member.6.ParameterValue=20260530110127&StackName=convox&Tags.member.1.Key=System&Tags.member.1.Value=convox&Tags.member.2.Key=Type&Tags.member.2.Value=rack&TemplateURL=https%3A%2F%2Fs3.us-test-1.amazonaws.com%2Fconvox-settings%2Ftest-key&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `
+			<UpdateStackResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+				<UpdateStackResult>
+					<StackId>arn:aws:cloudformation:us-east-1:901416387788:stack/convox/9a10bbe0-51d5-11e5-b85a-5001dc3ed8d2</StackId>
+				</UpdateStackResult>
+				<ResponseMetadata>
+					<RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
+				</ResponseMetadata>
+			</UpdateStackResponse>
+		`,
+	},
+}
+
+var cycleSameVersionUpdateStackInProgress = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Body:       `Action=UpdateStack&Capabilities.member.1=CAPABILITY_IAM&NotificationARNs.member.1=&Parameters.member.1.ParameterKey=AvailabilityZones&Parameters.member.1.ParameterValue=&Parameters.member.2.ParameterKey=DefaultAmi&Parameters.member.2.ParameterValue=%2Faws%2Fservice%2Fecs%2Foptimized-ami%2Famazon-linux-2023%2Frecommended%2Fimage_id&Parameters.member.3.ParameterKey=DefaultAmiArm&Parameters.member.3.ParameterValue=%2Faws%2Fservice%2Fecs%2Foptimized-ami%2Famazon-linux-2023%2Farm64%2Frecommended%2Fimage_id&Parameters.member.4.ParameterKey=InstanceCount&Parameters.member.4.UsePreviousValue=true&Parameters.member.5.ParameterKey=InstanceType&Parameters.member.5.UsePreviousValue=true&Parameters.member.6.ParameterKey=Version&Parameters.member.6.ParameterValue=20260530110127&StackName=convox&Tags.member.1.Key=System&Tags.member.1.Value=convox&Tags.member.2.Key=Type&Tags.member.2.Value=rack&TemplateURL=https%3A%2F%2Fs3.us-test-1.amazonaws.com%2Fconvox-settings%2Ftest-key&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 400,
+		Body: `
+			<ErrorResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+				<Error>
+					<Type>Sender</Type>
+					<Code>ValidationError</Code>
+					<Message>Stack:arn:aws:cloudformation:us-east-1:778743527532:stack/convox/eb743e00 is in UPDATE_IN_PROGRESS state and can not be updated.</Message>
+				</Error>
+				<RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
+			</ErrorResponse>
+		`,
+	},
+}
+
+var cyclePinnedAmiUpdateStackNoUpdates = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Body:       `Action=UpdateStack&Capabilities.member.1=CAPABILITY_IAM&NotificationARNs.member.1=&Parameters.member.1.ParameterKey=Ami&Parameters.member.1.UsePreviousValue=true&Parameters.member.2.ParameterKey=AvailabilityZones&Parameters.member.2.ParameterValue=&Parameters.member.3.ParameterKey=DefaultAmi&Parameters.member.3.ParameterValue=%2Faws%2Fservice%2Fecs%2Foptimized-ami%2Famazon-linux-2023%2Frecommended%2Fimage_id&Parameters.member.4.ParameterKey=DefaultAmiArm&Parameters.member.4.ParameterValue=%2Faws%2Fservice%2Fecs%2Foptimized-ami%2Famazon-linux-2023%2Farm64%2Frecommended%2Fimage_id&Parameters.member.5.ParameterKey=InstanceCount&Parameters.member.5.UsePreviousValue=true&Parameters.member.6.ParameterKey=InstanceType&Parameters.member.6.UsePreviousValue=true&Parameters.member.7.ParameterKey=Version&Parameters.member.7.ParameterValue=20260530110127&StackName=convox&Tags.member.1.Key=System&Tags.member.1.Value=convox&Tags.member.2.Key=Type&Tags.member.2.Value=rack&TemplateURL=https%3A%2F%2Fs3.us-test-1.amazonaws.com%2Fconvox-settings%2Ftest-key&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 400,
+		Body: `
+			<ErrorResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+				<Error>
+					<Type>Sender</Type>
+					<Code>ValidationError</Code>
+					<Message>No updates are to be performed.</Message>
+				</Error>
+				<RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
+			</ErrorResponse>
+		`,
+	},
+}
+
+var cycleSameVersionNotificationPublish = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Body:       `Action=Publish&Message=%7B%22action%22%3A%22rack%3Aupdate%22%2C%22data%22%3A%7B%22rack%22%3A%22convox%22%2C%22version%22%3A%2220260530110127%22%7D%2C%22status%22%3A%22success%22%2C%22timestamp%22%3A%220001-01-01T00%3A00%3A00Z%22%7D&Subject=rack%3Aupdate&TargetArn=&Version=2010-03-31`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `
+			<PublishResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+				<PublishResult>
+					<MessageId>94f20ce6-13c5-43a0-9a9e-ca52d816e90b</MessageId>
+				</PublishResult>
+				<ResponseMetadata>
+					<RequestId>f187a3c1-376f-11df-8963-01868b7c937a</RequestId>
+				</ResponseMetadata>
+			</PublishResponse>
+		`,
+	},
+}
+
+func TestSystemUpdateMigratesRetiredAmiPaths(t *testing.T) {
+	provider := StubAwsProvider(
+		cycleSystemDescribeStacksRetiredAmi,
+		cycleSystemUpdateStackMigratedAmi,
+		cycleSystemUpdateParamsNotificationPublish,
+	)
+	defer provider.Close()
+
+	err := provider.SystemUpdate(structs.SystemUpdateOptions{
+		Parameters: map[string]string{"ApiCpu": "256"},
+	})
+
+	assert.NoError(t, err)
+}
+
+func TestSystemUpdateExplicitAmiParamWinsOverMigration(t *testing.T) {
+	provider := StubAwsProvider(
+		cycleSystemDescribeStacksRetiredAmi,
+		cycleSystemUpdateStackExplicitAmi,
+		cycleSystemUpdateParamsNotificationPublish,
+	)
+	defer provider.Close()
+
+	err := provider.SystemUpdate(structs.SystemUpdateOptions{
+		Parameters: map[string]string{"DefaultAmi": "/custom/ami/path"},
+	})
+
+	assert.NoError(t, err)
+}
+
+var cycleSystemDescribeStacksRetiredAmi = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Body:       `Action=DescribeStacks&StackName=convox&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `<DescribeStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+			<DescribeStacksResult>
+				<Stacks>
+					<member>
+						<Outputs>
+						</Outputs>
+						<Capabilities>
+							<member>CAPABILITY_IAM</member>
+						</Capabilities>
+						<CreationTime>2015-10-28T16:14:09.590Z</CreationTime>
+						<NotificationARNs/>
+						<StackId>arn:aws:cloudformation:us-east-1:778743527532:stack/convox/eb743e00-7d8e-11e5-8280-50ba0727c06e</StackId>
+						<StackName>convox</StackName>
+						<StackStatus>UPDATE_COMPLETE</StackStatus>
+						<DisableRollback>false</DisableRollback>
+						<Tags/>
+						<LastUpdatedTime>2016-08-27T16:29:05.963Z</LastUpdatedTime>
+						<Parameters>
+							<member>
+								<ParameterKey>Ami</ParameterKey>
+								<ParameterValue/>
+							</member>
+							<member>
+								<ParameterKey>ApiCpu</ParameterKey>
+								<ParameterValue>128</ParameterValue>
+							</member>
+							<member>
+								<ParameterKey>DefaultAmi</ParameterKey>
+								<ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id</ParameterValue>
+							</member>
+							<member>
+								<ParameterKey>DefaultAmiArm</ParameterKey>
+								<ParameterValue>/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id</ParameterValue>
+							</member>
+							<member>
+								<ParameterKey>InstanceType</ParameterKey>
+								<ParameterValue>t2.small</ParameterValue>
+							</member>
+						</Parameters>
+					</member>
+				</Stacks>
+			</DescribeStacksResult>
+			<ResponseMetadata>
+				<RequestId>9715cab7-6c75-11e6-837d-ebe72becd936</RequestId>
+			</ResponseMetadata>
+		</DescribeStacksResponse>`,
+	},
+}
+
+var cycleSystemUpdateStackMigratedAmi = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Body:       `Action=UpdateStack&Capabilities.member.1=CAPABILITY_IAM&NotificationARNs.member.1=&Parameters.member.1.ParameterKey=Ami&Parameters.member.1.UsePreviousValue=true&Parameters.member.2.ParameterKey=ApiCpu&Parameters.member.2.ParameterValue=256&Parameters.member.3.ParameterKey=DefaultAmi&Parameters.member.3.ParameterValue=%2Faws%2Fservice%2Fecs%2Foptimized-ami%2Famazon-linux-2023%2Frecommended%2Fimage_id&Parameters.member.4.ParameterKey=DefaultAmiArm&Parameters.member.4.ParameterValue=%2Faws%2Fservice%2Fecs%2Foptimized-ami%2Famazon-linux-2023%2Farm64%2Frecommended%2Fimage_id&Parameters.member.5.ParameterKey=InstanceType&Parameters.member.5.UsePreviousValue=true&StackName=convox&Tags.member.1.Key=System&Tags.member.1.Value=convox&Tags.member.2.Key=Type&Tags.member.2.Value=rack&UsePreviousTemplate=true&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `
+			<UpdateStackResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+				<UpdateStackResult>
+					<StackId>arn:aws:cloudformation:us-east-1:901416387788:stack/convox/9a10bbe0-51d5-11e5-b85a-5001dc3ed8d2</StackId>
+				</UpdateStackResult>
+				<ResponseMetadata>
+					<RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
+				</ResponseMetadata>
+			</UpdateStackResponse>
+		`,
+	},
+}
+
+var cycleSystemUpdateStackExplicitAmi = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Body:       `Action=UpdateStack&Capabilities.member.1=CAPABILITY_IAM&NotificationARNs.member.1=&Parameters.member.1.ParameterKey=Ami&Parameters.member.1.UsePreviousValue=true&Parameters.member.2.ParameterKey=ApiCpu&Parameters.member.2.UsePreviousValue=true&Parameters.member.3.ParameterKey=DefaultAmi&Parameters.member.3.ParameterValue=%2Fcustom%2Fami%2Fpath&Parameters.member.4.ParameterKey=DefaultAmiArm&Parameters.member.4.ParameterValue=%2Faws%2Fservice%2Fecs%2Foptimized-ami%2Famazon-linux-2023%2Farm64%2Frecommended%2Fimage_id&Parameters.member.5.ParameterKey=InstanceType&Parameters.member.5.UsePreviousValue=true&StackName=convox&Tags.member.1.Key=System&Tags.member.1.Value=convox&Tags.member.2.Key=Type&Tags.member.2.Value=rack&UsePreviousTemplate=true&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `
+			<UpdateStackResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+				<UpdateStackResult>
+					<StackId>arn:aws:cloudformation:us-east-1:901416387788:stack/convox/9a10bbe0-51d5-11e5-b85a-5001dc3ed8d2</StackId>
+				</UpdateStackResult>
+				<ResponseMetadata>
+					<RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
+				</ResponseMetadata>
+			</UpdateStackResponse>
+		`,
+	},
+}
+
+var cycleSystemUpdateParamsNotificationPublish = awsutil.Cycle{
+	Request: awsutil.Request{
+		RequestURI: "/",
+		Body:       `Action=Publish&Message=%7B%22action%22%3A%22rack%3Aupdate%22%2C%22data%22%3A%7B%22rack%22%3A%22convox%22%7D%2C%22status%22%3A%22success%22%2C%22timestamp%22%3A%220001-01-01T00%3A00%3A00Z%22%7D&Subject=rack%3Aupdate&TargetArn=&Version=2010-03-31`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `
+			<PublishResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+				<PublishResult>
+					<MessageId>94f20ce6-13c5-43a0-9a9e-ca52d816e90b</MessageId>
+				</PublishResult>
+				<ResponseMetadata>
+					<RequestId>f187a3c1-376f-11df-8963-01868b7c937a</RequestId>
+				</ResponseMetadata>
+			</PublishResponse>
+		`,
+	},
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Amazon Linux 2023 Default AMIs**

AWS ended support for the ECS-optimized Amazon Linux 2 AMIs on June 30, 2026. The `DefaultAmi` and `DefaultAmiArm` rack parameters now default to the ECS-optimized Amazon Linux 2023 AMI paths:

| Parameter | New default |
|-----------|-------------|
| `DefaultAmi` | `/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id` |
| `DefaultAmiArm` | `/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id` |

Racks still set to the previous Amazon Linux 2 default paths are migrated to the Amazon Linux 2023 paths automatically on their next rack update or parameter change after the rack is running this version. Racks with a custom `DefaultAmi` or `DefaultAmiArm` path keep their configured values. Racks with an explicit `Ami` override continue running the pinned AMI, and the parameter migration itself replaces no instances on them; their default parameters migrate on the next update that changes anything else (a version update or another parameter change), and a migration-only update on those racks reports success without applying changes. Like any rack, they still see instance rotation from the update that installs this version, since the instance configuration changed.

Docker image and build cache pruning on rack instances now runs via systemd timers, which work on both Amazon Linux 2 and Amazon Linux 2023 instances. The `PruneOlderImagesInHour` and `PruneOlderImagesCronRunFreq` parameters keep their existing behavior.

---

### How to use it?

Update your rack to this version:

```
$ convox rack update
```

Wait for this update to complete before continuing; check with `convox rack` until the status returns to `running`. This update replaces every instance on a rolling basis, so allow time for the full rotation. Then run the update once more with the version specified to apply the AMI migration:

```
$ convox rack update 20260714094620
```

The first command installs this version. The second, now executed by the new version, detects the retired Amazon Linux 2 paths and applies the Amazon Linux 2023 paths. The version must be passed explicitly on the second run because a bare `convox rack update` will do nothing when already on the latest version. Any parameter change or future update also triggers the migration.

Both updates replace instances in the rack's Auto Scaling groups following your rack's `InstanceUpdateBatchSize` setting: the first applies this release's updated instance configuration, the second applies the Amazon Linux 2023 AMI. The second update replaces instances only on racks it migrates; racks with an explicit `Ami` override, a custom `DefaultAmi`/`DefaultAmiArm` path, or already on the Amazon Linux 2023 paths complete it quickly with no changes. Spot fleet capacity (racks using `SpotFleetMaxPrice`) is replaced as a fleet operation instead.

To verify:

```
$ convox rack params | grep DefaultAmi
```

Racks with an explicit `Ami` override still show the previous paths at this point; they migrate on the next update that changes anything else.

If a rack can no longer complete updates because the Amazon Linux 2 SSM parameters are unavailable, set the paths explicitly in a single command (works on earlier rack versions as well):

```
$ convox rack params set DefaultAmi=/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id DefaultAmiArm=/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id
```

Racks with an explicit `Ami` override should include one other parameter change in the same command (for example a small `ApiCpu` adjustment), since CloudFormation rejects updates that change only parameters no resource currently uses.

Racks running `a1` family instances must move to a Graviton2 or later instance type (for example `t4g` or `m6g`) or pin the `Ami` parameter before updating: Amazon Linux 2023 does not support first generation Graviton.

---

### Does it have a breaking change?

No breaking changes. Racks already on the Amazon Linux 2023 paths behave exactly as before, and custom `DefaultAmi`/`DefaultAmiArm` values are never modified. Setting `DefaultAmi` or `DefaultAmiArm` explicitly in the same update always takes precedence over the automatic migration.

---

### Requirements

To receive this update, you must update to rack version `20260714094620` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`

---

  - closes #3803 Stop rotating docker TLS CA on update [@ntner]
  - closes #3804 Add passkey browser auth to CLI [@ntner]
