### PR TITLE
add BuildLogDriver rack param for build logs

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -32,7 +32,7 @@ var sensitiveParams = map[string]bool{
 
 // paramGroups categorizes V2 rack params into curated logical groups for the
 // `convox rack params -g <group>` filter. A param may belong to multiple
-// groups (5 V2 params are dual-listed). Every V2 rack.json Parameter must
+// groups (6 V2 params are dual-listed). Every V2 rack.json Parameter must
 // land in at least one group — enforced by TestParamGroupsCoverRackJSON.
 //
 // When adding a new rack param to provider/aws/formation/rack.json, add it
@@ -131,6 +131,7 @@ var paramGroups = map[string]map[string]bool{
 		"BuildImage":                  true,
 		"BuildInstance":               true,
 		"BuildInstancePolicy":         true, // dual-listed in security
+		"BuildLogDriver":              true, // dual-listed in logging
 		"BuildMemory":                 true,
 		"BuildMethod":                 true,
 		"BuildVolumeSize":             true,
@@ -156,6 +157,7 @@ var paramGroups = map[string]map[string]bool{
 		"RouterMitigationMode":    true,
 	},
 	"logging": {
+		"BuildLogDriver":    true, // dual-listed in build
 		"ContainerInsights": true,
 		"LogBucket":         true,
 		"LogDriver":         true,

--- a/pkg/cli/rack_group_test.go
+++ b/pkg/cli/rack_group_test.go
@@ -221,5 +221,5 @@ func TestParamGroupsCoverRackJSON(t *testing.T) {
 	}
 	require.Empty(t, stale, "paramGroups members not in rack.json Parameters: %v", stale)
 
-	require.Equal(t, 116, len(rack.Parameters), "post-hardening rack.json should have 116 Parameters")
+	require.Equal(t, 117, len(rack.Parameters), "post-hardening rack.json should have 117 Parameters")
 }

--- a/provider/aws/builds_logs.go
+++ b/provider/aws/builds_logs.go
@@ -2,7 +2,7 @@ package aws
 
 // BuildLogs implementation that supports three transports:
 //   * docker logs (EC2 builder by default)
-//   * CloudWatch Logs (preferred when rack parameter LogDriver=CloudWatch)
+//   * CloudWatch Logs (when the build task definition uses the awslogs driver)
 //   * returns an error if neither is available
 
 import (
@@ -48,15 +48,12 @@ func (p *Provider) BuildLogs(app, id string, opts structs.LogsOptions) (io.ReadC
 	go p.waitTaskStopped(*task.TaskArn, done) // non-blocking
 
 	// Fargate path
-	if p.cloudWatchEnabled() {
-		group, stream, err := p.cwStreamForTask(task, "build")
-		if err != nil {
-			return nil, err
-		}
-		return p.followCW(group, stream, done)
+	group, stream, err := p.cwStreamForTask(task, "build")
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, fmt.Errorf("cloudwatch disabled and ecs-exec not enabled; unable to stream logs for fargate task")
+	return p.followCW(group, stream, done)
 }
 
 // waitTaskStopped waits for the specified task to reach the "STOPPED" status.
@@ -144,13 +141,6 @@ func (p *Provider) historicLogs(b *structs.Build) (io.ReadCloser, error) {
 	default:
 		return io.NopCloser(strings.NewReader(b.Logs)), nil
 	}
-}
-
-// cloudWatchEnabled checks stack parameter EnableCloudWatch == "Yes"
-func (p *Provider) cloudWatchEnabled() bool {
-	v, _ := p.stackParameter(p.Rack, "LogDriver")
-
-	return v == "CloudWatch"
 }
 
 // cwStreamForTask retrieves the CloudWatch log group and log stream name for a given ECS task.

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -114,6 +114,9 @@
     "ContainerInsightsEnabled": { "Fn::Equals": [ { "Ref": "ContainerInsights" }, "Yes" ] },
     "EnableCloudWatch": { "Fn::Equals": [ { "Ref": "LogDriver" }, "CloudWatch" ] },
     "EnableSyslog": { "Fn::Equals": [ { "Ref": "LogDriver" }, "Syslog" ] },
+    "BuildLogCloudWatch": { "Fn::Equals": [ { "Ref": "BuildLogDriver" }, "CloudWatch" ] },
+    "BuildLogSyslog": { "Fn::And": [ { "Fn::Equals": [ { "Ref": "BuildLogDriver" }, "" ] }, { "Condition": "EnableSyslog" } ] },
+    "LogGroupEnabled": { "Fn::Or": [ { "Condition": "EnableCloudWatch" }, { "Condition": "BuildLogCloudWatch" } ] },
     "EnableSharedEFSVolumeEncryptionCond": { "Fn::Equals": [ { "Ref": "EnableSharedEFSVolumeEncryption" }, "true" ] },
     "EncryptEbs": { "Fn::Equals": [ { "Ref": "EncryptEbs" }, "Yes" ] },
     "ExistingVpc": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "ExistingVpc" }, "" ] } ] },
@@ -458,7 +461,7 @@
       "Value": { "Ref": "LogDriver" }
     },
     "LogGroup": {
-      "Condition": "EnableCloudWatch",
+      "Condition": "LogGroupEnabled",
       "Value": { "Ref": "LogGroup" }
     },
     "NatGateways": {
@@ -803,6 +806,12 @@
       "Default": "",
       "Description": "ARN of an additional IAM policy to add to the cluster build instances",
       "Type": "String"
+    },
+    "BuildLogDriver": {
+      "Type": "String",
+      "Description": "Log driver for build tasks only. Blank inherits LogDriver. Set to CloudWatch to keep builds on CloudWatch while services use Syslog.",
+      "Default": "",
+      "AllowedValues": [ "", "CloudWatch" ]
     },
     "BuildMethod": {
       "Type": "String",
@@ -1449,7 +1458,7 @@
     },
     "LogGroup": {
       "Type": "AWS::Logs::LogGroup",
-      "Condition": "EnableCloudWatch",
+      "Condition": "LogGroupEnabled",
       "Properties": {
         "RetentionInDays": { "Fn::If": [ "BlankLogRetention", { "Ref": "AWS::NoValue" }, { "Ref": "LogRetention" } ] }
       }
@@ -4591,7 +4600,8 @@
               { "Name": "DOCKER_BUILDKIT", "Value": "1" },
               { "Name": "BUILD_CACHE", "Value": { "Fn::If": ["BuildCacheEnabled", "true", "false"] } },
               { "Name": "BUILD_CACHE_CLEANUP", "Value": { "Ref": "BuildCacheCleanup" } },
-              { "Name": "BUILD_CACHE_RETENTION_DAYS", "Value": { "Ref": "BuildCacheRetentionDays" } }
+              { "Name": "BUILD_CACHE_RETENTION_DAYS", "Value": { "Ref": "BuildCacheRetentionDays" } },
+              { "Name": "BUILD_LOG_DRIVER", "Value": { "Ref": "BuildLogDriver" } }
             ],
             "Image": {
               "Fn::If": [
@@ -4608,7 +4618,7 @@
             },
             "LogConfiguration": {
               "Fn::If": [
-                "EnableSyslog",
+                "BuildLogSyslog",
                 {
                   "LogDriver": "syslog",
                   "Options": {
@@ -4618,7 +4628,7 @@
                 },
                 {
                   "Fn::If": [
-                    "EnableCloudWatch",
+                    "LogGroupEnabled",
                     {
                       "LogDriver": "awslogs",
                       "Options": {
@@ -4736,7 +4746,8 @@
               { "Name": "STACK_ID", "Value": { "Ref": "AWS::StackId" } },
               { "Name": "BUILD_RUNTIME", "Value": "daemonless" },
               { "Name": "BUILD_CACHE_CLEANUP", "Value": { "Ref": "BuildCacheCleanup" } },
-              { "Name": "BUILD_CACHE_RETENTION_DAYS", "Value": { "Ref": "BuildCacheRetentionDays" } }
+              { "Name": "BUILD_CACHE_RETENTION_DAYS", "Value": { "Ref": "BuildCacheRetentionDays" } },
+              { "Name": "BUILD_LOG_DRIVER", "Value": { "Ref": "BuildLogDriver" } }
             ],
             "Image": {
               "Fn::If": [
@@ -4753,7 +4764,7 @@
             },
             "LogConfiguration": {
               "Fn::If": [
-                "EnableSyslog",
+                "BuildLogSyslog",
                 {
                   "LogDriver": "syslog",
                   "Options": {
@@ -4763,7 +4774,7 @@
                 },
                 {
                   "Fn::If": [
-                    "EnableCloudWatch",
+                    "LogGroupEnabled",
                     {
                       "LogDriver": "awslogs",
                       "Options": {

--- a/provider/aws/template_test.go
+++ b/provider/aws/template_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"encoding/json"
 	"html/template"
 	"os"
 	"path/filepath"
@@ -38,5 +39,109 @@ func TestAppTemplateParses(t *testing.T) {
 
 	if _, err := template.New(filepath.Base(path)).Funcs(formationHelpers()).Parse(string(data)); err != nil {
 		t.Fatalf("app.json.tmpl failed to parse: %v", err)
+	}
+}
+
+// TestBuildLogDriverWiring pins what BuildLogDriver depends on: LogGroup must
+// exist whenever the build awslogs branch refs it, and the parameter needs an
+// unconditional reference or CloudFormation reports no updates on a change.
+func TestBuildLogDriverWiring(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("formation", "rack.json"))
+	if err != nil {
+		t.Fatalf("read rack.json: %v", err)
+	}
+
+	type fnIf struct {
+		If []json.RawMessage `json:"Fn::If"`
+	}
+
+	var tmpl struct {
+		Outputs map[string]struct {
+			Condition string `json:"Condition"`
+		} `json:"Outputs"`
+		Resources map[string]struct {
+			Condition  string `json:"Condition"`
+			Properties struct {
+				ContainerDefinitions []struct {
+					Environment []struct {
+						Name  string          `json:"Name"`
+						Value json.RawMessage `json:"Value"`
+					} `json:"Environment"`
+					LogConfiguration fnIf `json:"LogConfiguration"`
+				} `json:"ContainerDefinitions"`
+			} `json:"Properties"`
+		} `json:"Resources"`
+	}
+
+	if err := json.Unmarshal(data, &tmpl); err != nil {
+		t.Fatalf("parse rack.json: %v", err)
+	}
+
+	if got := tmpl.Resources["LogGroup"].Condition; got != "LogGroupEnabled" {
+		t.Errorf("LogGroup resource condition is %q, want LogGroupEnabled", got)
+	}
+
+	if got := tmpl.Outputs["LogGroup"].Condition; got != "LogGroupEnabled" {
+		t.Errorf("LogGroup output condition is %q, want LogGroupEnabled", got)
+	}
+
+	// Only the build task defs follow BuildLogDriver, the rack api tasks stay on
+	// the rack-wide driver.
+	conditions := map[string][2]string{
+		"ApiBuildTasks":   {"BuildLogSyslog", "LogGroupEnabled"},
+		"ApiBuildFargate": {"BuildLogSyslog", "LogGroupEnabled"},
+		"ApiMonitorTasks": {"EnableSyslog", "EnableCloudWatch"},
+		"ApiWebTasks":     {"EnableSyslog", "EnableCloudWatch"},
+	}
+
+	for name, want := range conditions {
+		cds := tmpl.Resources[name].Properties.ContainerDefinitions
+		if len(cds) == 0 {
+			t.Fatalf("%s has no container definitions", name)
+		}
+
+		var outer string
+		var inner fnIf
+
+		if len(cds[0].LogConfiguration.If) != 3 {
+			t.Fatalf("%s LogConfiguration is not an Fn::If with three elements", name)
+		}
+		if err := json.Unmarshal(cds[0].LogConfiguration.If[0], &outer); err != nil {
+			t.Fatalf("%s outer condition: %v", name, err)
+		}
+		if err := json.Unmarshal(cds[0].LogConfiguration.If[2], &inner); err != nil {
+			t.Fatalf("%s inner branch: %v", name, err)
+		}
+
+		var innerCond string
+		if len(inner.If) != 3 {
+			t.Fatalf("%s inner branch is not an Fn::If with three elements", name)
+		}
+		if err := json.Unmarshal(inner.If[0], &innerCond); err != nil {
+			t.Fatalf("%s inner condition: %v", name, err)
+		}
+
+		if outer != want[0] || innerCond != want[1] {
+			t.Errorf("%s log conditions are (%s, %s), want (%s, %s)", name, outer, innerCond, want[0], want[1])
+		}
+	}
+
+	for _, name := range []string{"ApiBuildTasks", "ApiBuildFargate"} {
+		found := false
+
+		for _, e := range tmpl.Resources[name].Properties.ContainerDefinitions[0].Environment {
+			if e.Name != "BUILD_LOG_DRIVER" {
+				continue
+			}
+
+			var ref map[string]string
+			if err := json.Unmarshal(e.Value, &ref); err == nil && ref["Ref"] == "BuildLogDriver" {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Errorf("%s is missing an unconditional BUILD_LOG_DRIVER environment ref", name)
+		}
 	}
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: BuildLogDriver, a build-only log driver override**

`LogDriver` applies to every task in the rack, including the build task. Builds run on the dedicated build cluster, so a syslog destination that is only reachable from the rack's main instances, such as a collector listening on the instance loopback address, is unreachable from the build instances. Docker initializes a `tcp://` syslog driver when the container is created, so the build container fails to start and no build can complete while that destination is set.

`BuildLogDriver` sets the log driver for the build task alone. Set it to `CloudWatch` and builds log to the rack's CloudWatch log group while services, the rack API, and the monitor keep sending their logs to syslog.

| Parameter | Type | Default | Values | Effect |
|-----------|------|---------|--------|--------|
| `BuildLogDriver` | String | `""` | `""`, `CloudWatch` | Log driver for build tasks only. Blank inherits `LogDriver`. `CloudWatch` sends build logs to the rack log group regardless of the rack-wide driver. |

Two things follow from setting it to `CloudWatch` on a rack whose `LogDriver` is `Syslog` or blank. The rack CloudWatch log group is created, since the build task now writes to it, which means `convox rack logs` starts returning output (build streams and CloudFormation events) where it previously reported that the log group did not exist. And clearing `BuildLogDriver` back to blank removes that log group again along with the build log history in it, the same way switching `LogDriver` away from `CloudWatch` always has. Logs for completed builds are stored separately and are not affected.

On a Fargate builder, build log streaming now follows the build task definition's own log configuration rather than the rack-wide `LogDriver` parameter, so `convox builds logs` works on a Fargate rack that uses the override. Log streaming behavior is unchanged on every rack that does not set the parameter.

---

### How to use it?

Update the rack first and wait for the update to complete; check with `convox rack` until the status returns to `running`:

```
$ convox rack update
```

Then set the parameter:

```
$ convox rack params set BuildLogDriver=CloudWatch -w
```

Confirm it, then run a build:

```
$ convox rack params | grep BuildLogDriver
BuildLogDriver  CloudWatch

$ convox build
```

To go back to the rack-wide driver:

```
$ convox rack params set BuildLogDriver="" -w
```

---

### Does it have a breaking change?

No breaking changes. The parameter defaults to blank, which inherits `LogDriver` exactly as before, so a rack that does not set it renders the same build log configuration it renders today. Services, the rack API, and the monitor are untouched by this parameter in every case.

---

### Requirements

To use this feature, you must update to rack version `20260729093017` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
