### PR TITLE
fail builds whose task stops before starting

### DIFF
--- a/provider/aws/builds.go
+++ b/provider/aws/builds.go
@@ -75,6 +75,11 @@ func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions)
 
 	if err := p.runBuild(b, url, opts); err != nil {
 		log.Error(err)
+
+		if b.Tags["task"] == "" {
+			p.failBuildIfNotTerminal(b.App, b.Id, err.Error())
+		}
+
 		return nil, err
 	}
 
@@ -985,6 +990,8 @@ func (p *Provider) runBuild(build *structs.Build, burl string, opts structs.Buil
 		return err
 	}
 
+	build.Tags["task"] = *task.TaskArn
+
 	b, err := p.BuildGet(build.App, build.Id)
 	if err != nil {
 		return err
@@ -998,8 +1005,25 @@ func (p *Provider) runBuild(build *structs.Build, burl string, opts structs.Buil
 		return err
 	}
 
-	if _, err := p.waitForTask(*task.TaskArn); err != nil {
+	status, err := p.waitForTask(*task.TaskArn)
+	if err != nil {
+		if reason, stopped := p.taskStopReason(*task.TaskArn); stopped {
+			p.failBuildIfNotTerminal(build.App, build.Id, reason)
+		}
 		return err
+	}
+
+	if status == "STOPPED" {
+		reason, ok := p.taskStopReason(*task.TaskArn)
+		if !ok || reason == "" {
+			reason = "task stopped"
+		}
+
+		if p.failBuildIfNotTerminal(build.App, build.Id, reason) {
+			return nil
+		}
+
+		return fmt.Errorf("build task stopped before running: %s", reason)
 	}
 
 	if buildMethod == "ec2" {
@@ -1009,6 +1033,52 @@ func (p *Provider) runBuild(build *structs.Build, burl string, opts structs.Buil
 	}
 
 	return nil
+}
+
+// taskStopReason reports why a task stopped, and whether it is stopped at all.
+func (p *Provider) taskStopReason(arn string) (string, bool) {
+	t, err := p.describeTask(arn)
+	if err != nil || t == nil || aws.StringValue(t.LastStatus) != "STOPPED" {
+		return "", false
+	}
+
+	reason := aws.StringValue(t.StoppedReason)
+
+	if len(t.Containers) > 0 {
+		if r := aws.StringValue(t.Containers[0].Reason); r != "" {
+			reason = strings.TrimPrefix(fmt.Sprintf("%s: %s", reason, r), ": ")
+		}
+	}
+
+	return reason, true
+}
+
+// failBuildIfNotTerminal marks a build failed, reporting whether it was already terminal.
+func (p *Provider) failBuildIfNotTerminal(app, id, reason string) bool {
+	log := Logger.At("failBuildIfNotTerminal").Namespace("app=%q id=%q", app, id).Start()
+
+	b, err := p.BuildGet(app, id)
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	if b.Status == "complete" || b.Status == "failed" {
+		return true
+	}
+
+	b.Status = "failed"
+	b.Ended = time.Now().UTC()
+
+	if reason != "" {
+		b.Reason = reason
+	}
+
+	if err := p.buildSave(b); err != nil {
+		log.Error(err)
+	}
+
+	return false
 }
 
 func (p *Provider) waitForContainer(task *ecs.Task) error {

--- a/provider/aws/builds_stuck_test.go
+++ b/provider/aws/builds_stuck_test.go
@@ -1,0 +1,243 @@
+package aws
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/convox/rack/pkg/test/awsutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stubProvider(t *testing.T, cycles ...awsutil.Cycle) (*Provider, *[]string) {
+	t.Helper()
+	t.Setenv("PROVIDER", "test")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+	t.Setenv("AWS_REGION", "us-test-1")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+
+	inner := awsutil.NewHandler(cycles)
+	bodies := []string{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %s", err)
+			return
+		}
+
+		bodies = append(bodies, string(b))
+		r.Body = io.NopCloser(bytes.NewReader(b))
+
+		inner.ServeHTTP(w, r)
+	}))
+
+	t.Cleanup(srv.Close)
+
+	p := &Provider{
+		BuildCluster: "cluster-test",
+		Cluster:      "cluster-test",
+		DynamoBuilds: "convox-builds",
+		Endpoint:     srv.URL,
+		Rack:         "convox",
+		Region:       "us-test-1",
+		SkipCache:    true,
+	}
+
+	return p, &bodies
+}
+
+func cycleBuildStuckGetItem(status string) awsutil.Cycle {
+	return awsutil.Cycle{
+		Request: awsutil.Request{
+			Method:     "POST",
+			RequestURI: "/",
+			Operation:  "DynamoDB_20120810.GetItem",
+			Body:       "ignore",
+		},
+		Response: awsutil.Response{
+			StatusCode: 200,
+			Body: `{"Item":{
+				"id": {"S": "B123"},
+				"app": {"S": "httpd"},
+				"created": {"S": "20160404.143416.178278576"},
+				"status": {"S": "` + status + `"}
+			}}`,
+		},
+	}
+}
+
+var cycleBuildStuckDescribeStacks = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Body:       `Action=DescribeStacks&StackName=convox-httpd&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `<DescribeStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+			<DescribeStacksResult>
+				<Stacks>
+					<member>
+						<StackName>convox-httpd</StackName>
+						<StackStatus>UPDATE_COMPLETE</StackStatus>
+					</member>
+				</Stacks>
+			</DescribeStacksResult>
+		</DescribeStacksResponse>`,
+	},
+}
+
+var cycleBuildStuckPutItem = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Operation:  "DynamoDB_20120810.PutItem",
+		Body:       "ignore",
+	},
+	Response: awsutil.Response{StatusCode: 200, Body: `{}`},
+}
+
+func cycleBuildStuckDescribeTasks(body string) awsutil.Cycle {
+	return awsutil.Cycle{
+		Request: awsutil.Request{
+			Method:     "POST",
+			RequestURI: "/",
+			Operation:  "AmazonEC2ContainerServiceV20141113.DescribeTasks",
+			Body:       "ignore",
+		},
+		Response: awsutil.Response{StatusCode: 200, Body: body},
+	}
+}
+
+func taskResponse(status, stopped, containerReason string) string {
+	return `{"tasks":[{
+		"taskArn": "arn:aws:ecs:us-test-1:901416387788:task/cluster-test/50b8de99",
+		"lastStatus": "` + status + `",
+		"stoppedReason": "` + stopped + `",
+		"containers": [{"reason": "` + containerReason + `"}]
+	}]}`
+}
+
+func TestFailBuildIfNotTerminal(t *testing.T) {
+	for _, c := range []struct {
+		status   string
+		terminal bool
+	}{
+		{"created", false},
+		{"running", false},
+		{"complete", true},
+		{"failed", true},
+	} {
+		t.Run(c.status, func(t *testing.T) {
+			cycles := []awsutil.Cycle{cycleBuildStuckGetItem(c.status)}
+			if !c.terminal {
+				cycles = append(cycles, cycleBuildStuckDescribeStacks, cycleBuildStuckPutItem)
+			}
+
+			p, bodies := stubProvider(t, cycles...)
+
+			assert.Equal(t, c.terminal, p.failBuildIfNotTerminal("httpd", "B123", "dial tcp 127.0.0.1:5140: connection refused"))
+			require.Len(t, *bodies, len(cycles))
+
+			if c.terminal {
+				return
+			}
+
+			put := (*bodies)[2]
+			assert.Contains(t, put, `"status":{"S":"failed"}`)
+			assert.Contains(t, put, `"reason":{"S":"dial tcp 127.0.0.1:5140: connection refused"}`)
+		})
+	}
+}
+
+func TestFailBuildIfNotTerminalKeepsExistingReason(t *testing.T) {
+	p, bodies := stubProvider(t, cycleBuildStuckGetItem("running"), cycleBuildStuckDescribeStacks, cycleBuildStuckPutItem)
+
+	assert.False(t, p.failBuildIfNotTerminal("httpd", "B123", ""))
+	require.Len(t, *bodies, 3)
+	assert.NotContains(t, (*bodies)[2], `"reason"`)
+}
+
+func TestTaskStopReason(t *testing.T) {
+	arn := "arn:aws:ecs:us-test-1:901416387788:task/cluster-test/50b8de99"
+
+	for _, c := range []struct {
+		name     string
+		response string
+		reason   string
+		stopped  bool
+	}{
+		{
+			name:     "task and container reasons",
+			response: taskResponse("STOPPED", "Task failed to start", "CannotStartContainerError: failed to initialize logging driver"),
+			reason:   "Task failed to start: CannotStartContainerError: failed to initialize logging driver",
+			stopped:  true,
+		},
+		{
+			name:     "task reason only",
+			response: taskResponse("STOPPED", "Essential container in task exited", ""),
+			reason:   "Essential container in task exited",
+			stopped:  true,
+		},
+		{
+			name:     "container reason only",
+			response: taskResponse("STOPPED", "", "CannotPullContainerError"),
+			reason:   "CannotPullContainerError",
+			stopped:  true,
+		},
+		{
+			name:     "no containers",
+			response: `{"tasks":[{"lastStatus":"STOPPED","stoppedReason":"placement failed"}]}`,
+			reason:   "placement failed",
+			stopped:  true,
+		},
+		{
+			name:     "still running",
+			response: taskResponse("RUNNING", "", ""),
+			reason:   "",
+			stopped:  false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			p, _ := stubProvider(t, cycleBuildStuckDescribeTasks(c.response))
+
+			reason, stopped := p.taskStopReason(arn)
+
+			assert.Equal(t, c.reason, reason)
+			assert.Equal(t, c.stopped, stopped)
+		})
+	}
+}
+
+func TestWaitForTask(t *testing.T) {
+	arn := "arn:aws:ecs:us-test-1:901416387788:task/cluster-test/50b8de99"
+
+	for _, c := range []struct {
+		name     string
+		statuses []string
+		expect   string
+	}{
+		{"fargate start failure", []string{"PROVISIONING", "PENDING", "STOPPED"}, "STOPPED"},
+		{"fargate healthy launch", []string{"PROVISIONING", "ACTIVATING", "RUNNING"}, "RUNNING"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			cycles := []awsutil.Cycle{}
+			for _, s := range c.statuses {
+				cycles = append(cycles, cycleBuildStuckDescribeTasks(taskResponse(s, "", "")))
+			}
+
+			p, bodies := stubProvider(t, cycles...)
+
+			status, err := p.waitForTask(arn)
+
+			require.NoError(t, err)
+			assert.Equal(t, c.expect, status)
+			assert.Len(t, *bodies, len(c.statuses))
+		})
+	}
+}

--- a/provider/aws/processes.go
+++ b/provider/aws/processes.go
@@ -798,7 +798,8 @@ func (p *Provider) describeTaskInner(arn string) (*ecs.Task, error) {
 func (p *Provider) describeTask(arn string) (*ecs.Task, error) {
 	var err error
 	for attempt := 0; attempt < 3; attempt++ {
-		task, err := p.describeTaskInner(arn)
+		var task *ecs.Task
+		task, err = p.describeTaskInner(arn)
 		if err != nil {
 			time.Sleep((1 << uint(attempt)) * time.Second)
 		} else {
@@ -1679,7 +1680,8 @@ func (p *Provider) waitForTask(arn string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			if status := *task.LastStatus; status != "PENDING" {
+			switch status := *task.LastStatus; status {
+			case "RUNNING", "STOPPED":
 				return status, nil
 			}
 		case <-timeout:

--- a/provider/aws/workers_events.go
+++ b/provider/aws/workers_events.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -22,6 +23,8 @@ import (
 var (
 	ecsEvents = map[string]bool{}
 	started   = time.Now().UTC()
+
+	errNoLogGroup = errors.New("stack has no log group")
 )
 
 type queueHandler func(body string) error
@@ -207,6 +210,9 @@ func (p *Provider) pollECSEvents() error {
 
 			group, err := p.getStackLogGroup(stack)
 			if err != nil {
+				if errors.Is(err, errNoLogGroup) {
+					continue
+				}
 				return err
 			}
 
@@ -264,6 +270,10 @@ func (p *Provider) getStackLogGroup(stack string) (string, error) {
 		return group, nil
 	}
 
+	if _, ok := cache.Get("stackNoLogGroup", stack).(bool); ok {
+		return "", errNoLogGroup
+	}
+
 	s, err := p.describeStack(stack)
 	if err != nil {
 		return "", err
@@ -275,10 +285,19 @@ func (p *Provider) getStackLogGroup(stack string) (string, error) {
 
 	r, err := p.stackResource(stack, "LogGroup")
 	if err != nil {
-		if strings.Contains(err.Error(), "resource not found") {
-			return p.getStackLogGroup(p.Rack)
+		if !strings.Contains(err.Error(), "resource not found") {
+			return "", err
 		}
-		return "", err
+
+		if stack != p.Rack {
+			if g, rerr := p.getStackLogGroup(p.Rack); !errors.Is(rerr, errNoLogGroup) {
+				return g, rerr
+			}
+		}
+
+		cache.Set("stackNoLogGroup", stack, true, 5*time.Minute)
+
+		return "", errNoLogGroup
 	}
 
 	g := *r.PhysicalResourceId

--- a/provider/aws/workers_events_test.go
+++ b/provider/aws/workers_events_test.go
@@ -1,0 +1,128 @@
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/convox/rack/pkg/test/awsutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var cycleRackDescribeStacks = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Body:       `Action=DescribeStacks&StackName=convox&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `<DescribeStacksResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+			<DescribeStacksResult>
+				<Stacks>
+					<member>
+						<StackName>convox</StackName>
+						<StackStatus>UPDATE_COMPLETE</StackStatus>
+					</member>
+				</Stacks>
+			</DescribeStacksResult>
+		</DescribeStacksResponse>`,
+	},
+}
+
+var cycleRackListStackResourcesNoLogGroup = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Body:       `Action=ListStackResources&StackName=convox&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `<ListStackResourcesResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+			<ListStackResourcesResult>
+				<StackResourceSummaries>
+					<member>
+						<LogicalResourceId>Cluster</LogicalResourceId>
+						<PhysicalResourceId>convox-Cluster-QLZBS9RCPJ3T</PhysicalResourceId>
+						<ResourceType>AWS::ECS::Cluster</ResourceType>
+						<ResourceStatus>CREATE_COMPLETE</ResourceStatus>
+					</member>
+				</StackResourceSummaries>
+			</ListStackResourcesResult>
+		</ListStackResourcesResponse>`,
+	},
+}
+
+var cycleAppListStackResourcesNoLogGroup = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Body:       `Action=ListStackResources&StackName=convox-httpd&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `<ListStackResourcesResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+			<ListStackResourcesResult>
+				<StackResourceSummaries>
+					<member>
+						<LogicalResourceId>ServiceWeb</LogicalResourceId>
+						<PhysicalResourceId>arn:aws:ecs:us-test-1:901416387788:service/convox-httpd-ServiceWeb</PhysicalResourceId>
+						<ResourceType>AWS::ECS::Service</ResourceType>
+						<ResourceStatus>CREATE_COMPLETE</ResourceStatus>
+					</member>
+				</StackResourceSummaries>
+			</ListStackResourcesResult>
+		</ListStackResourcesResponse>`,
+	},
+}
+
+var cycleRackListStackResourcesLogGroup = awsutil.Cycle{
+	Request: awsutil.Request{
+		Method:     "POST",
+		RequestURI: "/",
+		Body:       `Action=ListStackResources&StackName=convox&Version=2010-05-15`,
+	},
+	Response: awsutil.Response{
+		StatusCode: 200,
+		Body: `<ListStackResourcesResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+			<ListStackResourcesResult>
+				<StackResourceSummaries>
+					<member>
+						<LogicalResourceId>LogGroup</LogicalResourceId>
+						<PhysicalResourceId>convox-LogGroup-1LO7CKS3HFDN9</PhysicalResourceId>
+						<ResourceType>AWS::Logs::LogGroup</ResourceType>
+						<ResourceStatus>CREATE_COMPLETE</ResourceStatus>
+					</member>
+				</StackResourceSummaries>
+			</ListStackResourcesResult>
+		</ListStackResourcesResponse>`,
+	},
+}
+
+// A rack with LogDriver=Syslog has no LogGroup, and the not-found fallback used to
+// re-enter with the same stack name until the monitor's goroutine stack blew up.
+func TestGetStackLogGroupRackWithoutLogGroup(t *testing.T) {
+	p, bodies := stubProvider(t, cycleRackDescribeStacks, cycleRackListStackResourcesNoLogGroup)
+
+	group, err := p.getStackLogGroup("convox")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNoLogGroup))
+	assert.Empty(t, group)
+	assert.Len(t, *bodies, 2)
+}
+
+func TestGetStackLogGroupFallsBackToRack(t *testing.T) {
+	p, bodies := stubProvider(t,
+		cycleBuildStuckDescribeStacks,
+		cycleAppListStackResourcesNoLogGroup,
+		cycleRackDescribeStacks,
+		cycleRackListStackResourcesLogGroup,
+	)
+
+	group, err := p.getStackLogGroup("convox-httpd")
+
+	require.NoError(t, err)
+	assert.Equal(t, "convox-LogGroup-1LO7CKS3HFDN9", group)
+	assert.Len(t, *bodies, 4)
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Builds report failed when the build container never starts**

A build's status is written by the build binary running inside the build container. When the container never starts, nothing reports back, so the build record stays at `running` and `convox builds` shows it that way indefinitely. A Docker log driver that cannot reach its destination, an image that cannot be pulled, and a Fargate task that stops during provisioning all produce that shape: the ECS task stops before the binary ever runs.

The rack now watches the build task until it is running or stopped. A task that stops before the build reports in marks the build `failed` and records the ECS stop reason, so `convox build` exits non-zero with the underlying cause in the message, for example `build task stopped before running: Task failed to start: CannotStartContainerError: failed to initialize logging driver: dial tcp 127.0.0.1:5140: connect: connection refused`. A status the build binary already wrote is never overwritten, so a build that succeeds is unaffected and a build that fails inside the container keeps reporting its own error along with its logs.

Two supporting changes come with it. The task wait now polls until the task is running or stopped rather than returning on the first status other than pending, which is what makes the check correct on racks that build with Fargate, where an awsvpc task's first status is `PROVISIONING`. And the monitor no longer recurses without end when it looks up a log group on a rack that has none, such as a rack whose `LogDriver` is `Syslog` or blank; those racks previously restarted their monitor in a loop, and the monitor now skips log delivery for those stacks and keeps running.

---

### How to use it?

The fix applies automatically on rack update. No parameters and no CLI flags change.

```
$ convox rack update
```

Builds that stop before starting now surface the reason directly:

```
$ convox build
ERROR: build task stopped before running: Task failed to start: CannotStartContainerError: failed to initialize logging driver: dial tcp 127.0.0.1:5140: connect: connection refused

$ convox builds
ID           STATUS  RELEASE  STARTED        ELAPSED  DESCRIPTION
BABCDEFGHIJ  failed           2 minutes ago  15s
```

---

### Does it have a breaking change?

No breaking changes. Successful builds behave exactly as they do today, no API field is added or changed, and no CloudFormation resource, parameter or output is touched. The only difference a user sees is that a build which previously sat at `running` forever now settles at `failed` with a reason.

On racks that build with Fargate, the starting step of `convox build` takes a few seconds longer, since the rack now waits for the build task to be running rather than only placed. Total build time and the point where output starts streaming are unchanged.

---

### Requirements

To receive this fix, you must update to rack version `20260729093017` or newer.

- Check your rack's version with `convox rack`
- Update your rack with `convox rack update`
